### PR TITLE
[Feature] Pick the fastest DreamerV3 compile strategy by default

### DIFF
--- a/.github/unittest/linux_sota/scripts/test_sota.py
+++ b/.github/unittest/linux_sota/scripts/test_sota.py
@@ -349,6 +349,7 @@ commands = {
   replay_buffer.seq_len=4 \
   replay_buffer.warmup_factor=1 \
   optimization.updates_per_batch=1 \
+  optimization.compile=off \
   logger.eval_every=200 \
   logger.eval_episodes=1 \
   logger.output_plot= \

--- a/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
@@ -248,6 +248,8 @@ def main() -> None:
         cfg = _load_config(repo_root)
         cfg.replay_buffer.batch_size = args.batch
         cfg.replay_buffer.seq_len = args.steps
+        # Each variant sets the three switches itself.
+        cfg.optimization.compile = "off"
         cfg.optimization.compile_rssm = (
             "scan" if variant in ("compiled_scan", "cuda_graph") else None
         )

--- a/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
@@ -250,9 +250,7 @@ def main() -> None:
         cfg.replay_buffer.seq_len = args.steps
         # Each variant sets the three switches itself.
         cfg.optimization.compile = "off"
-        cfg.optimization.compile_rssm = (
-            "scan" if variant in ("compiled_scan", "cuda_graph") else None
-        )
+        cfg.optimization.compile_rssm = "scan" if variant != "eager" else None
         cfg.optimization.rssm_scan_unroll = args.unroll
         cfg.optimization.compile_train_step = variant in (
             "compiled_train_step",

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -156,8 +156,11 @@ the compiled region, so a seeded run diverges from an eager one. The scan uses
 time and graph size, while `1` disables manual unrolling.
 `optimization.compile_train_step=true` compiles the complete learner forward
 and backward with TorchInductor, including the model, actor, value, and replay
-value losses. It subsumes `optimization.compile_rssm`, which is ignored to avoid
-nested compilation of shared RSSM modules. The compile mode defaults to
+value losses. `optimization.compile_rssm` then selects the recurrence backend
+inside that compiled step without a nested `torch.compile`: with `scan`, Dynamo
+traces one higher-order scan of `rssm_scan_unroll` steps, whereas the default
+explicit loop is unrolled over the whole sequence and makes the compile of a
+long sequence very slow. The compile mode defaults to
 `optimization.compile_train_step_mode=default`; autotuning modes are opt-in.
 Compilation and CUDA-graph warmup use a fixed-shape synthetic batch before the
 collector is constructed, so async collection is not live while Dynamo runs.

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -147,29 +147,46 @@ over most of the run, so the script refuses one before launching anything. The
 command above keeps the 50,000-step window and still fills two of them with
 about 48 episodes each.
 
-`optimization.compile_rssm` compiles the RSSM recurrence and is off by default,
-since a short run never repays the build. `step` compiles the deterministic work
-and draws the same categories as an eager run; `scan` compiles the unrolled
-recurrence and the imagination prior, and is faster, but its draws fall inside
-the compiled region, so a seeded run diverges from an eager one. The scan uses
-`optimization.rssm_scan_unroll=8` by default; lower values reduce compilation
-time and graph size, while `1` disables manual unrolling.
+`optimization.compile=auto` (the default) takes the fastest supported path for
+the training device without further input: on CUDA the complete learner forward
+and backward is compiled with TorchInductor around a higher-order scan of the
+RSSM recurrence and then captured in a CUDA graph; on other devices everything
+runs eagerly, since a short CPU run never repays the build.
+`optimization.compile=off` disables all of it. The three switches
+`optimization.compile_train_step`, `optimization.compile_rssm` and
+`optimization.cudagraph_train_step` default to `null`, which follows the
+strategy; setting one overrides that single decision, for example
+`optimization.compile_train_step=false` keeps the compiled scan and the CUDA
+graph but not the whole-step compile.
+
+`optimization.compile_rssm` selects the recurrence backend. `step` compiles the
+deterministic work of the explicit loop and draws the same categories as an
+eager run; `scan` uses the higher-order scan, unrolled by
+`optimization.rssm_scan_unroll=8` steps (lower values reduce compilation time
+and graph size, `1` disables manual unrolling), and is faster, but its draws
+fall inside the compiled region, so a seeded run diverges from an eager one.
+On its own the scan gets its own `torch.compile`, together with the imagination
+prior. Inside a compiled step it is selected without a nested compile, so Dynamo
+traces one scan of `rssm_scan_unroll` steps; the explicit loop would be unrolled
+over the whole sequence there, which makes the compile of a long sequence very
+slow (a 256-step batch was still compiling after 15 minutes).
 `optimization.compile_train_step=true` compiles the complete learner forward
-and backward with TorchInductor, including the model, actor, value, and replay
-value losses. `optimization.compile_rssm` then selects the recurrence backend
-inside that compiled step without a nested `torch.compile`: with `scan`, Dynamo
-traces one higher-order scan of `rssm_scan_unroll` steps, whereas the default
-explicit loop is unrolled over the whole sequence and makes the compile of a
-long sequence very slow. The compile mode defaults to
-`optimization.compile_train_step_mode=default`; autotuning modes are opt-in.
-Compilation and CUDA-graph warmup use a fixed-shape synthetic batch before the
-collector is constructed, so async collection is not live while Dynamo runs.
-When combined with `optimization.cudagraph_train_step=true`, the
-Inductor-compiled function is warmed up before CUDA graph capture.
-`optimization.cudagraph_train_step=true` captures the learner forward and
-backward after five warmup calls. It requires CUDA and fixed input shapes;
-optimizer and target-network steps remain outside capture so their schedules
-continue to advance normally.
+and backward, including the model, actor, value, and replay value losses. The
+compile mode defaults to `optimization.compile_train_step_mode=default`;
+autotuning modes are opt-in. Compilation and CUDA-graph warmup use a
+fixed-shape synthetic batch before the collector is constructed, so async
+collection is not live while Dynamo runs. When combined with
+`optimization.cudagraph_train_step=true`, the Inductor-compiled function is
+warmed up before CUDA graph capture. `optimization.cudagraph_train_step=true`
+captures the learner forward and backward after five warmup calls. It requires
+CUDA and fixed input shapes; optimizer and target-network steps remain outside
+capture so their schedules continue to advance normally.
+
+The public :class:`~torchrl.trainers.algorithms.DreamerV3OptimizationStepper`
+follows the same defaults: `compile_train_step=None` and `cudagraph=None`
+resolve from the sample device at `warmup`, and a compiled step switches every
+`RSSMRolloutV3` of its loss to the scan (`rssm_scan_unroll=8`) unless a backend
+was already selected.
 
 Train-update timing remains asynchronous by default. Set
 `optimization.sync_timers=true` when completed GPU timing is needed; this

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -72,17 +72,25 @@ optimization:
   deferred_policy_sync: false
   separate_policy_rng: false
   mixed_precision: false
-  # Compile the RSSM recurrence: null, "step" or "scan". "scan" is faster but
-  # changes the random stream; see the README.
+  # Compile strategy. "auto" takes the fastest supported path for the training
+  # device: on CUDA the complete learner forward/backward is compiled with
+  # TorchInductor around a higher-order scan of the recurrence and captured in
+  # a CUDA graph; elsewhere everything runs eagerly. "off" disables all of it.
+  # The three switches below default to null, which follows this strategy; set
+  # one to override that single decision.
+  compile: auto
+  # Compile the complete learner forward/backward with TorchInductor.
+  compile_train_step: null
+  # torch.compile mode for the complete learner step.
+  compile_train_step_mode: default
+  # RSSM recurrence backend: null, "step" or "scan". Inside a compiled step
+  # "scan" is traced as one higher-order scan; on its own it gets its own
+  # torch.compile. "scan" changes the random stream; see the README.
   compile_rssm: null
   # Number of RSSM steps traced per higher-order scan iteration.
   rssm_scan_unroll: 8
-  # Compile the complete learner forward/backward with TorchInductor.
-  compile_train_step: false
-  # torch.compile mode for the complete learner step.
-  compile_train_step_mode: default
   # Capture the fixed-shape learner forward/backward on CUDA after warmup.
-  cudagraph_train_step: false
+  cudagraph_train_step: null
   # Synchronize CUDA around train-update timing. This disables CPU/GPU overlap.
   sync_timers: false
   collection_warmup_seconds: 0

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -341,7 +341,10 @@ def build_world_model(
     ``cfg.env.pixels_key``; ``None`` disables the image path. The decoded
     vector is written to ``("next", "reco_pixels")`` without an image, which
     keeps the vector-only keys unchanged, and to ``("next", "reco_vector")``
-    next to the decoded image otherwise.
+    next to the decoded image otherwise. ``compile_rollout`` wraps the RSSM
+    recurrence in its own :func:`torch.compile`; pass ``False`` when the whole
+    learner step is compiled, so ``cfg.optimization.compile_rssm`` only selects
+    the backend that the enclosing compile traces.
     """
     state_dim = latent_state_dim(cfg)
     vector = _normalize_hydra_key(cfg.env.vector_key) if obs_dim else None
@@ -457,7 +460,10 @@ def build_world_model(
     # Canonical transitions retain is_init. Native replay slices stay within
     # one episode, and the rollout handles a reset at the first transition.
     rollout = RSSMRolloutV3(rssm_prior, rssm_posterior, reset_key="is_init")
-    if compile_rollout and cfg.optimization.compile_rssm:
+    if cfg.optimization.compile_rssm:
+        # With compile_rollout=False the backend is selected for the enclosing
+        # compiled learner step: the higher-order scan is then traced once per
+        # unroll instead of the explicit loop being unrolled over the sequence.
         rollout.compile_rollout(
             cfg.optimization.compile_rssm,
             unroll=(
@@ -465,6 +471,7 @@ def build_world_model(
                 if cfg.optimization.compile_rssm == "scan"
                 else 1
             ),
+            compile=compile_rollout,
         )
 
     decoder_modules = []

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 from collections.abc import Callable
+from typing import Literal
 
 import torch
 from dreamer_v3_utils import latent_state_dim
@@ -332,6 +333,8 @@ def build_world_model(
     action_dim: int,
     pixels_shape: tuple[int, int, int] | None = None,
     compile_rollout: bool = True,
+    rssm_backend: Literal["step", "scan"] | None = None,
+    rssm_scan_unroll: int = 8,
 ) -> tuple[TensorDictSequential, RSSMPriorV3, DreamerV3MLP, SymExpTwoHot, DreamerV3MLP]:
     """Build the world model: encoder, RSSM rollout, decoder and two heads.
 
@@ -341,10 +344,10 @@ def build_world_model(
     ``cfg.env.pixels_key``; ``None`` disables the image path. The decoded
     vector is written to ``("next", "reco_pixels")`` without an image, which
     keeps the vector-only keys unchanged, and to ``("next", "reco_vector")``
-    next to the decoded image otherwise. ``compile_rollout`` wraps the RSSM
-    recurrence in its own :func:`torch.compile`; pass ``False`` when the whole
-    learner step is compiled, so ``cfg.optimization.compile_rssm`` only selects
-    the backend that the enclosing compile traces.
+    next to the decoded image otherwise. ``rssm_backend`` is the resolved
+    recurrence backend; with ``compile_rollout`` it is wrapped in its own
+    :func:`torch.compile`. Pass ``compile_rollout=False`` when the whole
+    learner step is compiled: the stepper then selects the scan itself.
     """
     state_dim = latent_state_dim(cfg)
     vector = _normalize_hydra_key(cfg.env.vector_key) if obs_dim else None
@@ -460,18 +463,12 @@ def build_world_model(
     # Canonical transitions retain is_init. Native replay slices stay within
     # one episode, and the rollout handles a reset at the first transition.
     rollout = RSSMRolloutV3(rssm_prior, rssm_posterior, reset_key="is_init")
-    if cfg.optimization.compile_rssm:
-        # With compile_rollout=False the backend is selected for the enclosing
-        # compiled learner step: the higher-order scan is then traced once per
-        # unroll instead of the explicit loop being unrolled over the sequence.
+    if compile_rollout and rssm_backend:
+        # Without compile_rollout the rollout stays eager here: the compiled
+        # learner step selects the higher-order scan for it before tracing.
         rollout.compile_rollout(
-            cfg.optimization.compile_rssm,
-            unroll=(
-                cfg.optimization.rssm_scan_unroll
-                if cfg.optimization.compile_rssm == "scan"
-                else 1
-            ),
-            compile=compile_rollout,
+            rssm_backend,
+            unroll=rssm_scan_unroll if rssm_backend == "scan" else 1,
         )
 
     decoder_modules = []

--- a/sota-implementations/dreamer_v3/dreamer_v3_utils.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_utils.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+from typing import NamedTuple
 
 import numpy as np
 import torch
@@ -53,6 +54,62 @@ def append_jsonl(path: Path | None, record: dict[str, object]) -> None:
 
 def latent_state_dim(cfg: DictConfig) -> int:
     return cfg.networks.num_categoricals * cfg.networks.num_classes
+
+
+class CompileSettings(NamedTuple):
+    """The resolved compile decisions of one run."""
+
+    strategy: str
+    train_step: bool
+    rssm: str | None
+    scan_unroll: int
+    cudagraph: bool
+    mode: str
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.train_step or self.rssm or self.cudagraph)
+
+
+def resolve_compile_settings(cfg: DictConfig, device: torch.device) -> CompileSettings:
+    """Turn ``optimization.compile`` and its overrides into concrete decisions.
+
+    ``auto`` takes the fastest supported path for ``device``: on CUDA the
+    complete learner step is compiled around a higher-order scan of the
+    recurrence and captured in a CUDA graph, elsewhere everything runs eagerly.
+    ``off`` disables all of it. ``compile_train_step``, ``compile_rssm`` and
+    ``cudagraph_train_step`` default to ``null``, which follows the strategy;
+    an explicit value overrides that single decision.
+    """
+    strategy = cfg.optimization.get("compile", "auto")
+    if strategy not in ("auto", "off"):
+        raise ValueError(
+            f"optimization.compile must be 'auto' or 'off', got {strategy!r}."
+        )
+    fast = strategy == "auto" and device.type == "cuda"
+    train_step = cfg.optimization.compile_train_step
+    train_step = fast if train_step is None else bool(train_step)
+    rssm = cfg.optimization.compile_rssm
+    if rssm is None and fast:
+        rssm = "scan"
+    if rssm not in (None, "step", "scan"):
+        raise ValueError(
+            f"optimization.compile_rssm must be null, 'step' or 'scan', got {rssm!r}."
+        )
+    cudagraph = cfg.optimization.cudagraph_train_step
+    cudagraph = fast if cudagraph is None else bool(cudagraph)
+    if cudagraph and device.type != "cuda":
+        raise ValueError(
+            "optimization.cudagraph_train_step requires a CUDA training device."
+        )
+    return CompileSettings(
+        strategy=strategy,
+        train_step=train_step,
+        rssm=rssm,
+        scan_unroll=cfg.optimization.rssm_scan_unroll,
+        cudagraph=cudagraph,
+        mode=cfg.optimization.compile_train_step_mode,
+    )
 
 
 def training_episode_returns(

--- a/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
+++ b/sota-implementations/dreamer_v3/reproduce_dmc_walker.sh
@@ -61,7 +61,7 @@ if [ "$smoke" -eq 1 ]; then
     replay_buffer.buffer_size=400
     replay_buffer.seq_len=4
     replay_buffer.warmup_factor=1
-    optimization.compile_rssm=null
+    optimization.compile=off
     optimization.updates_per_batch=1
     optimization.train_ratio=null
     optimization.mixed_precision=false

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -49,6 +49,7 @@ from dreamer_v3_utils import (
     LEARNER_RNG_STREAM,
     plot_enabled,
     REPLAY_RNG_STREAM,
+    resolve_compile_settings,
     save_run_plot,
     stream_seed,
     training_episode_returns,
@@ -219,14 +220,17 @@ def _make_learner_update(
         continuation_horizon=cfg.optimization.continuation_horizon,
         lmbda=cfg.optimization.lmbda,
     )
+    settings = resolve_compile_settings(cfg, device)
     return DreamerV3OptimizationStepper(
         loss_module,
         learner.optimizer,
         learner.value_target_updater,
-        compile_train_step=cfg.optimization.compile_train_step,
-        compile_mode=cfg.optimization.compile_train_step_mode,
-        cudagraph=cfg.optimization.cudagraph_train_step,
-        warmup_steps=cudagraph_warmup if cfg.optimization.cudagraph_train_step else 1,
+        compile_train_step=settings.train_step,
+        compile_mode=settings.mode,
+        cudagraph=settings.cudagraph,
+        # Inside the compiled step only the scan or the explicit loop exist.
+        rssm_scan_unroll=settings.scan_unroll if settings.rssm == "scan" else None,
+        warmup_steps=cudagraph_warmup if settings.cudagraph else 1,
         mixed_precision=cfg.optimization.mixed_precision and device.type == "cuda",
     )
 
@@ -283,11 +287,7 @@ def _warm_up_learner(
     obs_dim: int,
     action_dim: int,
 ) -> None:
-    if not (
-        cfg.optimization.compile_train_step
-        or cfg.optimization.compile_rssm
-        or cfg.optimization.cudagraph_train_step
-    ):
+    if not resolve_compile_settings(cfg, device).enabled:
         return
     learner_update.warmup(_fake_learner_sample(cfg, device, obs_dim, action_dim))
 
@@ -350,6 +350,7 @@ def _build_learner(
     pixels_shape: tuple[int, int, int] | None = None,
     discrete: bool = False,
 ) -> _Learner:
+    settings = resolve_compile_settings(cfg, device)
     (
         world_model,
         prior_net,
@@ -361,18 +362,17 @@ def _build_learner(
         obs_dim=obs_dim,
         action_dim=action_dim,
         pixels_shape=pixels_shape,
-        compile_rollout=not cfg.optimization.compile_train_step,
+        compile_rollout=not settings.train_step,
+        rssm_backend=settings.rssm,
+        rssm_scan_unroll=settings.scan_unroll,
     )
     world_model = world_model.to(device)
     imagination_model = build_imagination_model(
         prior_net=prior_net,
         reward_net=reward_net,
         reward_decoder=reward_decoder,
-        # The whole-step compile owns shared modules and subsumes RSSM compile.
-        compile_prior=(
-            cfg.optimization.compile_rssm == "scan"
-            and not cfg.optimization.compile_train_step
-        ),
+        # The whole-step compile owns the shared modules and traces the prior.
+        compile_prior=settings.rssm == "scan" and not settings.train_step,
     ).to(device)
     continuation_model = build_continuation_model(continuation_net=continuation_net).to(
         device
@@ -786,21 +786,19 @@ def main(cfg: DictConfig):
         torch.device(cfg.replay_buffer.device) if cfg.replay_buffer.device else device
     )
     use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
+    compile_settings = resolve_compile_settings(cfg, device)
     torchrl_logger.info(
-        "DreamerV3 execution: device=%s, replay_device=%s, rssm_backend=%s, "
-        "rssm_scan_unroll=%s, mixed_precision=%s, compile_train_step=%s, "
-        "cudagraph_train_step=%s",
+        "DreamerV3 execution: device=%s, replay_device=%s, compile=%s "
+        "(train_step=%s, rssm_backend=%s, rssm_scan_unroll=%s, cudagraph=%s), "
+        "mixed_precision=%s",
         device,
         replay_device,
-        cfg.optimization.compile_rssm or "eager",
-        (
-            cfg.optimization.rssm_scan_unroll
-            if cfg.optimization.compile_rssm == "scan"
-            else "n/a"
-        ),
+        compile_settings.strategy,
+        compile_settings.train_step,
+        compile_settings.rssm or "eager",
+        compile_settings.scan_unroll if compile_settings.rssm == "scan" else "n/a",
+        compile_settings.cudagraph,
         use_bfloat16,
-        cfg.optimization.compile_train_step,
-        cfg.optimization.cudagraph_train_step,
     )
     num_envs = cfg.collector.num_envs
     count_reset_records = cfg.collector.count_reset_records

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -1143,6 +1143,27 @@ class TestDreamerV3Components:
         ).backward()
         assert all(parameter.grad is not None for parameter in rollout.parameters())
 
+    @pytest.mark.skipif(
+        version.parse(torch.__version__) < version.parse("2.6.0"),
+        reason="the higher-order scan backend requires Torch >= 2.6.0",
+    )
+    @pytest.mark.skipif(not _has_hoptorch, reason="hoptorch is not installed")
+    def test_rssm_rollout_scan_backend_inside_outer_compile(self):
+        """``compile=False`` selects the scan for an enclosing compiled region."""
+        rollout = self._make_rollout(torch.device("cpu"))
+        rollout.compile_rollout("scan", unroll=2, compile=False)
+        assert isinstance(rollout._scan_fn, ft.partial)
+        assert rollout._scan_fn.keywords == {"unroll": 2}
+
+        data = self._make_rollout_data(torch.device("cpu"))
+        compiled = torch.compile(rollout, backend=_compile_backend)
+        output = compiled(data)
+        (
+            output["next", "posterior_logits"].square().mean()
+            + output["next", "prior_logits"].square().mean()
+        ).backward()
+        assert all(parameter.grad is not None for parameter in rollout.parameters())
+
 
 def test_public_block_gru_triton_errors():
     with mock.patch("torchrl.modules.models.model_based._has_dreamer_v3_triton", False):

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -1277,7 +1277,12 @@ class TestDreamerV3(LossModuleTestBase):  # type: ignore[misc]
         not (_has_hydra and _has_omegaconf and _has_gym),
         reason="requires hydra, omegaconf, and gym",
     )
-    @pytest.mark.parametrize("compile_train_step", [False, True])
+    # This compares two independently compiled forward/backward paths and
+    # CUDA capture. Even the previous loop backend took ~266s on CI runners.
+    @pytest.mark.parametrize(
+        "compile_train_step",
+        [False, pytest.param(True, marks=pytest.mark.timeout(600))],
+    )
     def test_dreamer_v3_full_learner_cuda_graph_matches_uncaptured(
         self, device, monkeypatch, compile_train_step
     ):
@@ -2645,6 +2650,7 @@ def test_dreamer_v3_checkpoint_resume_processes(
         example_dir, compile_train_step=False, cudagraph_train_step=device == "cuda"
     )
     cfg.optimization.device = device
+    cfg.optimization.compile = "off"
     cfg.optimization.compile_rssm = None
     cfg.optimization.updates_per_batch = 1
     cfg.optimization.separate_policy_rng = True
@@ -2720,8 +2726,13 @@ def test_dreamer_v3_checkpoint_resume_processes(
     assert first_steps >= 8 if terminate else first_steps == 16
     assert first_state["updates"] > 0
     assert ("replay" in Checkpoint.manifest(first_path)["components"]) == include_replay
-    first_learner = example["_build_learner"](cfg, torch.device("cpu"), 3, 1)
-    stepper = example["_make_learner_update"](cfg, torch.device("cpu"), first_learner)
+    # Inspect CUDA checkpoints on CPU with an eager execution configuration.
+    inspect_cfg = copy.deepcopy(cfg)
+    inspect_cfg.optimization.cudagraph_train_step = False
+    first_learner = example["_build_learner"](inspect_cfg, torch.device("cpu"), 3, 1)
+    stepper = example["_make_learner_update"](
+        inspect_cfg, torch.device("cpu"), first_learner
+    )
     modules = stepper.loss_module
     policy = example["DreamerV3SeededPolicy"](first_learner.real_world_actor, seed=0)
     schedule = example["DreamerV3UpdateRatio"](0.0)

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2530,6 +2530,9 @@ def test_dreamer_v3_native_replay_collection_smoke(
     cfg.env.name = PENDULUM_VERSIONED()
     cfg.optimization.separate_policy_rng = collector_backend == "async" and not custom
     cfg.optimization.device = device
+    # This test covers collection and replay; keep the learner eager apart
+    # from the explicit capture below.
+    cfg.optimization.compile = "off"
     cfg.optimization.cudagraph_train_step = device == "cuda"
     cfg.optimization.updates_per_batch = 1
     cfg.optimization.train_ratio = None
@@ -2847,7 +2850,7 @@ def test_dreamer_v3_dmc_reproduction_modes(tmp_path):
     ).stdout.splitlines()
     assert smoke[:3] == [expected_benchmark, "--output-dir", "dmc_walker_smoke"]
     assert "replay_buffer.buffer_size=400" in smoke
-    assert "optimization.compile_rssm=null" in smoke
+    assert "optimization.compile=off" in smoke
     assert "optimization.updates_per_batch=1" in smoke
     assert "optimization.train_ratio=null" in smoke
 
@@ -2892,6 +2895,124 @@ def test_dreamer_v3_optimizer_updates_and_resume(device):
         current.step()
     torch.testing.assert_close(restored_parameter, parameter)
     assert not torch.equal(parameter, expected)
+
+
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
+class TestDreamerV3CompileStrategy:
+    """`optimization.compile` resolves to concrete decisions, and the stepper follows them."""
+
+    @staticmethod
+    def _load(monkeypatch, run_name):
+        example_dir = Path(__file__).parents[2] / "sota-implementations/dreamer_v3"
+        monkeypatch.syspath_prepend(str(example_dir))
+        return example_dir, runpy.run_path(example_dir / "train.py", run_name=run_name)
+
+    def test_resolve_compile_settings(self, monkeypatch):
+        from omegaconf import OmegaConf
+
+        example_dir, example = self._load(monkeypatch, "dreamer_v3_compile_settings")
+        resolve = example["resolve_compile_settings"]
+        cpu, cuda = torch.device("cpu"), torch.device("cuda")
+        cfg = OmegaConf.load(example_dir / "config.yaml")
+
+        # auto: the whole fast path on CUDA, eager elsewhere.
+        fast = resolve(cfg, cuda)
+        assert (fast.train_step, fast.rssm, fast.cudagraph) == (True, "scan", True)
+        assert fast.scan_unroll == cfg.optimization.rssm_scan_unroll
+        assert fast.enabled
+        eager = resolve(cfg, cpu)
+        assert (eager.train_step, eager.rssm, eager.cudagraph) == (False, None, False)
+        assert not eager.enabled
+
+        # off: nothing, unless a switch is set explicitly.
+        cfg.optimization.compile = "off"
+        assert not resolve(cfg, cuda).enabled
+        cfg.optimization.compile_rssm = "scan"
+        explicit = resolve(cfg, cuda)
+        assert (explicit.train_step, explicit.rssm, explicit.cudagraph) == (
+            False,
+            "scan",
+            False,
+        )
+
+        # an explicit switch overrides one decision of auto.
+        cfg.optimization.compile = "auto"
+        cfg.optimization.compile_rssm = None
+        cfg.optimization.compile_train_step = False
+        partial = resolve(cfg, cuda)
+        assert (partial.train_step, partial.rssm, partial.cudagraph) == (
+            False,
+            "scan",
+            True,
+        )
+
+        cfg.optimization.compile = "sometimes"
+        with pytest.raises(ValueError, match="'auto' or 'off'"):
+            resolve(cfg, cuda)
+        cfg.optimization.compile = "auto"
+        cfg.optimization.cudagraph_train_step = True
+        with pytest.raises(ValueError, match="requires a CUDA training device"):
+            resolve(cfg, cpu)
+
+    def test_stepper_defaults_follow_the_device(self, monkeypatch):
+        from torchrl.trainers.algorithms import DreamerV3OptimizationStepper
+
+        example_dir, example = self._load(monkeypatch, "dreamer_v3_stepper_defaults")
+        cfg = TestDreamerV3()._small_sota_config(
+            example_dir, compile_train_step=False, cudagraph_train_step=False
+        )
+        cfg.optimization.compile_rssm = None
+        device = torch.device("cpu")
+        learner = example["_build_learner"](cfg, device, 3, 1)
+        loss_module = example["_make_learner_update"](cfg, device, learner).loss_module
+        stepper = DreamerV3OptimizationStepper(
+            loss_module, learner.optimizer, learner.value_target_updater
+        )
+        assert stepper.resolve(torch.device("cuda")) == (True, True)
+        assert stepper.resolve(device) == (False, False)
+        # On CPU the defaults run eagerly without a warm-up.
+        sample = example["_fake_learner_sample"](cfg, device, 3, 1)
+        before = [parameter.detach().clone() for parameter in loss_module.parameters()]
+        stepper.step(None, sample)
+        assert any(
+            not torch.equal(parameter, previous)
+            for parameter, previous in zip(loss_module.parameters(), before)
+        )
+
+    def test_compiled_step_selects_the_scan_for_untouched_rollouts(self, monkeypatch):
+        example_dir, example = self._load(monkeypatch, "dreamer_v3_stepper_scan")
+        cfg = TestDreamerV3()._small_sota_config(
+            example_dir, compile_train_step=True, cudagraph_train_step=False
+        )
+        device = torch.device("cpu")
+        learner = example["_build_learner"](cfg, device, 3, 1)
+        update = example["_make_learner_update"](cfg, device, learner)
+        rollouts = [
+            module
+            for module in update.loss_module.modules()
+            if isinstance(module, RSSMRolloutV3)
+        ]
+        assert rollouts
+        # The builder left the rollouts eager for the compiled step.
+        assert all(
+            rollout._scan_fn is None and rollout._step_fn is None
+            for rollout in rollouts
+        )
+        selected = update._select_scan_backends()
+        assert selected == rollouts
+        assert all(
+            isinstance(rollout._scan_fn, ft.partial)
+            and rollout._scan_fn.keywords
+            == {"unroll": cfg.optimization.rssm_scan_unroll}
+            for rollout in rollouts
+        )
+        # A rollout with a backend keeps it, and the selection is idempotent.
+        assert update._select_scan_backends() == []
+        update.rssm_scan_unroll = None
+        assert update._select_scan_backends() == []
 
 
 if __name__ == "__main__":

--- a/torchrl/modules/models/model_based.py
+++ b/torchrl/modules/models/model_based.py
@@ -2429,6 +2429,10 @@ class RSSMRolloutV3(TensorDictModuleBase):
         """Run the recurrence with the higher-order :func:`torch.scan`."""
         if not isinstance(unroll, int) or isinstance(unroll, bool) or unroll < 1:
             raise ValueError(f"unroll must be a positive integer, got {unroll!r}.")
+        if not action.is_floating_point():
+            # A one-hot action spec yields bool actions; the explicit loop casts
+            # them in the prior, the scan body must receive floats.
+            action = action.to(belief.dtype)
         prior_net = self.rssm_prior.module
         posterior_net = self.rssm_posterior.module
         length = action.shape[-2]
@@ -2545,6 +2549,7 @@ class RSSMRolloutV3(TensorDictModuleBase):
         scope: Literal["step", "scan"] = "step",
         *,
         unroll: int = 1,
+        compile: bool = True,
         **compile_kwargs,
     ) -> None:
         """Compile the recurrence with :func:`torch.compile`.
@@ -2563,8 +2568,15 @@ class RSSMRolloutV3(TensorDictModuleBase):
                 higher-order scan iteration. Larger values can improve runtime
                 at the cost of compilation time and graph size. Only applies
                 to ``scope="scan"``. Defaults to ``1``.
+            compile (bool, optional): If ``False``, select the backend without
+                wrapping it in :func:`torch.compile`, for a rollout that runs
+                inside an enclosing compiled region such as a compiled learner
+                step. The enclosing compile then traces one higher-order scan
+                of ``unroll`` steps instead of unrolling the explicit loop over
+                the whole sequence. Defaults to ``True``.
             **compile_kwargs: Keyword arguments for :func:`torch.compile`.
-                ``dynamic`` defaults to ``False``.
+                ``dynamic`` defaults to ``False``. Ignored when ``compile`` is
+                ``False``.
         """
         if not self._fast_path:
             raise RuntimeError(
@@ -2580,14 +2592,17 @@ class RSSMRolloutV3(TensorDictModuleBase):
         compile_kwargs.setdefault("dynamic", False)
         self._step_fn = self._scan_fn = None
         if scope == "step":
-            self._step_fn = torch.compile(self._step, **compile_kwargs)
+            self._step_fn = (
+                torch.compile(self._step, **compile_kwargs) if compile else self._step
+            )
         else:
             devices = {value.device for value in self.parameters()}
             devices.update(value.device for value in self.buffers())
             for device in devices:
                 _maybe_warm_scan_backward(device)
-            self._scan_fn = torch.compile(
-                ft.partial(self._scan, unroll=unroll), **compile_kwargs
+            scan_fn = ft.partial(self._scan, unroll=unroll)
+            self._scan_fn = (
+                torch.compile(scan_fn, **compile_kwargs) if compile else scan_fn
             )
 
     def __getstate__(self) -> dict:

--- a/torchrl/trainers/algorithms/configs/hooks.py
+++ b/torchrl/trainers/algorithms/configs/hooks.py
@@ -197,9 +197,10 @@ class DreamerV3OptimizationStepperConfig(HookConfig):
     loss_module: Any = None
     optimizer: Any = None
     target_updater: Any = None
-    compile_train_step: bool = False
+    compile_train_step: bool | None = None
     compile_mode: str = "default"
-    cudagraph: bool = False
+    cudagraph: bool | None = None
+    rssm_scan_unroll: int | None = 8
     warmup_steps: int = 5
     mixed_precision: bool = False
     _target_: str = "torchrl.trainers.algorithms.DreamerV3OptimizationStepper"

--- a/torchrl/trainers/algorithms/dreamer_v3.py
+++ b/torchrl/trainers/algorithms/dreamer_v3.py
@@ -13,6 +13,7 @@ from tensordict import TensorDictBase
 from tensordict.nn import CudaGraphModule
 
 from torchrl.checkpoint import GlobalRNGState
+from torchrl.modules.models.model_based import RSSMRolloutV3
 from torchrl.objectives.dreamer_v3 import DreamerV3Loss
 from torchrl.objectives.utils import TargetNetUpdater
 from torchrl.trainers.trainers import OptimizationStepper
@@ -208,13 +209,21 @@ class DreamerV3OptimizationStepper(OptimizationStepper):
             after each optimizer step. Default: ``None``.
 
     Keyword Args:
-        compile_train_step (bool, optional): Compile the complete
-            forward/backward pass. Requires PyTorch's
+        compile_train_step (bool or None, optional): Compile the complete
+            forward/backward pass with TorchInductor. Requires PyTorch's
             ``torch._dynamo.config.inline_inbuilt_nn_modules`` support to be
-            enabled for functional parameter contexts. Default: ``False``.
+            enabled for functional parameter contexts. ``None`` picks the
+            fastest supported path for the sample device: compiled on CUDA,
+            eager elsewhere. Default: ``None``.
         compile_mode (str, optional): PyTorch compile mode. Default: ``"default"``.
-        cudagraph (bool, optional): Capture forward/backward on CUDA.
-            Default: ``False``.
+        cudagraph (bool or None, optional): Capture forward/backward on CUDA.
+            ``None`` captures on CUDA and stays eager elsewhere. Default: ``None``.
+        rssm_scan_unroll (int or None, optional): When the step is compiled,
+            every :class:`~torchrl.modules.RSSMRolloutV3` of the loss without a
+            selected backend switches to the higher-order scan, unrolled by this
+            many steps, so the compile traces one scan instead of the explicit
+            loop over the whole sequence. ``None`` leaves the rollouts as they
+            are. Default: ``8``.
         warmup_steps (int, optional): Representative forward/backward calls
             before training. Must be positive. Default: ``5``.
         mixed_precision (bool, optional): Use bfloat16 autocast for CUDA
@@ -225,6 +234,11 @@ class DreamerV3OptimizationStepper(OptimizationStepper):
         scope. Pause collection and synchronize pending replay operations before
         warm-up or checkpointing. Distributed execution is outside this stepper's
         supported modes.
+
+    .. note::
+        The device decides the defaults, so a stepper built with the default
+        arguments must call :meth:`warmup` before its first update on CUDA;
+        on CPU the first update runs eagerly without it.
 
     Examples:
         Continue from the runnable :class:`~torchrl.objectives.DreamerV3Loss`
@@ -256,33 +270,83 @@ class DreamerV3OptimizationStepper(OptimizationStepper):
         optimizer: torch.optim.Optimizer,
         target_updater: TargetNetUpdater | None = None,
         *,
-        compile_train_step: bool = False,
+        compile_train_step: bool | None = None,
         compile_mode: Literal[
             "default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"
         ] = "default",
-        cudagraph: bool = False,
+        cudagraph: bool | None = None,
+        rssm_scan_unroll: int | None = 8,
         warmup_steps: int = 5,
         mixed_precision: bool = False,
     ):
         if warmup_steps < 1:
             raise ValueError("warmup_steps must be positive.")
-        if compile_train_step and not getattr(
-            torch._dynamo.config, "inline_inbuilt_nn_modules", False
+        if rssm_scan_unroll is not None and (
+            not isinstance(rssm_scan_unroll, int)
+            or isinstance(rssm_scan_unroll, bool)
+            or rssm_scan_unroll < 1
         ):
-            raise RuntimeError(
-                "Whole-step compilation requires a PyTorch runtime with "
-                "torch._dynamo.config.inline_inbuilt_nn_modules enabled."
+            raise ValueError(
+                f"rssm_scan_unroll must be a positive integer or None, got "
+                f"{rssm_scan_unroll!r}."
             )
+        if compile_train_step:
+            self._check_compile_support()
         self.loss_module = loss_module
         self.optimizer = optimizer
         self.target_updater = target_updater
         self.compile_train_step = compile_train_step
         self.compile_mode = compile_mode
         self.cudagraph = cudagraph
+        self.rssm_scan_unroll = rssm_scan_unroll
         self.warmup_steps = warmup_steps
         self.mixed_precision = mixed_precision
-        self._ready = not (compile_train_step or cudagraph)
+        self._ready = compile_train_step is False and cudagraph is False
         self._train_step = self._forward_backward
+
+    @staticmethod
+    def _check_compile_support() -> None:
+        if not getattr(torch._dynamo.config, "inline_inbuilt_nn_modules", False):
+            raise RuntimeError(
+                "Whole-step compilation requires a PyTorch runtime with "
+                "torch._dynamo.config.inline_inbuilt_nn_modules enabled."
+            )
+
+    def resolve(self, device: torch.device) -> tuple[bool, bool]:
+        """Return the ``(compile_train_step, cudagraph)`` pair used on ``device``.
+
+        ``None`` requests resolve to ``True`` on CUDA and ``False`` elsewhere;
+        explicit requests are returned unchanged.
+        """
+        is_cuda = device.type == "cuda"
+        compile_train_step = (
+            is_cuda if self.compile_train_step is None else self.compile_train_step
+        )
+        cudagraph = is_cuda if self.cudagraph is None else self.cudagraph
+        return compile_train_step, cudagraph
+
+    def _select_scan_backends(self) -> list[RSSMRolloutV3]:
+        """Switch the loss's rollouts without a backend to the higher-order scan.
+
+        The scan is selected without its own :func:`torch.compile` so that the
+        compiled step traces one scan of ``rssm_scan_unroll`` steps. Rollouts
+        with a backend, compiled or not, keep it.
+        """
+        if self.rssm_scan_unroll is None:
+            return []
+        selected = []
+        for module in self.loss_module.modules():
+            if (
+                isinstance(module, RSSMRolloutV3)
+                and module._fast_path
+                and module._step_fn is None
+                and module._scan_fn is None
+            ):
+                module.compile_rollout(
+                    "scan", unroll=self.rssm_scan_unroll, compile=False
+                )
+                selected.append(module)
+        return selected
 
     def _prepare_sample(self, sample: TensorDictBase) -> TensorDictBase:
         sample = sample.select(*self.loss_module.in_keys, strict=False)
@@ -323,13 +387,16 @@ class DreamerV3OptimizationStepper(OptimizationStepper):
         """
         sample = self._prepare_sample(sample)
         reference = sample.get(self.loss_module.in_keys[0])
-        if self.cudagraph and reference.device.type != "cuda":
+        compile_train_step, cudagraph = self.resolve(reference.device)
+        if cudagraph and reference.device.type != "cuda":
             raise RuntimeError("CUDA graph learner updates require CUDA inputs.")
         self._ready = False
         train_step = self._forward_backward
-        if self.compile_train_step:
+        if compile_train_step:
+            self._check_compile_support()
+            self._select_scan_backends()
             train_step = torch.compile(train_step, mode=self.compile_mode)
-        if self.cudagraph:
+        if cudagraph:
             train_step = CudaGraphModule(
                 train_step, warmup=self.warmup_steps, device=reference.device
             )
@@ -376,9 +443,17 @@ class DreamerV3OptimizationStepper(OptimizationStepper):
                     "Distributed DreamerV3 updates are not supported."
                 )
         if not self._ready:
-            raise RuntimeError(
-                "Call warmup(sample) before compiled or captured learner updates."
-            )
+            sample = self._prepare_sample(sub_batch)
+            reference = sample.get(self.loss_module.in_keys[0])
+            if any(self.resolve(reference.device)):
+                raise RuntimeError(
+                    "Call warmup(sample) before compiled or captured learner "
+                    "updates. On CUDA the defaults compile and capture the step; "
+                    "pass compile_train_step=False and cudagraph=False to run "
+                    "eagerly without a warm-up."
+                )
+            self._train_step = self._forward_backward
+            self._ready = True
         result = self._train_step(self._prepare_sample(sub_batch))
         if not any(
             parameter.grad is not None


### PR DESCRIPTION
DreamerV3 can resolve compilation settings from the training device: `optimization.compile=auto` selects a compiled full learner step, RSSM scan, and CUDA graph on CUDA, while CPU defaults stay eager. Explicit settings override individual decisions; `compile=off` provides an eager baseline.

The full-step compiler selects the RSSM scan without nesting a separately compiled rollout. The public optimization stepper and Hydra configuration expose matching nullable compile/capture settings and scan unroll controls. The learner benchmark selects scan for both full-step variants, so those measurements exercise the proposed execution strategy.

Checkpoint regression tests explicitly disable automatic compilation while retaining CUDA capture coverage. Saved CUDA checkpoints are inspected using a separate eager CPU configuration. The end-to-end compiled/captured comparison has a 600-second timeout: it builds two independent forward/backward paths, and the previous implementation already took approximately 266 seconds against the former 300-second limit.

Validation: 11 focused CPU tests passed against current TensorDict main: all six checkpoint/resume process cases, compile-strategy tests, full learner compilation, and RSSM scan under an outer Inductor compile. Formatting and lint passed for the patch. GPU correctness and runtime remain subject to the new CI run; no local CUDA result or throughput improvement is claimed.
