### PR TITLE
[Performance] Serve process-slot inference passes from pinned staging batches

### DIFF
--- a/benchmarks/bench_inference_server.py
+++ b/benchmarks/bench_inference_server.py
@@ -1,0 +1,191 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Throughput benchmark for the process-hosted inference server.
+
+Measures requests per second served by a
+:class:`~torchrl.modules.inference_server.ProcessInferenceServer` behind a
+:class:`~torchrl.modules.inference_server.ProcessSlotTransport`, the topology
+used by :class:`~torchrl.collectors.AsyncBatchedCollector` with process
+environment workers. ``--num-clients`` workers (one process each by default)
+keep one request in flight at all times, so every server pass sees a full
+batch of ``--num-clients`` requests. The per-pass server overhead (collation,
+host-device transfers, synchronization and response scattering) dominates when
+the policy is small, which is what this script isolates.
+
+The default workload is an MLP policy with 64 clients, i.e. a batch of 64 per
+pass. Pass ``--static-batch-size 64`` to serve the policy through a CUDA graph.
+Pinned staging, non-blocking transfers and CUDA graphs require CUDA; the script
+runs on CPU as a smoke test only.
+
+To compare two revisions, run the same command from a checkout of each and
+compare ``requests_per_s``::
+
+    python benchmarks/bench_inference_server.py --device cuda:0
+    python benchmarks/bench_inference_server.py --device cuda:0 \
+        --static-batch-size 64
+
+Each run prints one JSON line with the throughput and the server's forward
+latency percentiles after a warm-up window.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing as mp
+import threading
+import time
+from dataclasses import dataclass
+
+import torch
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+from torchrl.modules import MLP
+from torchrl.modules.inference_server import (
+    ProcessInferenceServer,
+    ProcessSlotTransport,
+)
+
+
+@dataclass
+class MLPPolicyFactory:
+    """Picklable policy factory constructed inside the server process."""
+
+    observation_dim: int
+    action_dim: int
+    hidden_features: int
+    hidden_layers: int
+
+    def __call__(self) -> TensorDictModule:
+        torch.manual_seed(0)
+        return TensorDictModule(
+            MLP(
+                in_features=self.observation_dim,
+                out_features=self.action_dim,
+                num_cells=[self.hidden_features] * self.hidden_layers,
+            ),
+            in_keys=["observation"],
+            out_keys=["action"],
+        )
+
+
+def _client_loop(client, observation_dim: int, stop_event) -> None:
+    """Keep one request in flight until asked to stop."""
+    torch.set_num_threads(1)
+    request = TensorDict({"observation": torch.randn(observation_dim)})
+    while not stop_event.is_set():
+        request["observation"].add_(1.0)
+        client(request)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--num-clients", type=int, default=64)
+    parser.add_argument("--observation-dim", type=int, default=1024)
+    parser.add_argument("--action-dim", type=int, default=20)
+    parser.add_argument("--hidden-features", type=int, default=1024)
+    parser.add_argument("--hidden-layers", type=int, default=3)
+    parser.add_argument(
+        "--device", default="cuda:0" if torch.cuda.is_available() else "cpu"
+    )
+    parser.add_argument(
+        "--static-batch-size",
+        type=int,
+        default=None,
+        help="serve through a CUDA graph with this static batch size "
+        "(at least --num-clients).",
+    )
+    parser.add_argument(
+        "--client-backend",
+        choices=("process", "thread"),
+        default="process",
+        help="run clients in spawned processes (as env workers do) or threads.",
+    )
+    parser.add_argument("--warmup-s", type=float, default=3.0)
+    parser.add_argument("--duration-s", type=float, default=10.0)
+    args = parser.parse_args()
+
+    ctx = mp.get_context("spawn")
+    request_spec = TensorDict({"observation": torch.zeros(args.observation_dim)})
+    response_spec = TensorDict(
+        {
+            "action": torch.zeros(args.action_dim),
+            "policy_version": torch.zeros((), dtype=torch.long),
+        }
+    )
+    transport = ProcessSlotTransport(
+        request_spec, response_spec, num_slots=args.num_clients, ctx=ctx
+    )
+    server = ProcessInferenceServer(
+        policy_factory=MLPPolicyFactory(
+            observation_dim=args.observation_dim,
+            action_dim=args.action_dim,
+            hidden_features=args.hidden_features,
+            hidden_layers=args.hidden_layers,
+        ),
+        transport=transport,
+        request_spec=request_spec,
+        max_batch_size=args.num_clients,
+        static_batch_size=args.static_batch_size,
+        policy_device=args.device,
+        output_device="cpu",
+        stats_window_size=100_000,
+        mp_context=ctx,
+    )
+    clients = server.clients(args.num_clients)
+    stop_event = ctx.Event() if args.client_backend == "process" else threading.Event()
+    if args.client_backend == "process":
+        workers = [
+            ctx.Process(
+                target=_client_loop,
+                args=(client, args.observation_dim, stop_event),
+                daemon=True,
+            )
+            for client in clients
+        ]
+    else:
+        workers = [
+            threading.Thread(
+                target=_client_loop,
+                args=(client, args.observation_dim, stop_event),
+                daemon=True,
+            )
+            for client in clients
+        ]
+    with server:
+        for worker in workers:
+            worker.start()
+        time.sleep(args.warmup_s)
+        server.stats(reset=True)
+        started = time.perf_counter()
+        time.sleep(args.duration_s)
+        stats = server.stats()
+        elapsed = time.perf_counter() - started
+        stop_event.set()
+        for worker in workers:
+            worker.join(timeout=30.0)
+    result = {
+        "device": args.device,
+        "num_clients": args.num_clients,
+        "static_batch_size": args.static_batch_size,
+        "client_backend": args.client_backend,
+        "observation_dim": args.observation_dim,
+        "action_dim": args.action_dim,
+        "hidden_features": args.hidden_features,
+        "hidden_layers": args.hidden_layers,
+        "duration_s": round(elapsed, 3),
+        "requests": stats["requests"],
+        "requests_per_s": round(stats["requests"] / elapsed, 1),
+        "batches_per_s": round(stats["batches"] / elapsed, 1),
+        "avg_batch_size": round(stats["avg_batch_size"], 2),
+        "p50_forward_ms": round(stats["p50_forward_ms"], 3),
+        "p95_forward_ms": round(stats["p95_forward_ms"], 3),
+        "p50_queue_ms": round(stats["p50_queue_ms"], 3),
+    }
+    print(json.dumps(result, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_inference_server.py
+++ b/benchmarks/bench_inference_server.py
@@ -9,13 +9,14 @@ Measures requests per second served by a
 :class:`~torchrl.modules.inference_server.ProcessSlotTransport`, the topology
 used by :class:`~torchrl.collectors.AsyncBatchedCollector` with process
 environment workers. ``--num-clients`` workers (one process each by default)
-keep one request in flight at all times, so every server pass sees a full
-batch of ``--num-clients`` requests. The per-pass server overhead (collation,
+keep one request in flight at all times. The server batches whichever requests
+are ready, up to ``--num-clients``; the actual average batch size is reported.
+The per-pass server overhead (collation,
 host-device transfers, synchronization and response scattering) dominates when
 the policy is small, which is what this script isolates.
 
-The default workload is an MLP policy with 64 clients, i.e. a batch of 64 per
-pass. Pass ``--static-batch-size 64`` to serve the policy through a CUDA graph.
+The default workload is an MLP policy with 64 clients and a maximum batch size
+of 64. Pass ``--static-batch-size 64`` to serve the policy through a CUDA graph.
 Pinned staging, non-blocking transfers and CUDA graphs require CUDA; the script
 runs on CPU as a smoke test only.
 

--- a/docs/source/reference/modules_inference_server.rst
+++ b/docs/source/reference/modules_inference_server.rst
@@ -241,6 +241,17 @@ The driver continues to receive completed transitions from the workers. The
 transport requires fixed-shape CPU tensor request and response specs; policy
 execution and device transfers remain owned by the inference process.
 
+Because every slot has a fixed layout, the server serves this transport with
+one batched pass per sweep instead of collating and resolving requests one by
+one: the ready slots are gathered into a host staging batch (pinned when the
+policy runs on CUDA), copied to a persistent policy-device batch with
+non-blocking transfers, and the declared response keys are copied back and
+scattered into the response slots with one copy per leaf. A single CUDA event
+per pass waits for the response copy instead of a device-wide synchronize.
+The batched pass applies to stacking collate functions (the default,
+:func:`~tensordict.lazy_stack`, :func:`~tensordict.maybe_dense_stack` and
+:func:`torch.stack`); a custom ``collate_fn`` keeps the per-request path.
+
 Structured Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -72,6 +72,7 @@ from torchrl.modules.inference_server import (
 from torchrl.modules.inference_server._client import (
     _INTERACTION_TYPE_TO_CODE,
     _NO_INTERACTION_TYPE_CODE,
+    _REMOTE_INTERACTION_TYPE_KEY,
 )
 from torchrl.modules.inference_server._config import _resolve_device_config
 from torchrl.modules.inference_server._monarch import MonarchTransport
@@ -1968,6 +1969,274 @@ class TestProcessSlotTransport:
                 assert process.exitcode == 0
             assert server.stats()["requests"] == 6
         assert all(result_queue.get(timeout=1.0) is True for _ in processes)
+
+    def test_batched_slot_io(self):
+        """Slots are gathered and scattered as batches, in the drained order."""
+        request_spec = TensorDict({"agent": {"observation": torch.zeros(4)}})
+        response_spec = TensorDict(
+            {
+                "agent": {"action": torch.zeros(2)},
+                "policy_version": torch.zeros((), dtype=torch.long),
+            }
+        )
+        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=4)
+        clients = [transport.client() for _ in range(4)]
+        futures = [
+            client.submit(
+                TensorDict({"agent": {"observation": torch.full((4,), float(slot))}})
+            )
+            for slot, client in enumerate(clients)
+        ]
+        transport.wait_for_work(timeout=1.0)
+        slots, submitted_at = transport.drain_slots(3)
+        assert slots == [0, 1, 2]
+        assert all(isinstance(value, float) and value > 0 for value in submitted_at)
+
+        requests = transport.request_batch(4)
+        assert requests.batch_size == (4,)
+        assert not requests.is_locked
+        assert requests.get(_REMOTE_INTERACTION_TYPE_KEY).shape == (4,)
+        # Rows follow the given order, not the slot numbering, and the tail
+        # rows of the staging batch stay untouched.
+        transport.gather_requests([2, 0], out=requests)
+        assert torch.equal(
+            requests["agent", "observation"],
+            torch.tensor([2.0, 0.0, 0.0, 0.0]).unsqueeze(-1).expand(4, 4),
+        )
+        with pytest.raises(ValueError, match="Cannot gather 5"):
+            transport.gather_requests([0, 1, 2, 3, 0], out=requests)
+
+        responses = transport.response_batch(4)
+        responses["agent", "action"][:2] = torch.tensor([[20.0, 20.0], [0.0, 0.0]])
+        responses["policy_version"][:2] = 7
+        # A row count that does not match the slots is rejected before any
+        # slot is written or woken.
+        with pytest.raises(RuntimeError, match="batch size"):
+            transport.resolve_batch([2, 0], responses[:3])
+        assert not futures[2].done()
+        transport.resolve_batch([2, 0], responses[:2])
+        assert torch.equal(
+            futures[2].result(timeout=1.0)["agent", "action"], torch.full((2,), 20.0)
+        )
+        result_0 = futures[0].result(timeout=1.0)
+        assert torch.equal(result_0["agent", "action"], torch.zeros(2))
+        assert result_0["policy_version"] == 7
+        assert not futures[1].done()
+        # The per-request path still serves the remaining slots.
+        transport.resolve(
+            1, TensorDict({"agent": {"action": torch.ones(2)}, "policy_version": 1})
+        )
+        assert torch.equal(
+            futures[1].result(timeout=1.0)["agent", "action"], torch.ones(2)
+        )
+        items, callbacks = transport.drain(4)
+        assert callbacks == [3]
+        assert torch.equal(items[0]["agent", "observation"], torch.full((4,), 3.0))
+
+    def test_server_batched_pass_matches_inputs(self):
+        """Concurrent clients get their own results across many batched passes."""
+        request_spec = TensorDict({"agent": {"observation": torch.zeros(4)}})
+        response_spec = TensorDict(
+            {
+                "agent": {"action": torch.zeros(4)},
+                "policy_version": torch.zeros((), dtype=torch.long),
+            }
+        )
+        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=4)
+        clients = [transport.client() for _ in range(4)]
+        model = TensorDictModule(
+            _Doubler(),
+            in_keys=[("agent", "observation")],
+            out_keys=[("agent", "action")],
+        )
+        errors = []
+
+        def run(idx):
+            try:
+                for i in range(10):
+                    obs = torch.full((4,), float(idx * 100 + i))
+                    result = clients[idx](TensorDict({"agent": {"observation": obs}}))
+                    assert torch.equal(result["agent", "action"], obs * 2.0)
+                    assert result["policy_version"] == 3
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with InferenceServer(
+            model, transport, max_batch_size=4, policy_version=3
+        ) as server:
+            assert server._slot_batches is not None
+            threads = [threading.Thread(target=run, args=(i,)) for i in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30.0)
+            stats = server.stats()
+        assert not errors
+        assert stats["requests"] == 40
+
+    def test_server_batched_pass_accumulates_min_batch(self):
+        """min_batch_size accumulation also applies to the batched slot pass."""
+        request_spec, response_spec = _make_shm_specs(
+            obs_size=1, act_size=1, with_version=False
+        )
+        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=2)
+        clients = [transport.client() for _ in range(2)]
+        policy = TensorDictModule(
+            _BatchSizeModule(), in_keys=["observation"], out_keys=["action"]
+        )
+        results = {}
+
+        def run(idx):
+            results[idx] = clients[idx](TensorDict({"observation": torch.zeros(1)}))
+
+        with InferenceServer(
+            policy, transport, max_batch_size=2, min_batch_size=2, timeout=1.0
+        ):
+            threads = [threading.Thread(target=run, args=(i,)) for i in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30.0)
+        # Both requests were served by one pass of two.
+        assert torch.equal(results[0]["action"], torch.tensor([2.0]))
+        assert torch.equal(results[1]["action"], torch.tensor([2.0]))
+
+    def test_server_batched_pass_propagates_interaction_type(self):
+        """The interaction code is read from the host staging batch."""
+
+        class _InteractionPolicy(nn.Module):
+            def forward(self, td: TensorDictBase) -> TensorDictBase:
+                value = 1 if interaction_type() is InteractionType.RANDOM else 0
+                return TensorDict(
+                    {"action": torch.full(td.batch_size, value)},
+                    batch_size=td.batch_size,
+                )
+
+        request_spec = TensorDict({"observation": torch.zeros(1)})
+        response_spec = TensorDict({"action": torch.zeros((), dtype=torch.long)})
+        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=1)
+        with InferenceServer(_InteractionPolicy(), transport, max_batch_size=1):
+            client = PolicyClientModule(transport.client(), out_keys=["action"])
+            with set_interaction_type(InteractionType.RANDOM):
+                result = client(TensorDict({"observation": torch.zeros(1)}))
+            assert result["action"].item() == 1
+            result = client(TensorDict({"observation": torch.zeros(1)}))
+            assert result["action"].item() == 0
+
+    def test_server_batched_pass_requires_declared_response_keys(self):
+        """A response key the model does not produce fails the request."""
+        request_spec, response_spec = _make_shm_specs(with_version=False)
+        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=1)
+        client = transport.client()
+
+        def no_action(td):
+            return td.set("something_else", td["observation"])
+
+        with InferenceServer(no_action, transport, max_batch_size=1):
+            with pytest.raises(KeyError, match="action"):
+                client(TensorDict({"observation": torch.zeros(4)}))
+
+    def test_custom_collate_keeps_per_request_path(self):
+        """A transforming collate_fn is not bypassed by the batched pass."""
+        request_spec, response_spec = _make_shm_specs(act_size=4, with_version=False)
+        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=1)
+        client = transport.client()
+
+        def offset_collate(items):
+            batch = lazy_stack(items).contiguous()
+            batch["observation"] += 1.0
+            return batch
+
+        with InferenceServer(
+            _make_doubling_policy(),
+            transport,
+            max_batch_size=1,
+            collate_fn=offset_collate,
+        ) as server:
+            assert server._slot_batches is None
+            result = client(TensorDict({"observation": torch.ones(4)}))
+        assert torch.equal(result["action"], torch.full((4,), 4.0))
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    @pytest.mark.parametrize("static", [False, True])
+    def test_server_batched_pass_on_cuda(self, static):
+        """Pinned staging and one event per pass keep CUDA results exact.
+
+        Varying partial batches (padded for the graph), fresh random draws on
+        every replay and in-place weight updates all behave as on the
+        per-request path.
+        """
+
+        class _ScaleAndNoise(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.scale = nn.Parameter(torch.ones(()))
+
+            def forward(self, observation):
+                return observation * self.scale, torch.rand_like(observation)
+
+        policy = TensorDictModule(
+            _ScaleAndNoise(), in_keys=["observation"], out_keys=["action", "noise"]
+        )
+        request_spec = TensorDict({"observation": torch.zeros(2)})
+        response_spec = TensorDict(
+            {
+                "action": torch.zeros(2),
+                "noise": torch.zeros(2),
+                "policy_version": torch.zeros((), dtype=torch.long),
+            }
+        )
+        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=3)
+        clients = [transport.client() for _ in range(3)]
+        with InferenceServer(
+            policy,
+            transport,
+            max_batch_size=4,
+            static_batch_size=4 if static else None,
+            request_spec=request_spec if static else None,
+            policy_device="cuda:0",
+        ) as server:
+            graph = server._cudagraph_model
+            assert (graph is not None) is static
+            assert server._slot_batches.host_request["observation"].is_pinned()
+            for round_index in range(3):
+                futures = [
+                    client.submit(
+                        TensorDict(
+                            {
+                                "observation": torch.tensor(
+                                    [float(10 * round_index + slot), -1.0]
+                                )
+                            }
+                        )
+                    )
+                    for slot, client in enumerate(clients)
+                ]
+                results = [future.result(timeout=10.0) for future in futures]
+                for slot, result in enumerate(results):
+                    assert result["action"].device.type == "cpu"
+                    assert torch.equal(
+                        result["action"],
+                        torch.tensor([float(10 * round_index + slot), -1.0]),
+                    )
+                    assert result["policy_version"] == 0
+                noises = torch.stack([result["noise"] for result in results])
+                assert (noises >= 0).all() and (noises < 1).all()
+                assert noises.unique().numel() == noises.numel()
+            first_noise = results[0]["noise"]
+            second = clients[0](TensorDict({"observation": torch.ones(2)}))
+            assert not torch.equal(second["noise"], first_noise)
+
+            def scale_weight(model):
+                with torch.no_grad():
+                    model.module.scale.fill_(3.0)
+
+            server.update_model(scale_weight)
+            assert server._cudagraph_model is graph
+            result = clients[1](TensorDict({"observation": torch.tensor([1.0, 2.0])}))
+            assert torch.equal(result["action"], torch.tensor([3.0, 6.0]))
+            assert result["policy_version"] == 1
 
 
 # =============================================================================

--- a/torchrl/modules/inference_server/_process_slot.py
+++ b/torchrl/modules/inference_server/_process_slot.py
@@ -219,6 +219,14 @@ class ProcessSlotTransport(InferenceTransport):
         transports, clients do not need registration with the already-running
         server because every slot and signal is allocated at construction.
 
+    .. note::
+        :class:`~torchrl.modules.inference_server.InferenceServer` serves this
+        transport with one batched pass per sweep: ready slots are gathered
+        straight into a host staging batch (pinned when the policy runs on
+        CUDA), copied to the policy device without blocking, and the responses
+        are copied back and scattered into the response slots with one copy
+        per leaf. One CUDA event per pass replaces device-wide synchronization.
+
     Example:
         >>> import torch
         >>> from tensordict import TensorDict
@@ -248,6 +256,7 @@ class ProcessSlotTransport(InferenceTransport):
     """
 
     _clients_require_registration = False
+    _batched_slot_io = True
 
     def __init__(
         self,
@@ -358,32 +367,117 @@ class ProcessSlotTransport(InferenceTransport):
         self, max_items: int
     ) -> tuple[list[TensorDictBase], list[int], list[float | None]]:
         """Sweep ready slots and return request submission timestamps."""
-        items = []
-        callbacks = []
-        submitted_at = []
+        slots, submitted_at = self.drain_slots(max_items)
+        items = [self._request_slots[slot].copy() for slot in slots]
+        return items, slots, submitted_at
+
+    def drain_slots(self, max_items: int) -> tuple[list[int], list[float]]:
+        """Claim ready slots in round-robin order without copying their payloads.
+
+        The requests stay in the slot bank until :meth:`gather_requests`
+        collates them.
+
+        Args:
+            max_items (int): maximum number of slots to claim.
+
+        Returns:
+            The claimed slot indices and their submission timestamps.
+        """
         # The semaphore is a doorbell, not the payload's memory barrier: a
         # timed drain can run without acquiring a signal. Synchronize with each
         # publisher before looking at flags, including on weakly ordered CPUs.
         with self._request_lock:
-            callbacks = _take_ready_slots(
-                self._request_ready, self._next_slot, max_items
-            )
-            if callbacks:
-                self._next_slot = (callbacks[-1] + 1) % self._num_slots
-        for slot in callbacks:
-            items.append(self._request_slots[slot].copy())
+            slots = _take_ready_slots(self._request_ready, self._next_slot, max_items)
+            if slots:
+                self._next_slot = (slots[-1] + 1) % self._num_slots
+        submitted_at = []
+        for slot in slots:
             submitted_at.append(self._submitted_at[slot])
             self._submitted_at[slot] = 0.0
 
         # Consume doorbells for drained requests, including a signal already
         # consumed by wait_for_work(). Extra wakeups are harmless.
-        signals_to_consume = len(items)
+        signals_to_consume = len(slots)
         acquired = min(signals_to_consume, self._acquired_signals)
         self._acquired_signals -= acquired
         signals_to_consume -= acquired
         for _ in range(signals_to_consume):
             self._work_semaphore.acquire(block=False)
-        return items, callbacks, submitted_at
+        return slots, submitted_at
+
+    def request_batch(self, capacity: int) -> TensorDictBase:
+        """Allocate a private, contiguous CPU batch of ``capacity`` requests.
+
+        The batch has the request slot layout (including the interaction-type
+        key) and is the staging area that :meth:`gather_requests` fills.
+
+        Args:
+            capacity (int): number of rows.
+        """
+        return (
+            self._request_slots[0]
+            .unsqueeze(0)
+            .expand(capacity, *self._request_slots.batch_size[1:])
+            .clone()
+        )
+
+    def response_batch(self, capacity: int) -> TensorDictBase:
+        """Allocate a private, contiguous CPU batch of ``capacity`` responses.
+
+        The batch has the response slot layout and is the staging area that
+        :meth:`resolve_batch` scatters into the slots.
+
+        Args:
+            capacity (int): number of rows.
+        """
+        return (
+            self._response_slots[0]
+            .unsqueeze(0)
+            .expand(capacity, *self._response_slots.batch_size[1:])
+            .clone()
+        )
+
+    def gather_requests(self, slots: list[int], out: TensorDictBase) -> None:
+        """Collate request slots into ``out[:len(slots)]`` with one gather per leaf.
+
+        Args:
+            slots (list of int): slots to collate, typically the ones returned
+                by :meth:`drain_slots`; row ``i`` of ``out`` receives
+                ``slots[i]``.
+            out (TensorDictBase): batch allocated with :meth:`request_batch`
+                (possibly pinned) holding at least ``len(slots)`` rows.
+        """
+        num_slots = len(slots)
+        if num_slots > out.batch_size[0]:
+            raise ValueError(
+                f"Cannot gather {num_slots} request slots into a batch of "
+                f"{out.batch_size[0]} rows."
+            )
+        index = torch.tensor(slots, dtype=torch.long)
+        for key, bank in self._request_slots.items(
+            include_nested=True, leaves_only=True
+        ):
+            torch.index_select(bank, 0, index, out=out.get(key)[:num_slots])
+
+    def resolve_batch(self, slots: list[int], results: TensorDictBase) -> None:
+        """Write a batch of responses into their slots and wake the owning workers.
+
+        Args:
+            slots (list of int): slots served by the pass; row ``i`` of
+                ``results`` is written to ``slots[i]``.
+            results (TensorDictBase): batch of ``len(slots)`` responses whose
+                leaves match the response layout (shapes and dtypes). Undeclared
+                keys are dropped and a missing declared key raises a
+                :class:`KeyError`.
+        """
+        if not slots:
+            return
+        self._response_slots[torch.tensor(slots, dtype=torch.long)] = results.select(
+            *self._response_keys, strict=True
+        )
+        for slot in slots:
+            self._response_status[slot] = 0
+            self._response_events[slot].set()
 
     def resolve(self, callback: int, result: TensorDictBase) -> None:
         """Copy a response into its slot and wake the owning worker."""

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -21,7 +21,7 @@ from statistics import mean
 from typing import Any, Literal
 
 import torch
-from tensordict import lazy_stack, TensorDict
+from tensordict import lazy_stack, maybe_dense_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn import CudaGraphModule
 from tensordict.nn.probabilistic import (
@@ -29,7 +29,7 @@ from tensordict.nn.probabilistic import (
     InteractionType,
     set_interaction_type,
 )
-from tensordict.utils import NestedKey
+from tensordict.utils import NestedKey, unravel_key
 from torch import nn
 
 from torchrl._comm import CommandChannel, Mailbox, watch_process_liveness
@@ -280,6 +280,60 @@ def _default_collate(items: list[TensorDictBase]) -> TensorDictBase:
     )
 
 
+# Collate functions that stack requests without transforming them. Transports
+# with fixed slot banks gather such batches straight from their slots; any
+# other collate_fn keeps the per-request path.
+_STACKING_COLLATE_FNS = (_default_collate, lazy_stack, maybe_dense_stack, torch.stack)
+
+
+class _SlotBatches:
+    """Reusable staging batches for a transport with fixed slot banks.
+
+    ``host_request`` and ``host_response`` mirror the transport's slot layouts
+    on the host and are pinned when the policy runs on CUDA, so the per-pass
+    copies to and from ``device_request`` (the persistent policy-device batch,
+    sized for the CUDA graph when one is configured) do not block the host.
+    One event per pass then waits for the device-to-host copy of the
+    responses instead of a device-wide synchronize.
+    """
+
+    def __init__(
+        self,
+        transport: InferenceTransport,
+        *,
+        capacity: int,
+        device_capacity: int,
+        policy_device: torch.device | None,
+        policy_version_key: NestedKey | None,
+    ):
+        self.host_request = transport.request_batch(capacity)
+        self.host_response = transport.response_batch(capacity)
+        self.device_request: TensorDictBase | None = None
+        self.event: torch.cuda.Event | None = None
+        self.non_blocking = False
+        if policy_device is not None and policy_device.type != "cpu":
+            self.device_request = (
+                transport.request_batch(device_capacity)
+                .exclude(_REMOTE_INTERACTION_TYPE_KEY)
+                .to(policy_device)
+            )
+            if policy_device.type == "cuda":
+                self.host_request = self.host_request.pin_memory()
+                self.host_response = self.host_response.pin_memory()
+                self.event = torch.cuda.Event()
+                self.non_blocking = True
+        # The server stamps the policy version on the host; every other
+        # response key comes from the model output.
+        self.model_response_keys = list(
+            self.host_response.keys(include_nested=True, leaves_only=True)
+        )
+        self.version: torch.Tensor | None = None
+        if policy_version_key is not None:
+            self.version = self.host_response.get(policy_version_key, default=None)
+            if self.version is not None:
+                self.model_response_keys.remove(unravel_key(policy_version_key))
+
+
 class InferenceServer(metaclass=_InferenceServerMeta):
     """Auto-batching inference server.
 
@@ -519,6 +573,7 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         self._cudagraph_tensor_references = None
         self._cudagraph_input_keys: frozenset[NestedKey] | None = None
         self._cudagraph_input_keys_validated = False
+        self._slot_batches: _SlotBatches | None = None
 
         _validate_static_batch_size(self.static_batch_size, self.max_batch_size)
         _validate_cudagraph_device(self.static_batch_size, self.policy_device)
@@ -685,6 +740,18 @@ class InferenceServer(metaclass=_InferenceServerMeta):
                     "can be captured before the serve loop starts."
                 )
             self.prepare_cudagraph(self._cudagraph_request_spec)
+        if (
+            self._slot_batches is None
+            and self.transport._batched_slot_io
+            and self.collate_fn in _STACKING_COLLATE_FNS
+        ):
+            self._slot_batches = _SlotBatches(
+                self.transport,
+                capacity=self.max_batch_size,
+                device_capacity=self.static_batch_size or self.max_batch_size,
+                policy_device=self.policy_device,
+                policy_version_key=self.policy_version_key,
+            )
         self._shutdown_event.clear()
         self._worker = threading.Thread(
             target=self._run, daemon=True, name="InferenceServer-worker"
@@ -977,118 +1044,229 @@ class InferenceServer(metaclass=_InferenceServerMeta):
     @torch.no_grad()
     def _run(self) -> None:
         self._init_weight_sync()
+        transport = self.transport
+        slot_batches = self._slot_batches
+        if slot_batches is not None:
+            # Requests stay in the slot bank; _serve_slot_batch gathers them.
+            def drain(max_items):
+                slots, submitted_at = transport.drain_slots(max_items)
+                return None, slots, submitted_at
+
+        else:
+            drain_with_timing = getattr(transport, "drain_with_timing", None)
+            if drain_with_timing is not None:
+                drain = drain_with_timing
+            else:
+
+                def drain(max_items):
+                    items, callbacks = transport.drain(max_items)
+                    return items, callbacks, [None] * len(items)
 
         try:
             while not self._shutdown_event.is_set():
                 self._poll_weight_update()
 
-                self.transport.wait_for_work(timeout=self.timeout)
+                transport.wait_for_work(timeout=self.timeout)
 
-                drain_with_timing = getattr(self.transport, "drain_with_timing", None)
-                if drain_with_timing is None:
-                    items, callbacks = self.transport.drain(self.max_batch_size)
-                    submitted_at = [None] * len(items)
-                else:
-                    items, callbacks, submitted_at = drain_with_timing(
-                        self.max_batch_size
-                    )
-                if not items:
+                items, callbacks, submitted_at = drain(self.max_batch_size)
+                if not callbacks:
                     continue
 
                 # Accumulate up to min_batch_size (or until timeout expires)
-                if len(items) < self.min_batch_size:
+                if len(callbacks) < self.min_batch_size:
                     deadline = time.monotonic() + self.timeout
-                    while len(items) < self.min_batch_size:
+                    while len(callbacks) < self.min_batch_size:
                         remaining = deadline - time.monotonic()
                         if remaining <= 0:
                             break
-                        self.transport.wait_for_work(timeout=remaining)
-                        if drain_with_timing is None:
-                            more_items, more_cbs = self.transport.drain(
-                                self.max_batch_size - len(items)
-                            )
-                            more_submitted_at = [None] * len(more_items)
-                        else:
-                            more_items, more_cbs, more_submitted_at = drain_with_timing(
-                                self.max_batch_size - len(items)
-                            )
-                        items.extend(more_items)
+                        transport.wait_for_work(timeout=remaining)
+                        more_items, more_cbs, more_submitted_at = drain(
+                            self.max_batch_size - len(callbacks)
+                        )
+                        if items is not None:
+                            items.extend(more_items)
                         callbacks.extend(more_cbs)
                         submitted_at.extend(more_submitted_at)
 
                 try:
-                    now = time.monotonic()
-                    queue_wait_ms = [
-                        (now - item_submitted_at) * 1000.0
-                        for item_submitted_at in submitted_at
-                        if item_submitted_at is not None
-                    ]
-                    real_batch_size = len(callbacks)
-                    padded_for_cudagraph = self._cudagraph_model is not None
-                    batch = self._collate_model_batch(
-                        items, pad_to_static=padded_for_cudagraph
-                    )
-                    if self.policy_device is not None:
-                        batch = batch.to(self.policy_device)
-                    forward_start = time.monotonic()
-                    with self._model_lock:
-                        (
-                            interaction_context,
-                            batch,
-                            interaction_code,
-                        ) = self._interaction_type_context(batch)
-                        use_cudagraph = self._cudagraph_model is not None
-                        if (
-                            use_cudagraph
-                            and interaction_code != self._cudagraph_interaction_code
-                        ):
-                            raise RuntimeError(
-                                "CUDA-graphed inference requires the interaction "
-                                "type used during capture."
-                            )
-                        if use_cudagraph and not self._cudagraph_input_keys_validated:
-                            request_keys = frozenset(
-                                batch.keys(include_nested=True, leaves_only=True)
-                            )
-                            missing_keys = self._cudagraph_input_keys - request_keys
-                            if missing_keys:
-                                raise RuntimeError(
-                                    "The first CUDA-graph request does not match "
-                                    "request_spec; missing policy input keys "
-                                    f"{list(missing_keys)!r}."
-                                )
-                            self._cudagraph_input_keys_validated = True
-                        with interaction_context:
-                            if not use_cudagraph:
-                                result_batch = self.model(batch)
-                            else:
-                                result_batch = self._cudagraph_model(batch)
-                        if padded_for_cudagraph:
-                            result_batch = result_batch[:real_batch_size]
-                        if self.output_device is not None:
-                            result_batch = result_batch.to(self.output_device)
-                        if use_cudagraph:
-                            result_batch = result_batch.clone()
-                        result_batch = self._set_policy_version(result_batch)
-                    forward_ms = (time.monotonic() - forward_start) * 1000.0
-                    self._record_batch_stats(
-                        batch_size=len(callbacks),
-                        queue_wait_ms=queue_wait_ms,
-                        forward_ms=forward_ms,
-                    )
-                    results = result_batch.unbind(0)
-                    if len(results) != len(callbacks):
-                        raise RuntimeError(
-                            f"Model returned {len(results)} results for a "
-                            f"batch of {len(callbacks)} inputs."
-                        )
-                    for cb, res in zip(callbacks, results):
-                        self.transport.resolve(cb, res)
+                    if slot_batches is not None:
+                        self._serve_slot_batch(slot_batches, callbacks, submitted_at)
+                    else:
+                        self._serve_batch(items, callbacks, submitted_at)
                 except Exception as exc:
                     for cb in callbacks:
-                        self.transport.resolve_exception(cb, exc)
+                        transport.resolve_exception(cb, exc)
         finally:
             self._drain_pending_on_shutdown()
+
+    def _check_cudagraph_batch(
+        self, batch: TensorDictBase, interaction_code: int
+    ) -> bool:
+        """Validate a batch against the captured graph; return whether to replay it.
+
+        Must run under the model lock so a concurrent weight update cannot
+        drop the graph between the check and the forward pass.
+        """
+        if self._cudagraph_model is None:
+            return False
+        if interaction_code != self._cudagraph_interaction_code:
+            raise RuntimeError(
+                "CUDA-graphed inference requires the interaction "
+                "type used during capture."
+            )
+        if not self._cudagraph_input_keys_validated:
+            request_keys = frozenset(batch.keys(include_nested=True, leaves_only=True))
+            missing_keys = self._cudagraph_input_keys - request_keys
+            if missing_keys:
+                raise RuntimeError(
+                    "The first CUDA-graph request does not match "
+                    "request_spec; missing policy input keys "
+                    f"{list(missing_keys)!r}."
+                )
+            self._cudagraph_input_keys_validated = True
+        return True
+
+    def _serve_batch(
+        self,
+        items: list[TensorDictBase],
+        callbacks: list,
+        submitted_at: list[float | None],
+    ) -> None:
+        """Collate, run and resolve one batch of individually drained requests."""
+        now = time.monotonic()
+        queue_wait_ms = [
+            (now - item_submitted_at) * 1000.0
+            for item_submitted_at in submitted_at
+            if item_submitted_at is not None
+        ]
+        real_batch_size = len(callbacks)
+        padded_for_cudagraph = self._cudagraph_model is not None
+        batch = self._collate_model_batch(items, pad_to_static=padded_for_cudagraph)
+        if self.policy_device is not None:
+            batch = batch.to(self.policy_device)
+        forward_start = time.monotonic()
+        with self._model_lock:
+            (
+                interaction_context,
+                batch,
+                interaction_code,
+            ) = self._interaction_type_context(batch)
+            use_cudagraph = self._check_cudagraph_batch(batch, interaction_code)
+            with interaction_context:
+                if not use_cudagraph:
+                    result_batch = self.model(batch)
+                else:
+                    result_batch = self._cudagraph_model(batch)
+            if padded_for_cudagraph:
+                result_batch = result_batch[:real_batch_size]
+            if self.output_device is not None:
+                result_batch = result_batch.to(self.output_device)
+            if use_cudagraph:
+                result_batch = result_batch.clone()
+            result_batch = self._set_policy_version(result_batch)
+        forward_ms = (time.monotonic() - forward_start) * 1000.0
+        self._record_batch_stats(
+            batch_size=len(callbacks),
+            queue_wait_ms=queue_wait_ms,
+            forward_ms=forward_ms,
+        )
+        results = result_batch.unbind(0)
+        if len(results) != len(callbacks):
+            raise RuntimeError(
+                f"Model returned {len(results)} results for a "
+                f"batch of {len(callbacks)} inputs."
+            )
+        for cb, res in zip(callbacks, results):
+            self.transport.resolve(cb, res)
+
+    def _serve_slot_batch(
+        self,
+        batches: _SlotBatches,
+        slots: list[int],
+        submitted_at: list[float | None],
+    ) -> None:
+        """Serve one pass straight from and into the transport's slot banks.
+
+        The ready slots are gathered into the host staging batch, copied to
+        the persistent device batch (padded to the CUDA-graph size by
+        repeating the last request), run through the model, and the response
+        keys are copied back into the host response batch. A single event
+        wait per pass makes the responses visible before they are scattered
+        into the slots with one copy per leaf.
+        """
+        now = time.monotonic()
+        queue_wait_ms = [
+            (now - item_submitted_at) * 1000.0
+            for item_submitted_at in submitted_at
+            if item_submitted_at is not None
+        ]
+        real_batch_size = len(slots)
+        self.transport.gather_requests(slots, out=batches.host_request)
+        host_batch = batches.host_request[:real_batch_size]
+        forward_start = time.monotonic()
+        with self._model_lock:
+            # The interaction code is read from the host copy: no device sync.
+            (
+                interaction_context,
+                host_batch,
+                interaction_code,
+            ) = self._interaction_type_context(host_batch)
+            use_cudagraph = self._check_cudagraph_batch(host_batch, interaction_code)
+            device_batch = batches.device_request
+            if device_batch is None:
+                batch = host_batch
+            else:
+                device_batch[:real_batch_size].update_(
+                    host_batch, non_blocking=batches.non_blocking
+                )
+                if use_cudagraph:
+                    padding = device_batch.batch_size[0] - real_batch_size
+                    if padding:
+                        device_batch[real_batch_size:].update_(
+                            device_batch[real_batch_size - 1 : real_batch_size].expand(
+                                padding, *device_batch.batch_size[1:]
+                            )
+                        )
+                    # A shallow copy receives the module's output keys so the
+                    # persistent batch keeps the request layout.
+                    batch = device_batch.copy()
+                else:
+                    batch = device_batch[:real_batch_size]
+            with interaction_context:
+                if not use_cudagraph:
+                    result_batch = self.model(batch)
+                else:
+                    result_batch = self._cudagraph_model(batch)
+            if use_cudagraph:
+                result_batch = result_batch[:real_batch_size]
+            if (
+                result_batch.batch_dims == 0
+                or result_batch.batch_size[0] != real_batch_size
+            ):
+                raise RuntimeError(
+                    f"Model returned {result_batch.batch_size} results for a "
+                    f"batch of {real_batch_size} inputs."
+                )
+            # Only the declared response keys travel back to the host. The
+            # CUDA-graph output is read before the next replay overwrites it,
+            # so no clone is needed.
+            host_response = batches.host_response[:real_batch_size]
+            host_response.update_(
+                result_batch.select(*batches.model_response_keys, strict=True),
+                non_blocking=batches.non_blocking,
+            )
+            if batches.version is not None:
+                batches.version[:real_batch_size].fill_(self.policy_version)
+            if batches.event is not None:
+                batches.event.record(torch.cuda.current_stream(self.policy_device))
+                batches.event.synchronize()
+        forward_ms = (time.monotonic() - forward_start) * 1000.0
+        self._record_batch_stats(
+            batch_size=real_batch_size,
+            queue_wait_ms=queue_wait_ms,
+            forward_ms=forward_ms,
+        )
+        self.transport.resolve_batch(slots, host_response)
 
     def _drain_pending_on_shutdown(self) -> None:
         """Resolve all pending requests with an error during shutdown."""

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -851,9 +851,12 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         batch = self.collate_fn(items).contiguous().to(self.policy_device)
         padding = self.static_batch_size - len(items)
         if padding:
-            batch = torch.cat(
-                [batch, batch[-1:].expand(padding, *batch.batch_size[1:])], dim=0
-            )
+            # Index the final request repeatedly: concatenating an expanded
+            # tail can mix NonTensorStack and NonTensorData metadata leaves.
+            index = torch.arange(
+                self.static_batch_size, device=self.policy_device
+            ).clamp_max_(len(items) - 1)
+            batch = batch[index]
         return batch
 
     def _validate_cudagraph_storage(self) -> None:

--- a/torchrl/modules/inference_server/_transport.py
+++ b/torchrl/modules/inference_server/_transport.py
@@ -23,6 +23,11 @@ class InferenceTransport(abc.ABC):
 
     # Fixed-slot transports allocate every client channel before server startup.
     _clients_require_registration: bool = True
+    # Transports with fixed request/response slot banks that the server gathers
+    # from and scatters into directly (drain_slots, request_batch,
+    # response_batch, gather_requests, resolve_batch), bypassing per-request
+    # collation and resolution.
+    _batched_slot_io: bool = False
 
     @abc.abstractmethod
     def submit(self, td: TensorDictBase) -> Future[TensorDictBase]:


### PR DESCRIPTION
Stack: #4305 → #4306 → #4307 → #4308; depends on #4305.

Batch process-slot inference through reusable pinned buffers, non-blocking transfers, and one CUDA event per pass. Gather/scatter replaces per-request copies; only response keys return to CPU.

```python
server = InferenceServer(
    policy,
    transport=transport,  # ProcessSlotTransport; batched I/O is automatic
    policy_device="cuda",
)
```

Custom collate functions retain their existing path.

Validation: CPU inference suite and metadata regression tests pass. CUDA validation and throughput measurements pending.
