### PR TITLE
[Feature] Serve the DreamerV3 acting policy from environment processes

### DIFF
--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -69,6 +69,21 @@ synchronous `Collector`. `collector.async_env_backend` selects `threading` or
 post-processing, episode reporting, device normalization, and replay writes
 happen through the collector's standard replay integration.
 
+`collector.inference_backend` selects where the acting policy is served.
+`thread` (the default) runs the inference server in a thread of the training
+process, and coordinator threads relay observations and actions between the
+environment workers and the server. `process` starts a dedicated inference
+process that reads each environment worker's shared-memory request slot and
+writes the action back into it, so no observation or action crosses the
+training process; the driver only receives completed transitions. It requires
+`collector.async_env_backend=multiprocessing` and `collector.envs_per_worker=1`,
+uses the worker exchange owned by the transport (`collector.env_exchange` is
+ignored), and takes `collector.inference_static_batch_size` like the thread
+server. The policy is rebuilt from the configuration inside the server process
+and receives the learner's weights through the collector's policy-update path:
+the server starts with the first collected batch, receives the learner's
+weights right after it, and again after every training batch.
+
 For a three-seed median and interquartile reproduction run:
 
 ```bash

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -24,6 +24,12 @@ collector:
   inference_min_batch_size: 1
   inference_timeout: 0.01
   inference_static_batch_size: null
+  # Where the acting policy is served. "thread": the inference server runs in a
+  # thread of this process and coordinator threads relay observations and
+  # actions. "process": a dedicated inference process reads each environment
+  # worker's shared-memory slot directly, so nothing crosses the driver on the
+  # action path; needs async_env_backend=multiprocessing and envs_per_worker=1.
+  inference_backend: thread
   num_envs: 1
   frames_per_batch: 200
   total_frames: 5000

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -39,6 +39,7 @@ from torchrl.modules import (
     DreamerV3ImageDecoder,
     DreamerV3ImageEncoder,
     DreamerV3MLP,
+    DreamerV3SeededPolicy,
     RSSMStateEstimatorV3,
     SymExpTwoHot,
     WorldModelWrapper,
@@ -648,6 +649,39 @@ def build_actor(
         ),
     )
     return actor_model
+
+
+def build_serving_policy(
+    cfg: dict,
+    obs_dim: int,
+    action_dim: int,
+    pixels_shape: tuple[int, int, int] | None,
+    discrete: bool,
+) -> TensorDictModuleBase:
+    """Build the acting policy inside an inference server process.
+
+    A picklable zero-argument factory is made with :func:`functools.partial`
+    over the resolved configuration container; the server moves the policy to
+    its device and receives the learner's weights through the collector's
+    policy-update path.
+    """
+    cfg = OmegaConf.create(cfg)
+    world_model, *_ = build_world_model(
+        cfg=cfg,
+        obs_dim=obs_dim,
+        action_dim=action_dim,
+        pixels_shape=pixels_shape,
+        compile_rollout=False,
+    )
+    actor_model = build_actor(cfg=cfg, action_dim=action_dim, discrete=discrete)
+    policy = build_real_world_actor(
+        world_model=world_model,
+        actor_model=actor_model,
+        mixed_precision=cfg.optimization.mixed_precision,
+    )
+    if cfg.optimization.separate_policy_rng:
+        policy = DreamerV3SeededPolicy(policy, cfg.env.seed)
+    return policy
 
 
 def build_real_world_actor(

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -35,6 +35,7 @@ from dreamer_v3_agent import (
     build_imagination_model,
     build_mb_env,
     build_real_world_actor,
+    build_serving_policy,
     build_value,
     build_world_model,
     DreamerV3BehaviorPolicySync,
@@ -75,6 +76,7 @@ from torchrl.modules import DreamerV3SeededPolicy
 from torchrl.modules.inference_server import (
     InferenceDeviceConfig,
     InferenceServerConfig,
+    ProcessSlotTransport,
 )
 from torchrl.objectives import (
     DreamerV3ActorLoss,
@@ -473,6 +475,40 @@ def _build_learner(
     )
 
 
+def _behavior_policy_weights(
+    cfg: DictConfig, learner: _Learner
+) -> TensorDictBase | TensorDictModuleBase:
+    """The learner's acting weights in the layout of the served policy."""
+    policy_weights = learner.real_world_actor
+    if cfg.optimization.separate_policy_rng:
+        return TensorDict({"module": TensorDict.from_module(policy_weights)}, [])
+    return policy_weights
+
+
+def _inference_slot_specs(
+    cfg: DictConfig,
+    device: torch.device,
+    policy: TensorDictModuleBase,
+    state_dim: int,
+    action_dim: int,
+) -> tuple[TensorDictBase, TensorDictBase]:
+    """Representative request and response of the acting policy, on CPU.
+
+    A process-hosted inference server exchanges fixed shared-memory slots with
+    the environment workers, so their layout is fixed from one environment's
+    fake transition and one policy pass before collection starts.
+    """
+    primed_env = make_primed_env(cfg, cfg.env.seed + 1, state_dim, action_dim)
+    try:
+        request = primed_env.fake_tensordict().select(*policy.in_keys, strict=True)
+    finally:
+        primed_env.close()
+    request = request.cpu()
+    with torch.no_grad():
+        response = policy(request.clone().unsqueeze(0).to(device)).squeeze(0)
+    return request, response.select(*policy.out_keys, strict=True).cpu()
+
+
 def _build_collection(
     cfg: DictConfig,
     device: torch.device,
@@ -482,6 +518,10 @@ def _build_collection(
     collector_action_frames: int,
     replay_buffer: ReplayBufferEnsemble,
     post_collect_hook: Callable[[TensorDictBase], None],
+    *,
+    obs_dim: int,
+    pixels_shape: tuple[int, int, int] | None,
+    discrete: bool,
 ) -> tuple[Collector | AsyncBatchedCollector, DreamerV3BehaviorPolicySync | None]:
     num_envs = cfg.collector.num_envs
     collector_backend = cfg.collector.backend
@@ -554,27 +594,75 @@ def _build_collection(
         "replay_buffer": replay_buffer,
     }
     if collector_backend == "async":
-        collector = AsyncBatchedCollector(
-            create_env_fns,
-            policy=collector_policy,
-            env_backend=cfg.collector.async_env_backend,
-            env_exchange=cfg.collector.env_exchange,
-            envs_per_worker=cfg.collector.envs_per_worker,
-            server_config=InferenceServerConfig(
-                max_batch_size=cfg.collector.inference_max_batch_size or num_envs,
-                min_batch_size=cfg.collector.inference_min_batch_size,
-                timeout=cfg.collector.inference_timeout,
-                static_batch_size=cfg.collector.inference_static_batch_size,
-            ),
-            device_config=InferenceDeviceConfig(
-                policy_device=cfg.collector.policy_device or device,
-                output_device="cpu",
-                env_device="cpu",
-                storing_device="cpu",
-            ),
-            policy_version_key=None,
-            **collector_kwargs,
+        inference_backend = cfg.collector.inference_backend
+        if inference_backend not in ("thread", "process"):
+            raise ValueError(
+                "collector.inference_backend must be 'thread' or 'process', got "
+                f"{inference_backend!r}."
+            )
+        server_config = InferenceServerConfig(
+            service_backend=inference_backend,
+            max_batch_size=cfg.collector.inference_max_batch_size or num_envs,
+            min_batch_size=cfg.collector.inference_min_batch_size,
+            timeout=cfg.collector.inference_timeout,
+            static_batch_size=cfg.collector.inference_static_batch_size,
         )
+        device_config = InferenceDeviceConfig(
+            policy_device=cfg.collector.policy_device or device,
+            output_device="cpu",
+            env_device="cpu",
+            storing_device="cpu",
+        )
+        if inference_backend == "process":
+            if (
+                cfg.collector.async_env_backend != "multiprocessing"
+                or cfg.collector.envs_per_worker != 1
+            ):
+                raise ValueError(
+                    "collector.inference_backend='process' requires "
+                    "collector.async_env_backend=multiprocessing and "
+                    "collector.envs_per_worker=1."
+                )
+            request_spec, response_spec = _inference_slot_specs(
+                cfg, device, collector_policy, state_dim, action_dim
+            )
+            # The server process rebuilds the policy from the configuration and
+            # receives the learner's weights through update_policy_weights_.
+            collector = AsyncBatchedCollector(
+                create_env_fns,
+                policy_factory=ft.partial(
+                    build_serving_policy,
+                    OmegaConf.to_container(cfg, resolve=True),
+                    obs_dim,
+                    action_dim,
+                    pixels_shape,
+                    discrete,
+                ),
+                transport=ProcessSlotTransport(
+                    request_spec, response_spec, num_slots=num_envs
+                ),
+                env_backend="multiprocessing",
+                # The transport owns the worker exchange; the collector
+                # requires the queue setting here.
+                env_exchange="queue",
+                envs_per_worker=1,
+                server_config=server_config,
+                device_config=device_config,
+                policy_version_key=None,
+                **collector_kwargs,
+            )
+        else:
+            collector = AsyncBatchedCollector(
+                create_env_fns,
+                policy=collector_policy,
+                env_backend=cfg.collector.async_env_backend,
+                env_exchange=cfg.collector.env_exchange,
+                envs_per_worker=cfg.collector.envs_per_worker,
+                server_config=server_config,
+                device_config=device_config,
+                policy_version_key=None,
+                **collector_kwargs,
+            )
     else:
         collector = Collector(
             SerialEnv(num_envs, create_env_fns),
@@ -928,6 +1016,9 @@ def main(cfg: DictConfig):
         else -1,
         rb,
         post_collect_hook,
+        obs_dim=obs_dim,
+        pixels_shape=pixels_shape,
+        discrete=discrete,
     )
 
     history_steps: list[int] = []
@@ -1029,10 +1120,19 @@ def main(cfg: DictConfig):
             torchrl_logger.info("Saved DreamerV3 checkpoint to %s", path)
 
     collection_timer = None
+    # A process-hosted inference server starts from freshly built weights; the
+    # first collected batch starts it, then it receives the learner's weights.
+    initial_policy_sync_pending = (
+        isinstance(collector, AsyncBatchedCollector)
+        and cfg.collector.inference_backend == "process"
+    )
     try:
         for _ in collector:
             if collection_timer is None:
                 collection_timer = timeit("dreamer_v3/collection", sync=False).start()
+            if initial_policy_sync_pending:
+                collector.update_policy_weights_(_behavior_policy_weights(cfg, learner))
+                initial_policy_sync_pending = False
             # The collector writes canonical transitions directly into replay.
             if behavior_policy_sync is not None:
                 behavior_policy_sync.apply_after_action()
@@ -1116,12 +1216,7 @@ def main(cfg: DictConfig):
                 update_step += 1
 
             if isinstance(collector, AsyncBatchedCollector):
-                policy_weights = learner.real_world_actor
-                if cfg.optimization.separate_policy_rng:
-                    policy_weights = TensorDict(
-                        {"module": TensorDict.from_module(policy_weights)}, []
-                    )
-                collector.update_policy_weights_(policy_weights)
+                collector.update_policy_weights_(_behavior_policy_weights(cfg, learner))
 
             if record_loss_history:
                 loss_history.append(batch_losses.cpu())

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2601,6 +2601,66 @@ def test_dreamer_v3_native_replay_collection_smoke(
     not (_has_hydra and _has_omegaconf and _has_gym),
     reason="requires hydra, omegaconf, and gym",
 )
+@pytest.mark.parametrize("separate_policy_rng", [False, True])
+def test_dreamer_v3_process_inference_collection_smoke(
+    monkeypatch, tmp_path, separate_policy_rng
+):
+    """A process-hosted inference server collects, trains and syncs weights."""
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py", run_name="dreamer_v3_process_inference"
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.optimization.device = "cpu"
+    cfg.optimization.separate_policy_rng = separate_policy_rng
+    cfg.optimization.updates_per_batch = 1
+    cfg.optimization.train_ratio = None
+    cfg.collector.backend = "async"
+    cfg.collector.async_env_backend = "multiprocessing"
+    cfg.collector.inference_backend = "process"
+    cfg.collector.envs_per_worker = 1
+    cfg.collector.num_envs = 2
+    cfg.collector.frames_per_batch = 8
+    cfg.collector.total_frames = 16
+    cfg.replay_buffer.buffer_size = 64
+    cfg.replay_buffer.batch_size = 2
+    cfg.replay_buffer.seq_len = 2
+    cfg.replay_buffer.warmup_factor = 1
+    cfg.env.backend = "custom"
+    cfg.env.factory = f"{__name__}:_DreamerV3TestEnv"
+    cfg.env.factory_kwargs = {"pixels": False, "discrete": False}
+    cfg.env.vector_key = ["sensors", "vector"]
+    cfg.env.pixels_key = None
+    cfg.env.milestone_key = ["episode", "milestones"]
+    cfg.env.milestone_names = ["started", "completed"]
+    cfg.logger.eval_every = 0
+    cfg.logger.train_every = 8
+    cfg.logger.output_plot = None
+    cfg.logger.backend = "csv"
+    cfg.logger.log_dir = str(tmp_path / "logs")
+    cfg.logger.metrics_jsonl = str(tmp_path / "metrics.jsonl")
+    example["main"].__wrapped__(cfg)
+    records = [
+        json.loads(line)
+        for line in Path(cfg.logger.metrics_jsonl).read_text().splitlines()
+    ]
+    assert records[-1]["total_action_steps"] == 16
+    assert records[-1]["updates"] > 0
+    assert any(record["type"] == "train_episode" for record in records)
+
+    cfg.collector.envs_per_worker = 2
+    with pytest.raises(ValueError, match="envs_per_worker=1"):
+        example["main"].__wrapped__(cfg)
+
+
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
 @pytest.mark.parametrize(
     ("collector_backend", "include_replay", "terminate"),
     [


### PR DESCRIPTION
## Description

Adds `collector.inference_backend` to the DreamerV3 SOTA example so the acting policy can be served from a dedicated inference process instead of a thread of the training process.

- `thread` (default, unchanged): the `InferenceServer` runs in a thread of the training process and coordinator threads relay observations and actions between the environment workers and the server.
- `process`: `AsyncBatchedCollector` is built around a `ProcessSlotTransport`. A dedicated inference process reads each environment worker's shared-memory request slot and writes the action back into it, so no observation or action crosses the training process on the action path; the driver only receives completed transitions. Requires `collector.async_env_backend=multiprocessing` and `collector.envs_per_worker=1`; `collector.env_exchange` is owned by the transport.

Implementation notes:

- `dreamer_v3_agent.build_serving_policy` is a picklable factory (used through `functools.partial` over the resolved config container) that rebuilds the real-world actor inside the server process, including the `DreamerV3SeededPolicy` wrapper when `optimization.separate_policy_rng` is set, so the weight layout matches `collector.update_policy_weights_`.
- `_inference_slot_specs` derives the fixed request/response slot layout from one primed environment's `fake_tensordict()` and a single policy pass.
- The process server only starts with the first collector iteration, so the learner's weights are pushed right after the first collected batch, then after every training batch as before. The periodic sync is factored into `_behavior_policy_weights`.
- README and config document the new key.

## Motivation and Context

Profiling the async DreamerV3 stack on a 64-environment pixel task showed the driver process on the critical path of every environment step (about 2.5 ms of Python per transition across six hand-offs) while the inference server itself was idle most of the time. Serving the policy from the environment side removes the driver from the action path. The mode is opt-in; the default behavior is unchanged.

## Benchmark

DreamerV3 (196M) on a 64-environment pixel task, one 4-GPU node, `train_ratio=16`, otherwise identical configuration (compiled learner step, CUDA-graph static policy batches of 64). Throughput over the same elapsed window (1000 s to 1950 s after training start):

| acting policy served from | steps/s | learner updates/s |
|---|---|---|
| thread server, 4 envs per worker, `shm` exchange (compiled step) | 322 | 0.63 |
| thread server, 4 envs per worker, `shm` exchange (scan, eager step) | 301 | 0.59 |
| process server (`inference_backend=process`), 1 env per worker | 371 | 0.73 |

The learner cadence follows collection through the train ratio in all three runs, so the gain is on the collection path. Note: all three runs used CUDA-graph static policy batches, which turned out to break learning for this policy regardless of the serving backend; see the last section.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

- [x] I have read the CONTRIBUTION guide (required)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (required for a bug fix or a new feature).
- [x] I have updated the documentation accordingly.

## Tests

- New `test_dreamer_v3_process_inference_collection_smoke[False|True]` runs the example end to end on CPU with `inference_backend=process` (2 environments, multiprocessing backend, one env per worker), for both `separate_policy_rng` settings, and checks the validation error for `envs_per_worker != 1`.
- Existing `test_dreamer_v3_native_replay_collection_smoke` sync/async variants pass unchanged.

## Learning regression (resolved 09 Sep: not the process backend)

On a 64-environment pixel task the example collapsed after ~2M environment steps with this backend and with the thread server alike. The cause was `inference_static_batch_size` (a CUDA graph around the acting policy, which the process server forwards to its child): the DreamerV3 acting policy rewrites its `state` and `belief` input keys, which rebinds the graph's static inputs during capture, so the served policy ignored its recurrent inputs and acted from the reset state at every step. PR #4310 makes `InferenceServer` refuse that combination. With `inference_static_batch_size=null` the example learns normally (eager thread server: episode score 4.0-5.7 at 2-5.5M steps); this process backend without static batches (chunked worker-owned replay, 1,150-1,230 environment steps/s) learns the same curve: episode score 3.9 / 4.2 / 4.4 at 3-4.5M steps.

Generated with [Claude Code](https://claude.com/claude-code)


