### PR TITLE
[Test] Preserve metadata in static inference batches

### DIFF
--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -20,7 +20,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from tensordict import lazy_stack, TensorDict
+from tensordict import lazy_stack, NonTensorData, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModule
 from tensordict.nn.probabilistic import (
@@ -415,6 +415,39 @@ class TestInferenceServerCore:
             for r in results:
                 assert "action" in r.keys()
                 assert r["action"].shape == (2,)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_static_batch_pads_requests_with_non_tensor_leaves(self):
+        """Padding must not choke on the pool's non-tensor env_index leaf."""
+        policy = TensorDictModule(
+            _BatchSizeModule(), in_keys=["observation"], out_keys=["action"]
+        )
+        server = InferenceServer(
+            policy,
+            transport="auto",
+            max_batch_size=4,
+            static_batch_size=4,
+            request_spec=TensorDict({"observation": torch.zeros(1)}),
+            policy_device="cuda:0",
+        )
+        transport = server.transport
+        futures = [
+            transport.submit(
+                TensorDict(
+                    {
+                        "observation": torch.tensor([value]),
+                        "env_index": NonTensorData(data=index),
+                    }
+                )
+            )
+            for index, value in enumerate((1.0, 2.0))
+        ]
+        with server:
+            results = [future.result(timeout=5.0) for future in futures]
+        assert len(results) == 2
+        for result in results:
+            assert result["action"].shape == (2,)
 
     def test_static_batch_requires_cuda_policy_device(self):
         policy = TensorDictModule(

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -20,7 +20,12 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from tensordict import lazy_stack, NonTensorData, TensorDict
+from tensordict import (
+    lazy_stack,
+    NonTensorData,
+    set_capture_non_tensor_stack,
+    TensorDict,
+)
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModule
 from tensordict.nn.probabilistic import (
@@ -416,38 +421,32 @@ class TestInferenceServerCore:
                 assert "action" in r.keys()
                 assert r["action"].shape == (2,)
 
-    @pytest.mark.gpu
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
-    def test_static_batch_pads_requests_with_non_tensor_leaves(self):
-        """Padding must not choke on the pool's non-tensor env_index leaf."""
+    @pytest.mark.parametrize("capture", [False, True])
+    def test_static_batch_preserves_non_tensor_metadata(self, capture):
         policy = TensorDictModule(
             _BatchSizeModule(), in_keys=["observation"], out_keys=["action"]
         )
-        server = InferenceServer(
-            policy,
-            transport="auto",
-            max_batch_size=4,
-            static_batch_size=4,
-            request_spec=TensorDict({"observation": torch.zeros(1)}),
-            policy_device="cuda:0",
-        )
-        transport = server.transport
-        futures = [
-            transport.submit(
-                TensorDict(
-                    {
-                        "observation": torch.tensor([value]),
-                        "env_index": NonTensorData(data=index),
-                    }
-                )
+        server = InferenceServer(policy, _MockTransport(), max_batch_size=4)
+        # Exercise padding on CPU without preparing a CUDA graph.
+        server.static_batch_size = 4
+        items = [
+            TensorDict(
+                {
+                    "observation": torch.tensor([value]),
+                    "env_index": NonTensorData(index),
+                    "metadata": {"label": NonTensorData(str(index))},
+                }
             )
             for index, value in enumerate((1.0, 2.0))
         ]
-        with server:
-            results = [future.result(timeout=5.0) for future in futures]
-        assert len(results) == 2
-        for result in results:
-            assert result["action"].shape == (2,)
+        with set_capture_non_tensor_stack(capture):
+            batch = server._collate_model_batch(items, pad_to_static=True)
+        assert batch.batch_size == (4,)
+        assert [batch[i]["env_index"] for i in range(4)] == [0, 1, 1, 1]
+        assert [batch[i]["metadata", "label"] for i in range(4)] == ["0", "1", "1", "1"]
+        torch.testing.assert_close(
+            policy(batch)["action"], torch.tensor([[5.0], [6.0], [6.0], [6.0]])
+        )
 
     def test_static_batch_requires_cuda_policy_device(self):
         policy = TensorDictModule(
@@ -465,7 +464,9 @@ class TestInferenceServerCore:
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
-    def test_static_batch_pads_slices_and_owns_results(self):
+    @pytest.mark.parametrize("metadata", [False, True])
+    @set_capture_non_tensor_stack(True)
+    def test_static_batch_pads_slices_and_owns_results(self, metadata):
         policy = TensorDictModule(
             _BatchSizeModule(), in_keys=["observation"], out_keys=["action"]
         )
@@ -479,10 +480,13 @@ class TestInferenceServerCore:
             policy_device="cuda:0",
         )
         transport = server.transport
-        futures = [
-            transport.submit(TensorDict({"observation": torch.tensor([value])}))
-            for value in (1.0, 2.0)
+        requests = [
+            TensorDict({"observation": torch.tensor([value])}) for value in (1.0, 2.0)
         ]
+        if metadata:
+            for index, request in enumerate(requests):
+                request.set("env_index", NonTensorData(index))
+        futures = [transport.submit(request) for request in requests]
 
         with server:
             results = [future.result(timeout=5.0) for future in futures]

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -780,7 +780,14 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         # Materialize them before capture so the graph owns stable input storage.
         # Transfer real requests before padding so host-to-device traffic scales
         # with the ready batch rather than the configured graph capacity.
-        batch = self.collate_fn(items).contiguous().to(self.policy_device)
+        # Non-tensor leaves (the environment pool's env_index) have no static
+        # shape to pad to and are not policy inputs: drop them here.
+        batch = (
+            self.collate_fn(items)
+            .filter_non_tensor_data()
+            .contiguous()
+            .to(self.policy_device)
+        )
         padding = self.static_batch_size - len(items)
         if padding:
             batch = torch.cat(

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -780,14 +780,7 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         # Materialize them before capture so the graph owns stable input storage.
         # Transfer real requests before padding so host-to-device traffic scales
         # with the ready batch rather than the configured graph capacity.
-        # Non-tensor leaves (the environment pool's env_index) have no static
-        # shape to pad to and are not policy inputs: drop them here.
-        batch = (
-            self.collate_fn(items)
-            .filter_non_tensor_data()
-            .contiguous()
-            .to(self.policy_device)
-        )
+        batch = self.collate_fn(items).contiguous().to(self.policy_device)
         padding = self.static_batch_size - len(items)
         if padding:
             batch = torch.cat(


### PR DESCRIPTION
Static inference batches must retain per-request non-tensor metadata while repeating the final request for padding. The underlying concatenation bug is fixed by pytorch/tensordict#1786, which is now merged and is consumed by the existing source-dependency CI setup.

Remove the metadata-dropping workaround. Add CPU coverage for flat and nested metadata with non-tensor stack capture enabled and disabled, and extend the existing CUDA padding/output-ownership test with metadata requests. The test checks action values and preserves the one-element output shape.

Validation: 29 CPU inference-server core tests passed against TensorDict main (including #1786). CUDA coverage is delegated to the GPU CI jobs; no CUDA device is available locally.
