### PR TITLE
[Performance] Chunk process-slot worker results in AsyncBatchedCollector

### DIFF
--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -62,6 +62,16 @@ matches `async-process-slots`. Each point records its configuration in the
 changed. Use the fixed `async-process-slots*` series to separate the individual
 changes.
 
+`async-process-slots-chunked` is the same direct-transport workload with
+`transition_chunk_size=64`: each environment process sends 64 consecutive
+transitions per message instead of one, so the driver concatenates whole chunks
+into each 256-transition batch rather than unpickling and stacking transitions
+one at a time. Compare it with `async-process-slots` to see what the driver's
+per-transition work costs; the series skips on revisions before the option
+exists. `bench_collectors.py --backends async-process-slot --replay-mode
+background --transition-chunk-size N` measures the same choice as replay-buffer
+write throughput.
+
 `test_async_collection_pixels_64_envs[mode]` adds a separate CUDA acceptance
 comparison for `async-shm` and `async-process-slots`: 64 environments, one per
 worker, with the same CNN plus two 1024-wide layers, one-millisecond environment

--- a/benchmarks/bench_collectors.py
+++ b/benchmarks/bench_collectors.py
@@ -95,6 +95,11 @@ class BenchmarkResult:
     elapsed_s: float = 0.0
     frames_per_s: float = 0.0
     decisions_per_s: float = 0.0
+    # CPU time (user + system) of the driver process per collected frame over
+    # the measured window. With process-backed environments and inference this
+    # is the driver's own transition-path cost; thread backends include the
+    # coordinator and inference-server threads.
+    driver_cpu_ms_per_frame: float = 0.0
     failure: str = ""
     policy_stats: dict[str, float | int] = field(default_factory=dict)
 
@@ -378,6 +383,8 @@ def bench(
             collector.server_stats(reset=True)
         latencies = []
         initial_frames = collector._frames
+        process = psutil.Process()
+        cpu_start = process.cpu_times()
         t0 = previous = time_module.perf_counter()
         if replay_mode == "background":
             iterator.close()
@@ -402,9 +409,12 @@ def bench(
                 if total >= total_frames:
                     break
         elapsed = time_module.perf_counter() - t0
+        cpu_end = process.cpu_times()
+        driver_cpu_s = (cpu_end.user - cpu_start.user) + (
+            cpu_end.system - cpu_start.system
+        )
         if hasattr(collector, "server_stats"):
             policy_stats = collector.server_stats()
-        process = psutil.Process()
         host_rss = process.memory_info().rss
         for child in process.children(recursive=True):
             try:
@@ -445,6 +455,7 @@ def bench(
             elapsed_s=elapsed,
             frames_per_s=fps,
             decisions_per_s=fps,
+            driver_cpu_ms_per_frame=driver_cpu_s * 1000 / total if total else 0.0,
             policy_stats=policy_stats,
         )
     except Exception as err:
@@ -508,7 +519,7 @@ def _print_summary(results: list[BenchmarkResult]) -> None:
     print("=" * 132)
     print(
         f"{'collector':<28} {'backend':<16} {'batch rule':<18} "
-        f"{'envs':>5} {'status':<8} {'fps':>10} {'avg_bs':>8} "
+        f"{'envs':>5} {'status':<8} {'fps':>10} {'drv_ms/f':>9} {'avg_bs':>8} "
         f"{'p95_q_ms':>10} {'p95_fwd_ms':>11} failure"
     )
     print("-" * 132)
@@ -518,6 +529,7 @@ def _print_summary(results: list[BenchmarkResult]) -> None:
             f"{result.collector:<28} {result.backend:<16} "
             f"{result.batch_rule:<18} {result.num_envs:>5} "
             f"{result.status:<8} {result.frames_per_s:>10.1f} "
+            f"{result.driver_cpu_ms_per_frame:>9.3f} "
             f"{float(stats.get('avg_batch_size', 0.0)):>8.2f} "
             f"{float(stats.get('p95_queue_ms', 0.0)):>10.2f} "
             f"{float(stats.get('p95_forward_ms', 0.0)):>11.2f} "

--- a/benchmarks/bench_collectors.py
+++ b/benchmarks/bench_collectors.py
@@ -379,7 +379,7 @@ def bench(
         iterator = iter(collector)
         for _ in range(warmup_batches):
             next(iterator)
-        if hasattr(collector, "server_stats"):
+        if warmup_batches and hasattr(collector, "server_stats"):
             collector.server_stats(reset=True)
         latencies = []
         initial_frames = collector._frames

--- a/benchmarks/bench_collectors.py
+++ b/benchmarks/bench_collectors.py
@@ -10,6 +10,11 @@ Examples:
     python benchmarks/bench_collectors.py --num-envs 1,2,4,8 --policy-delay-ms 20
     python benchmarks/bench_collectors.py --backends async-env-mp --replay-mode iterator
     python benchmarks/bench_collectors.py --backends async-env-mp --replay-mode background
+    # Replay throughput of direct process slots, per-transition vs chunked results
+    python benchmarks/bench_collectors.py --num-envs 8 --backends async-process-slot \
+        --replay-mode background --total-frames 4096 --transition-chunk-size 1
+    python benchmarks/bench_collectors.py --num-envs 8 --backends async-process-slot \
+        --replay-mode background --total-frames 4096 --transition-chunk-size 64
     python benchmarks/bench_collectors.py --num-envs 64 \
         --backends async-env-mp --env-exchange shm \
         --env-step-latency-ms 50 --policy-hidden-features 9216 \
@@ -599,7 +604,19 @@ def main() -> None:
         "--replay-mode",
         choices=["none", "iterator", "background"],
         default="none",
-        help="Replay write mode for async-env-mp; iterator and background use identical storage.",
+        help=(
+            "Replay write mode for async-env-mp and async-process-slot; iterator "
+            "and background use identical storage."
+        ),
+    )
+    parser.add_argument(
+        "--transition-chunk-size",
+        type=int,
+        default=1,
+        help=(
+            "Transitions each environment process accumulates per message with "
+            "async-process-slot; 1 sends every transition on its own."
+        ),
     )
     parser.add_argument("--policy-device", default="auto")
     parser.add_argument("--output-device", default="cpu")
@@ -831,8 +848,15 @@ def main() -> None:
                     ) = _resolve_batching_rule(rule, num_envs)
                     results.append(
                         bench(
-                            name="AsyncBatched direct process slots",
-                            backend=backend,
+                            name=(
+                                "AsyncBatched direct process slots (chunk="
+                                f"{args.transition_chunk_size}, replay={args.replay_mode})"
+                            ),
+                            backend=(
+                                f"{backend}-chunk-{args.transition_chunk_size}"
+                                f"-replay-{args.replay_mode}"
+                            ),
+                            replay_mode=args.replay_mode,
                             batch_rule=label,
                             factory=ft.partial(
                                 AsyncBatchedCollector,
@@ -844,6 +868,7 @@ def main() -> None:
                                 frames_per_batch=args.frames_per_batch,
                                 total_frames=-1,
                                 env_backend="multiprocessing",
+                                transition_chunk_size=args.transition_chunk_size,
                                 server_config=InferenceServerConfig(
                                     service_backend="process",
                                     max_batch_size=max_batch_size,

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -71,6 +71,7 @@ class _ResetLatencyPixelEnv(PixelMockEnv):
         "async-shm-grouped",
         "async-process-slots",
         "async-process-slots-integrated",
+        "async-process-slots-chunked",
         pytest.param("async-shm-static", marks=pytest.mark.gpu),
         pytest.param("async-process-slots-static", marks=pytest.mark.gpu),
     ],
@@ -100,6 +101,12 @@ def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None
     if use_process and not hasattr(inference_server, "ProcessSlotTransport"):
         pytest.skip("Direct process slots are not available on this revision")
     integrated = mode in ("async-shm-integrated", "async-process-slots-integrated")
+    has_chunking = (
+        "transition_chunk_size"
+        in inspect.signature(AsyncBatchedCollector).parameters
+    )
+    if mode == "async-process-slots-chunked" and not has_chunking:
+        pytest.skip("Chunked worker results are not available on this revision")
     use_static = mode in ("async-shm-static", "async-process-slots-static") or (
         integrated and device != "cpu" and has_static
     )
@@ -113,9 +120,8 @@ def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None
     # collector accepts them; one transition per message before that.
     chunk_size = (
         64
-        if mode == "async-process-slots-integrated"
-        and "transition_chunk_size"
-        in inspect.signature(AsyncBatchedCollector).parameters
+        if mode == "async-process-slots-chunked"
+        or (mode == "async-process-slots-integrated" and has_chunking)
         else 1
     )
     if use_static:

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -102,8 +102,7 @@ def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None
         pytest.skip("Direct process slots are not available on this revision")
     integrated = mode in ("async-shm-integrated", "async-process-slots-integrated")
     has_chunking = (
-        "transition_chunk_size"
-        in inspect.signature(AsyncBatchedCollector).parameters
+        "transition_chunk_size" in inspect.signature(AsyncBatchedCollector).parameters
     )
     if mode == "async-process-slots-chunked" and not has_chunking:
         pytest.skip("Chunked worker results are not available on this revision")

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -208,6 +208,21 @@ while environment or policy calls are blocked. Call ``shutdown()`` for normal
 cleanup; abrupt owner death cannot guarantee environment cleanup hooks run.
 Environment factories in this mode must not start multiprocessing children.
 
+By default each worker sends every transition as its own message, and the
+driver unpickles, stacks and writes them one at a time. When many environments
+feed a replay buffer this per-transition work can leave the driver as the
+bottleneck while the environments wait for result capacity. Set
+``transition_chunk_size`` (for example ``64``) so that each worker accumulates
+that many consecutive transitions and sends them as one dense message. The
+driver then receives one message per chunk, concatenates whole chunks into each
+batch and performs a single routed replay write per batch, so its cost per
+transition is amortized over the chunk. Transitions reach the driver only once
+their chunk is complete, so pick a chunk size that keeps this delay acceptable
+for the environment step time; up to ``transition_chunk_size - 1`` transitions
+per environment remain in the worker while collection is paused or stopped.
+Chunked batches are dense :class:`~tensordict.TensorDict` instances whose
+``env_index`` is a tensor.
+
 Scaling ``Collector`` across local processes
 --------------------------------------------
 

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -49,6 +49,7 @@ from torchrl.data import (
     ListStorage,
     ReplayBuffer,
     ReplayBufferEnsemble,
+    StreamingSliceSampler,
     TensorDictReplayBuffer,
     TensorDictRoundRobinWriter,
 )
@@ -2914,19 +2915,26 @@ class TestAsyncBatchedCollector:
             collector.shutdown()
 
     @pytest.mark.parametrize(
-        ("env_backend", "env_exchange", "envs_per_worker", "process_slots"),
+        ("env_backend", "env_exchange", "envs_per_worker", "process_slots", "chunk"),
         [
-            ("threading", "queue", 1, False),
-            ("multiprocessing", "queue", 1, False),
-            ("multiprocessing", "shm", 1, False),
-            ("multiprocessing", "queue", 2, False),
-            ("multiprocessing", "shm", 2, False),
-            ("multiprocessing", "queue", 1, True),
+            ("threading", "queue", 1, False, 1),
+            ("multiprocessing", "queue", 1, False, 1),
+            ("multiprocessing", "shm", 1, False, 1),
+            ("multiprocessing", "queue", 2, False, 1),
+            ("multiprocessing", "shm", 2, False, 1),
+            ("multiprocessing", "queue", 1, True, 1),
+            ("multiprocessing", "queue", 1, True, 4),
         ],
     )
     @pytest.mark.parametrize("background", [False, True])
     def test_parent_replay_write_and_post_collect_hook(
-        self, env_backend, env_exchange, envs_per_worker, process_slots, background
+        self,
+        env_backend,
+        env_exchange,
+        envs_per_worker,
+        process_slots,
+        chunk,
+        background,
     ):
         """Post-processing, hooks and routed writes run in the parent."""
         parent_thread = threading.get_ident()
@@ -2971,6 +2979,7 @@ class TestAsyncBatchedCollector:
             replay_buffer=replay_buffer,
             env_exchange=env_exchange,
             envs_per_worker=envs_per_worker,
+            transition_chunk_size=chunk,
             env_backend=env_backend,
         )
         try:
@@ -3000,18 +3009,19 @@ class TestAsyncBatchedCollector:
             assert (stored["env_index"] == env_id).all()
 
     @pytest.mark.parametrize(
-        ("env_backend", "env_exchange", "envs_per_worker", "process_slots"),
+        ("env_backend", "env_exchange", "envs_per_worker", "process_slots", "chunk"),
         [
-            ("threading", "queue", 1, False),
-            ("multiprocessing", "queue", 1, False),
-            ("multiprocessing", "shm", 1, False),
-            ("multiprocessing", "queue", 2, False),
-            ("multiprocessing", "shm", 2, False),
-            ("multiprocessing", "queue", 1, True),
+            ("threading", "queue", 1, False, 1),
+            ("multiprocessing", "queue", 1, False, 1),
+            ("multiprocessing", "shm", 1, False, 1),
+            ("multiprocessing", "queue", 2, False, 1),
+            ("multiprocessing", "shm", 2, False, 1),
+            ("multiprocessing", "queue", 1, True, 1),
+            ("multiprocessing", "queue", 1, True, 3),
         ],
     )
     def test_replay_backpressure_does_not_block_shutdown(
-        self, env_backend, env_exchange, envs_per_worker, process_slots
+        self, env_backend, env_exchange, envs_per_worker, process_slots, chunk
     ):
         replay_buffer = TensorDictReplayBuffer(storage=LazyTensorStorage(64))
         collector = AsyncBatchedCollector(
@@ -3028,6 +3038,7 @@ class TestAsyncBatchedCollector:
             replay_buffer=replay_buffer,
             env_exchange=env_exchange,
             envs_per_worker=envs_per_worker,
+            transition_chunk_size=chunk,
             env_backend=env_backend,
         )
         iterator = iter(collector)
@@ -3720,6 +3731,146 @@ class TestAsyncBatchedCollector:
         finally:
             collector.shutdown()
         assert not any(worker.is_alive() for worker in workers)
+
+    @pytest.mark.parametrize("total_frames", [24, 26])
+    def test_process_slot_chunks_are_dense_and_ordered(self, total_frames):
+        """Chunked results form dense batches that keep each stream in order."""
+        num_envs = 3
+        collector = AsyncBatchedCollector(
+            create_env_fn=[ft.partial(_counting_env_factory, max_steps=10_000)]
+            * num_envs,
+            policy_factory=_make_counting_policy,
+            transport=_counting_process_transport(num_envs),
+            frames_per_batch=10,
+            total_frames=total_frames,
+            transition_chunk_size=4,
+            env_backend="multiprocessing",
+            server_config=InferenceServerConfig(
+                service_backend="process", max_batch_size=num_envs
+            ),
+        )
+        try:
+            batches = list(collector)
+        finally:
+            collector.shutdown()
+        # Exact budgets: chunks are split only where a batch or the total ends.
+        assert [batch.numel() for batch in batches] == [10, 10, total_frames - 20]
+        for batch in batches:
+            assert type(batch) is TensorDict
+            assert batch["env_index"].dtype == torch.long
+        stored = torch.cat(batches, 0)
+        assert stored["env_index"].unique().numel() > 1
+        for env_id in range(num_envs):
+            obs = stored[stored["env_index"] == env_id]["observation"].flatten()
+            torch.testing.assert_close(obs, torch.arange(len(obs), dtype=obs.dtype))
+
+    def test_process_slot_chunks_route_streams_and_sample_windows(self):
+        """Chunked writes reach the right stream and sample as contiguous windows."""
+        num_envs, slice_len = 3, 4
+        members = [
+            TensorDictReplayBuffer(
+                storage=LazyTensorStorage(64),
+                sampler=StreamingSliceSampler(
+                    slice_len=slice_len, end_key=("next", "done")
+                ),
+                writer=TensorDictRoundRobinWriter(track_generations=True),
+            )
+            for _ in range(num_envs)
+        ]
+        replay = ReplayBufferEnsemble(
+            *members,
+            p="sampleable",
+            num_buffer_sampled=2,
+            routing_key="env_index",
+            batch_size=2 * slice_len,
+        )
+        collector = AsyncBatchedCollector(
+            create_env_fn=[ft.partial(_counting_env_factory, max_steps=10_000)]
+            * num_envs,
+            policy_factory=_make_counting_policy,
+            transport=_counting_process_transport(num_envs),
+            frames_per_batch=12,
+            total_frames=96,
+            transition_chunk_size=slice_len,
+            replay_buffer=replay,
+            env_backend="multiprocessing",
+            server_config=InferenceServerConfig(
+                service_backend="process", max_batch_size=num_envs
+            ),
+        )
+        try:
+            collector.start()
+            collector._replay_thread.join(timeout=30)
+            assert not collector._replay_thread.is_alive()
+            assert replay.stats()["write_count"] == 96
+            for env_id, member in enumerate(members):
+                if not len(member):
+                    continue
+                stored = member[:]
+                assert (stored["env_index"] == env_id).all()
+                obs = stored["observation"].flatten()
+                torch.testing.assert_close(obs, torch.arange(len(obs), dtype=obs.dtype))
+            assert replay.can_sample()
+            for _ in range(4):
+                sample = replay.sample()
+                env_index = sample["env_index"].reshape(2, slice_len)
+                assert (env_index == env_index[:, :1]).all()
+                steps = sample["observation"].reshape(2, slice_len)
+                torch.testing.assert_close(
+                    steps - steps[:, :1],
+                    torch.arange(slice_len, dtype=steps.dtype).expand(2, -1),
+                )
+        finally:
+            collector.async_shutdown()
+
+    def test_process_slot_chunks_yield_completed_trajectories(self):
+        num_envs = 2
+        collector = AsyncBatchedCollector(
+            create_env_fn=[ft.partial(_counting_env_factory, max_steps=5)] * num_envs,
+            policy_factory=_make_counting_policy,
+            transport=_counting_process_transport(num_envs),
+            frames_per_batch=1,
+            total_frames=-1,
+            transition_chunk_size=4,
+            yield_completed_trajectories=True,
+            env_backend="multiprocessing",
+            server_config=InferenceServerConfig(
+                service_backend="process", max_batch_size=num_envs
+            ),
+        )
+        try:
+            iterator = iter(collector)
+            trajectories = [next(iterator) for _ in range(4)]
+        finally:
+            collector.shutdown()
+        for trajectory in trajectories:
+            assert trajectory.numel() == 6
+            env_index = trajectory["env_index"]
+            assert (env_index == env_index[0]).all()
+            obs = trajectory["observation"].flatten()
+            torch.testing.assert_close(obs, torch.arange(6, dtype=obs.dtype))
+            done = trajectory["next", "done"].flatten()
+            assert done[-1] and not done[:-1].any()
+
+    def test_transition_chunk_size_validation(self):
+        with pytest.raises(ValueError, match="positive integer"):
+            AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy_factory=_make_counting_policy,
+                transport=_counting_process_transport(2),
+                frames_per_batch=4,
+                transition_chunk_size=0,
+                env_backend="multiprocessing",
+                server_config=InferenceServerConfig(service_backend="process"),
+            )
+        with pytest.raises(ValueError, match="requires a ProcessSlotTransport"):
+            AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy=_make_counting_policy(),
+                frames_per_batch=4,
+                transition_chunk_size=2,
+                env_backend="threading",
+            )
 
     @pytest.mark.parametrize("failure", ["reset", "worker_death"])
     def test_process_slot_worker_failure_with_active_stream(self, failure):

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -3759,7 +3759,6 @@ class TestAsyncBatchedCollector:
             assert type(batch) is TensorDict
             assert batch["env_index"].dtype == torch.long
         stored = torch.cat(batches, 0)
-        assert stored["env_index"].unique().numel() > 1
         for env_id in range(num_envs):
             obs = stored[stored["env_index"] == env_id]["observation"].flatten()
             torch.testing.assert_close(obs, torch.arange(len(obs), dtype=obs.dtype))

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -3765,10 +3765,11 @@ class TestAsyncBatchedCollector:
 
     def test_process_slot_chunks_route_streams_and_sample_windows(self):
         """Chunked writes reach the right stream and sample as contiguous windows."""
-        num_envs, slice_len = 3, 4
+        num_envs, slice_len, total_frames = 3, 4, 96
         members = [
             TensorDictReplayBuffer(
-                storage=LazyTensorStorage(64),
+                # A single worker can supply the entire collection budget.
+                storage=LazyTensorStorage(total_frames),
                 sampler=StreamingSliceSampler(
                     slice_len=slice_len, end_key=("next", "done")
                 ),
@@ -3789,7 +3790,7 @@ class TestAsyncBatchedCollector:
             policy_factory=_make_counting_policy,
             transport=_counting_process_transport(num_envs),
             frames_per_batch=12,
-            total_frames=96,
+            total_frames=total_frames,
             transition_chunk_size=slice_len,
             replay_buffer=replay,
             env_backend="multiprocessing",
@@ -3801,7 +3802,7 @@ class TestAsyncBatchedCollector:
             collector.start()
             collector._replay_thread.join(timeout=30)
             assert not collector._replay_thread.is_alive()
-            assert replay.stats()["write_count"] == 96
+            assert replay.stats()["write_count"] == total_frames
             for env_id, member in enumerate(members):
                 if not len(member):
                     continue

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -3763,6 +3763,27 @@ class TestAsyncBatchedCollector:
             obs = stored[stored["env_index"] == env_id]["observation"].flatten()
             torch.testing.assert_close(obs, torch.arange(len(obs), dtype=obs.dtype))
 
+    @pytest.mark.parametrize("capture", [False, True])
+    def test_process_slot_chunks_preserve_non_tensor_metadata(self, capture):
+        with set_capture_non_tensor_stack(capture):
+            rows = [
+                TensorDict(
+                    observation=torch.tensor([index]),
+                    metadata=TensorDict(label=NonTensorData(label)),
+                )
+                for index, label in enumerate(("a", "b", "b", "b"))
+            ]
+            # The first chunk has varying labels; the second has one shared
+            # label and may collapse it to a NonTensorData leaf.
+            chunks = [
+                lazy_stack(rows[:2]).contiguous(),
+                lazy_stack(rows[2:]).contiguous(),
+            ]
+            batch = AsyncBatchedCollector._cat_chunks(chunks)
+        assert batch.batch_size == (4,)
+        assert [batch[i]["metadata", "label"] for i in range(4)] == ["a", "b", "b", "b"]
+        torch.testing.assert_close(batch["observation"], torch.arange(4).unsqueeze(-1))
+
     def test_process_slot_chunks_route_streams_and_sample_windows(self):
         """Chunked writes reach the right stream and sample as contiguous windows."""
         num_envs, slice_len, total_frames = 3, 4, 96

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -196,9 +196,17 @@ def _process_env_loop(
     worker_affinity: Sequence[int] | None,
     env_device: torch.device | None,
     storing_device: torch.device | None,
+    chunk_size: int = 1,
 ):
-    """Run environment stepping and remote inference in one worker process."""
+    """Run environment stepping and remote inference in one worker process.
+
+    With ``chunk_size > 1`` the worker accumulates that many consecutive
+    transitions and sends them as one dense result, so the driver handles one
+    message per chunk instead of one per transition. One capacity permit then
+    covers the whole chunk under construction.
+    """
     env = None
+    chunk: list[TensorDictBase] = []
     try:
         if worker_affinity is not None:
             os.sched_setaffinity(0, worker_affinity)
@@ -215,23 +223,38 @@ def _process_env_loop(
                 continue
             # Reserve capacity before inference/stepping. A full result queue
             # must still let the worker observe pause and shutdown requests.
-            if not result_capacity.acquire(timeout=0.01):
-                continue
-            if pause_event.is_set() or shutdown_event.is_set():
-                result_capacity.release()
-                continue
+            if not chunk:
+                if not result_capacity.acquire(timeout=0.01):
+                    continue
+                if pause_event.is_set() or shutdown_event.is_set():
+                    result_capacity.release()
+                    continue
             policy_output = client(observation)
             action_td = observation.update(policy_output)
             if env_device is not None:
                 action_td = action_td.to(env_device)
             transition, observation = env.step_and_maybe_reset(action_td)
-            transition.set(_ENV_IDX_KEY, env_id)
+            if chunk_size == 1:
+                transition.set(_ENV_IDX_KEY, env_id)
+            else:
+                # Chunks are concatenated in the driver; keep the index a tensor
+                # like the batched coordinator does.
+                transition.set(
+                    _ENV_IDX_KEY,
+                    torch.full(transition.batch_size, env_id, dtype=torch.long),
+                )
             # multiprocessing.Queue serializes on a feeder thread after put()
             # returns. Own the transition storage before the environment or
             # inference response slot can be reused.
             transition = transition.clone()
             if storing_device is not None:
                 transition = transition.to(storing_device)
+            if chunk_size > 1:
+                chunk.append(transition)
+                if len(chunk) < chunk_size:
+                    continue
+                transition = maybe_dense_stack(chunk)
+                chunk = []
             if all(
                 value.device.type == "cpu"
                 for value in transition.values(True, True)
@@ -415,8 +438,10 @@ class AsyncBatchedCollector(BaseCollector):
     * With a :class:`~torchrl.modules.inference_server.ProcessSlotTransport`,
       each multiprocessing environment worker talks directly to the dedicated
       inference process; the driver receives completed transitions only.
-      Completed and in-flight transitions are bounded to twice the environment
-      count. Workers and the inference server exit when their owner dies.
+      Completed and in-flight results are bounded to twice the environment
+      count; ``transition_chunk_size`` sets how many consecutive transitions
+      one result holds. Workers and the inference server exit when their
+      owner dies.
     * The :class:`~torchrl.modules.InferenceServer` running in a background
       thread continuously drains observation submissions, batches them, runs
       a single forward pass, and fans actions back out.
@@ -498,6 +523,21 @@ class AsyncBatchedCollector(BaseCollector):
             multiprocessing worker. Grouped workers share one coordinator that
             drains ready environments without waiting for a complete group.
             Defaults to ``1``.
+        transition_chunk_size (int, optional): number of consecutive
+            transitions each environment worker process accumulates before
+            sending them to the driver as one dense message. Requires a
+            :class:`~torchrl.modules.inference_server.ProcessSlotTransport`.
+            ``1`` (default) sends every transition as soon as it completes.
+            Larger values take the driver off the per-transition path: it
+            receives one message per chunk, concatenates whole chunks into
+            each batch and writes each batch to ``replay_buffer`` with a
+            single routed ``extend``, so its per-transition Python work is
+            amortized over the chunk. The cost is latency: a transition
+            reaches the driver only once its chunk is complete, and up to
+            ``transition_chunk_size - 1`` transitions per environment stay in
+            the worker while collection is paused or stopped. Batches are then
+            dense :class:`~tensordict.TensorDict` instances and ``env_index``
+            is a tensor. Defaults to ``1``.
         policy_backend (str, optional): backend for the inference transport
             used to communicate with the
             :class:`~torchrl.modules.InferenceServer`.  One of
@@ -601,6 +641,7 @@ class AsyncBatchedCollector(BaseCollector):
         env_backend: Literal["threading", "multiprocessing"] | None = None,
         env_exchange: Literal["queue", "shm", "auto"] = "queue",
         envs_per_worker: int = 1,
+        transition_chunk_size: int = 1,
         policy_backend: (
             Literal["threading", "multiprocessing", "ray", "monarch"] | None
         ) = None,
@@ -722,6 +763,17 @@ class AsyncBatchedCollector(BaseCollector):
                 "env_backend='multiprocessing'."
             )
         self._envs_per_worker = envs_per_worker
+        if (
+            isinstance(transition_chunk_size, bool)
+            or not isinstance(transition_chunk_size, int)
+            or transition_chunk_size < 1
+        ):
+            raise ValueError(
+                "transition_chunk_size must be a positive integer, got "
+                f"{transition_chunk_size!r}."
+            )
+        self._transition_chunk_size = transition_chunk_size
+        self._uses_chunked_results = transition_chunk_size > 1
         if worker_affinity is None:
             self._worker_affinity = None
         else:
@@ -767,6 +819,11 @@ class AsyncBatchedCollector(BaseCollector):
             )
         self._transport = transport
         self._uses_process_env_workers = isinstance(transport, ProcessSlotTransport)
+        if self._uses_chunked_results and not self._uses_process_env_workers:
+            raise ValueError(
+                "transition_chunk_size > 1 requires a ProcessSlotTransport so "
+                "that environment worker processes assemble the chunks."
+            )
         if self._uses_process_env_workers:
             if envs_per_worker != 1:
                 raise ValueError("ProcessSlotTransport requires envs_per_worker=1.")
@@ -972,6 +1029,7 @@ class AsyncBatchedCollector(BaseCollector):
                                 ),
                                 "env_device": self._env_device,
                                 "storing_device": self._storing_device,
+                                "chunk_size": self._transition_chunk_size,
                             },
                             name=f"AsyncBatchedCollector-env-{env_id}",
                             daemon=True,
@@ -1382,22 +1440,20 @@ class AsyncBatchedCollector(BaseCollector):
 
         while self._transition_carry and collected < frames_to_collect:
             transition = self._transition_carry.popleft()
-            transitions.append(transition)
-            collected += transition.numel()
+            if self._uses_chunked_results:
+                collected = self._append_chunk(
+                    transition, transitions, collected, frames_to_collect
+                )
+            else:
+                transitions.append(transition)
+                collected += transition.numel()
 
         while collected < frames_to_collect:
             # Block for at least one transition
             td = self._next_result()
-            if self._uses_batched_coordinator:
-                for transition in td.unbind(0):
-                    if collected < frames_to_collect:
-                        transitions.append(transition)
-                        collected += transition.numel()
-                    else:
-                        self._transition_carry.append(transition)
-            else:
-                transitions.append(td)
-                collected += td.numel()
+            collected = self._append_result(
+                td, transitions, collected, frames_to_collect
+            )
             # Batch-drain any additional items already in the queue
             while collected < frames_to_collect:
                 try:
@@ -1414,29 +1470,78 @@ class AsyncBatchedCollector(BaseCollector):
                 self._check_worker_result(td)
                 if self._uses_process_env_workers:
                     self._result_capacity.release()
-                if self._uses_batched_coordinator:
-                    for transition in td.unbind(0):
-                        if collected < frames_to_collect:
-                            transitions.append(transition)
-                            collected += transition.numel()
-                        else:
-                            self._transition_carry.append(transition)
-                else:
-                    transitions.append(td)
-                    collected += td.numel()
+                collected = self._append_result(
+                    td, transitions, collected, frames_to_collect
+                )
             if self.verbose:
                 torchrl_logger.debug(
                     f"AsyncBatchedCollector: {collected}/{self.frames_per_batch} frames"
                 )
 
+        if self._uses_chunked_results:
+            return self._cat_chunks(transitions)
         return lazy_stack(transitions)
+
+    def _append_result(
+        self,
+        td: TensorDictBase,
+        transitions: list[TensorDictBase],
+        collected: int,
+        budget: int,
+    ) -> int:
+        """Append one worker result, carrying frames beyond ``budget``."""
+        if self._uses_batched_coordinator:
+            for transition in td.unbind(0):
+                if collected < budget:
+                    transitions.append(transition)
+                    collected += transition.numel()
+                else:
+                    self._transition_carry.append(transition)
+            return collected
+        if self._uses_chunked_results:
+            return self._append_chunk(td, transitions, collected, budget)
+        transitions.append(td)
+        return collected + td.numel()
+
+    def _append_chunk(
+        self,
+        chunk: TensorDictBase,
+        transitions: list[TensorDictBase],
+        collected: int,
+        budget: int,
+    ) -> int:
+        """Append a chunk of consecutive transitions from one environment.
+
+        The chunk stays a dense block; it is only split along its leading
+        dimension where the frame budget ends, and the remainder is carried
+        over to the next batch in order. Like every other result, a single
+        transition is never split, so a budget that is not a multiple of one
+        transition's size is overshot by less than one transition.
+        """
+        steps = chunk.shape[0]
+        step_numel = chunk.numel() // steps
+        room = max(1, (budget - collected) // step_numel)
+        if steps > room:
+            self._transition_carry.append(chunk[room:])
+            chunk = chunk[:room]
+        transitions.append(chunk)
+        return collected + chunk.numel()
+
+    @staticmethod
+    def _cat_chunks(chunks: list[TensorDictBase]) -> TensorDictBase:
+        """Concatenate worker chunks into one dense batch."""
+        try:
+            return torch.cat(chunks, 0)
+        except (KeyError, RuntimeError):
+            # Environments with differing schemas cannot share a dense batch.
+            return lazy_stack([row for chunk in chunks for row in chunk.unbind(0)])
 
     @_maybe_record_function_decorator("AsyncBatchedCollector._rollout_yield_trajs")
     def _rollout_yield_trajs(self) -> TensorDictBase:
         """Drain transitions until a complete trajectory is available."""
         while not self._trajectory_queue:
             td = self._next_result()
-            if self._uses_batched_coordinator:
+            if self._uses_batched_coordinator or self._uses_chunked_results:
                 for transition in td.unbind(0):
                     self._record_trajectory_transition(transition)
             else:

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -1532,8 +1532,9 @@ class AsyncBatchedCollector(BaseCollector):
         """Concatenate worker chunks into one dense batch."""
         try:
             return torch.cat(chunks, 0)
-        except (KeyError, RuntimeError):
-            # Environments with differing schemas cannot share a dense batch.
+        except (KeyError, RuntimeError, TypeError):
+            # Different schemas or non-tensor metadata representations may
+            # prevent concatenating the chunks into a dense batch.
             return lazy_stack([row for chunk in chunks for row in chunk.unbind(0)])
 
     @_maybe_record_function_decorator("AsyncBatchedCollector._rollout_yield_trajs")


### PR DESCRIPTION
Stack: #4305 → #4306 → #4307 → #4308 (base).

Batch worker transitions to reduce queue, unpickling, and replay-write overhead.

```python
collector = AsyncBatchedCollector(
    ...,
    transition_chunk_size=64,  # ProcessSlotTransport only; default: 1
)
```

Chunks preserve stream order and frame budgets. Larger chunks increase latency and in-flight memory; batches become dense with tensor `env_index`.

Coverage: ordering/budgets, replay routing, trajectories, pause/shutdown. Reported CPU benchmark: ~6× less driver CPU/frame.
