### PR TITLE
[Performance] Keep the DreamerV3 replay write-back off the learner stream

### DIFF
--- a/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
@@ -12,6 +12,7 @@ native replay construction, prefetch, and conditional writeback as training.
 Example::
 
     python benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+    python benchmarks/ad_hoc/bench_dreamer_v3_learner.py --device cpu --variants eager --replay-device cpu
 """
 
 from __future__ import annotations
@@ -149,7 +150,8 @@ def _measure(step, synchronize, *, warmup: int, iterations: int):
     for _ in range(warmup):
         step()
     synchronize()
-    torch.cuda.reset_peak_memory_stats()
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
     host_latencies = []
     started = time.perf_counter()
     for _ in range(iterations):
@@ -160,13 +162,11 @@ def _measure(step, synchronize, *, warmup: int, iterations: int):
     return (time.perf_counter() - started) * 1000 / iterations, host_latencies
 
 
-def _profile_update(step, synchronize) -> dict:
-    with torch.profiler.profile(
-        activities=[
-            torch.profiler.ProfilerActivity.CPU,
-            torch.profiler.ProfilerActivity.CUDA,
-        ]
-    ) as profile:
+def _profile_update(step, synchronize, device: torch.device) -> dict:
+    activities = [torch.profiler.ProfilerActivity.CPU]
+    if device.type == "cuda":
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+    with torch.profiler.profile(activities=activities) as profile:
         step()
         synchronize()
 
@@ -201,6 +201,13 @@ def main() -> None:
     parser.add_argument("--warmup", type=int, default=10)
     parser.add_argument("--iterations", type=int, default=50)
     parser.add_argument(
+        "--device",
+        choices=("cpu", "cuda"),
+        default="cuda",
+        help="Learner device. CPU runs support the eager and compiled variants "
+        "without CUDA graphs.",
+    )
+    parser.add_argument(
         "--replay-device",
         choices=("cpu", "cuda"),
         help="Include native replay sampling and writeback on this device.",
@@ -215,19 +222,25 @@ def main() -> None:
             "compiled_train_step",
             "compiled_train_step_cuda_graph",
         ),
-        default=(
-            "cuda_graph",
-            "compiled_train_step_cuda_graph",
-        ),
+        default=None,
     )
     args = parser.parse_args()
-    if not torch.cuda.is_available():
-        raise RuntimeError("This benchmark requires CUDA.")
+    if args.variants is None:
+        args.variants = (
+            ("cuda_graph", "compiled_train_step_cuda_graph")
+            if args.device == "cuda"
+            else ("eager",)
+        )
+    if args.device == "cuda" or args.replay_device == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA devices were requested but CUDA is unavailable.")
+    elif any("cuda_graph" in variant for variant in args.variants):
+        raise RuntimeError("CUDA graph variants require --device cuda.")
 
     repo_root = Path(__file__).parents[2]
     example = _load_example(repo_root)
     template_cfg = _load_config(repo_root)
-    device = torch.device("cuda:0")
+    device = torch.device("cuda:0" if args.device == "cuda" else "cpu")
     torch.set_float32_matmul_precision("high")
 
     real_env = example["make_env"](template_cfg, template_cfg.env.seed)
@@ -285,7 +298,11 @@ def main() -> None:
         replay_step = None
         if args.replay_device is None:
             step = ft.partial(learner_update.step, None, data.clone())
-            synchronize = ft.partial(torch.cuda.synchronize, device)
+            synchronize = (
+                ft.partial(torch.cuda.synchronize, device)
+                if device.type == "cuda"
+                else lambda: None
+            )
             workload = "complete_learner_update"
         else:
             replay_step = _ReplayLearnerStep(
@@ -307,15 +324,21 @@ def main() -> None:
                 warmup=args.warmup,
                 iterations=args.iterations,
             )
-            peak_memory = torch.cuda.max_memory_allocated(device) / 2**20
-            profile_metrics = _profile_update(step, synchronize)
+            peak_memory = (
+                torch.cuda.max_memory_allocated(device) / 2**20
+                if device.type == "cuda"
+                else None
+            )
+            profile_metrics = _profile_update(step, synchronize, device)
         finally:
             if replay_step is not None:
                 replay_step.close()
         result = {
             "variant": variant,
             "workload": workload,
-            "device": torch.cuda.get_device_name(device),
+            "device": (
+                torch.cuda.get_device_name(device) if device.type == "cuda" else "cpu"
+            ),
             "replay_device": args.replay_device,
             "torch_version": torch.__version__,
             "cuda_version": torch.version.cuda,
@@ -328,6 +351,7 @@ def main() -> None:
             "warmup_updates": args.warmup,
             "measured_updates": args.iterations,
             "mean_update_ms": mean_ms,
+            "updates_per_second": 1000 / mean_ms,
             "transitions_per_second": args.batch * args.steps * 1000 / mean_ms,
             "p50_host_update_ms": statistics.median(host_latencies),
             "p95_host_update_ms": statistics.quantiles(
@@ -341,7 +365,8 @@ def main() -> None:
         # variant before measuring the next one's live and peak allocations.
         del step, synchronize, learner_update, learner, replay_step
         gc.collect()
-        torch.cuda.empty_cache()
+        if device.type == "cuda":
+            torch.cuda.empty_cache()
 
 
 if __name__ == "__main__":

--- a/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
@@ -234,7 +234,9 @@ def main() -> None:
     if args.device == "cuda" or args.replay_device == "cuda":
         if not torch.cuda.is_available():
             raise RuntimeError("CUDA devices were requested but CUDA is unavailable.")
-    elif any("cuda_graph" in variant for variant in args.variants):
+    if args.device != "cuda" and any(
+        "cuda_graph" in variant for variant in args.variants
+    ):
         raise RuntimeError("CUDA graph variants require --device cuda.")
 
     repo_root = Path(__file__).parents[2]

--- a/sota-implementations/dreamer_v3/dreamer_v3_replay.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_replay.py
@@ -40,12 +40,58 @@ def collector_action_budget(
     return (vector_records - reset_records) * num_envs
 
 
+def _last_rows_per_coordinate(coordinates: torch.Tensor) -> torch.Tensor:
+    """Return the last row holding each distinct coordinate, in coordinate order.
+
+    Packs the non-negative integer columns into one key so a single stable sort
+    orders the rows lexicographically with ties in their original order; the
+    last row of every run of equal keys then wins. When the packed key would
+    overflow ``int64``, the columns are sorted one at a time instead.
+    """
+    coordinates = coordinates.long()
+    n_rows, n_columns = coordinates.shape
+    radices = coordinates.amax(0) + 1
+    if bool(radices.double().log2().sum() < 62):
+        strides = torch.ones_like(radices)
+        strides[:-1] = radices[1:].flip(0).cumprod(0).flip(0)
+        key = (coordinates * strides).sum(-1)
+        order = key.argsort(stable=True)
+        ordered = key[order].unsqueeze(-1)
+    else:
+        order = torch.arange(n_rows, device=coordinates.device)
+        for column in range(n_columns - 1, -1, -1):
+            order = order[coordinates[order, column].argsort(stable=True)]
+        ordered = coordinates[order]
+    last = torch.ones(n_rows, dtype=torch.bool, device=coordinates.device)
+    last[:-1] = (ordered[:-1] != ordered[1:]).any(-1)
+    return order[last]
+
+
+def _index_on(index: torch.Tensor, device: torch.device) -> torch.Tensor:
+    """Move a host index to ``device`` without synchronizing the current stream.
+
+    A pageable host-to-device copy waits for every kernel already enqueued,
+    which after a learner step is the whole step; staging through pinned memory
+    keeps the copy asynchronous.
+    """
+    if index.device == device:
+        return index
+    if device.type == "cuda" and index.device.type == "cpu":
+        return index.pin_memory().to(device, non_blocking=True)
+    return index.to(device)
+
+
 def replay_context_update(
     sample: TensorDictBase,
     state: torch.Tensor,
     belief: torch.Tensor,
 ) -> tuple[TensorDictBase, torch.Tensor, Mapping[NestedKey, torch.Tensor]]:
-    """Build a deduplicated update for the context rows after a sampled step."""
+    """Build a deduplicated update for the context rows after a sampled step.
+
+    Nothing here synchronizes with the device holding ``state`` and
+    ``belief``; the returned patch stays on that device and may still be in
+    flight, so pass it to an asynchronous replay update.
+    """
     if sample.ndim != 2:
         raise RuntimeError(
             "Expected a replay sample with shape [batch, time], got "
@@ -69,23 +115,14 @@ def replay_context_update(
 
     # Sampled slices may overlap. Keep the last value for each destination so
     # indexed writes have deterministic semantics on every device.
-    order = torch.arange(coordinates.shape[0], device=coordinates.device)
-    for dimension in range(coordinates.shape[1] - 1, -1, -1):
-        order = order[coordinates[order, dimension].argsort(stable=True)]
-    ordered_coordinates = coordinates[order]
-    keep_ordered = torch.ones(
-        ordered_coordinates.shape[0], dtype=torch.bool, device=coordinates.device
-    )
-    keep_ordered[:-1] = (ordered_coordinates[:-1] != ordered_coordinates[1:]).any(-1)
-    keep = order[keep_ordered]
-
-    state = state.detach().float().reshape(-1, state.shape[-1])
-    belief = belief.detach().float().reshape(-1, belief.shape[-1])
+    keep = _last_rows_per_coordinate(coordinates)
+    state = state.detach().reshape(-1, state.shape[-1])
+    belief = belief.detach().reshape(-1, belief.shape[-1])
     return (
         handles[keep],
         generations[keep],
         {
-            "state": state[keep.to(state.device)],
-            "belief": belief[keep.to(belief.device)],
+            "state": state[_index_on(keep, state.device)].float(),
+            "belief": belief[_index_on(keep, belief.device)].float(),
         },
     )

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2537,6 +2537,115 @@ def test_dreamer_v3_async_replay_sequences_cross_episode_ends(monkeypatch, onlin
         rb.shutdown()
 
 
+def _reference_replay_context_update(sample, state, belief):
+    """Per-column stable sorts, the implementation the packed key replaced."""
+    handles = sample.get("index")[:, 1:].reshape(-1)
+    generations = sample.get("index_generation")[:, 1:].reshape(-1)
+    buffer_ids = handles.get("buffer_ids")
+    local_indices = handles.get("index")
+    coordinates = torch.cat(
+        (buffer_ids.reshape(-1, 1), local_indices.reshape(buffer_ids.numel(), -1)),
+        -1,
+    )
+    order = torch.arange(coordinates.shape[0])
+    for dimension in range(coordinates.shape[1] - 1, -1, -1):
+        order = order[coordinates[order, dimension].argsort(stable=True)]
+    ordered_coordinates = coordinates[order]
+    keep_ordered = torch.ones(ordered_coordinates.shape[0], dtype=torch.bool)
+    keep_ordered[:-1] = (ordered_coordinates[:-1] != ordered_coordinates[1:]).any(-1)
+    keep = order[keep_ordered]
+    state = state.detach().float().reshape(-1, state.shape[-1])
+    belief = belief.detach().float().reshape(-1, belief.shape[-1])
+    return (
+        handles[keep],
+        generations[keep],
+        {"state": state[keep], "belief": belief[keep]},
+    )
+
+
+def _overlapping_replay_sample(batch, time, *, local_ndim, scale=1):
+    """Slice windows that overlap within members, as sampled sequences do."""
+    generator = torch.Generator().manual_seed(0)
+    capacity = 12
+    starts = torch.randint(0, capacity - time + 1, (batch,), generator=generator)
+    local = starts.unsqueeze(1) + torch.arange(time)
+    if local_ndim == 2:
+        lane = torch.randint(0, 3, (batch, 1), generator=generator).expand(batch, time)
+        local = torch.stack((lane, local), -1)
+    buffer_ids = torch.randint(0, 4, (batch, 1), generator=generator).expand(
+        batch, time
+    )
+    # Two identical windows make whole rows collide, not only their tails.
+    buffer_ids = buffer_ids.clone()
+    buffer_ids[1] = buffer_ids[0]
+    local = local.clone()
+    local[1] = local[0]
+    return TensorDict(
+        {
+            "index": TensorDict(
+                {"buffer_ids": buffer_ids * scale, "index": local * scale},
+                [batch, time],
+            ),
+            "index_generation": torch.randint(0, 3, (batch, time), generator=generator),
+        },
+        [batch, time],
+    )
+
+
+@pytest.mark.parametrize("local_ndim", [1, 2])
+@pytest.mark.parametrize(
+    "scale", [1, 2**33], ids=["packed_key", "per_column_fallback"]
+)
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param(
+            "cuda",
+            marks=[
+                pytest.mark.gpu,
+                pytest.mark.skipif(
+                    not torch.cuda.is_available(), reason="requires CUDA"
+                ),
+            ],
+        ),
+    ],
+)
+def test_dreamer_v3_replay_context_update_matches_reference(
+    monkeypatch, local_ndim, scale, device
+):
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    replay = runpy.run_path(
+        example_dir / "dreamer_v3_replay.py", run_name="dreamer_v3_replay_test"
+    )
+    batch, time = 16, 5
+    sample = _overlapping_replay_sample(batch, time, local_ndim=local_ndim, scale=scale)
+    state = torch.randn(batch, time - 1, 6)
+    belief = torch.randn(batch, time - 1, 7)
+
+    index, generation, patch = replay["replay_context_update"](
+        sample, state.to(device), belief.to(device)
+    )
+    ref_index, ref_generation, ref_patch = _reference_replay_context_update(
+        sample, state, belief
+    )
+
+    coordinates = torch.cat(
+        (index["buffer_ids"].reshape(-1, 1), index["index"].reshape(len(index), -1)),
+        -1,
+    )
+    assert coordinates.shape[0] < batch * (time - 1)
+    assert torch.unique(coordinates, dim=0).shape[0] == coordinates.shape[0]
+    assert torch.equal(index["buffer_ids"], ref_index["buffer_ids"])
+    assert torch.equal(index["index"], ref_index["index"])
+    assert torch.equal(generation, ref_generation)
+    for key in ("state", "belief"):
+        assert patch[key].device.type == device
+        assert torch.equal(patch[key].cpu(), ref_patch[key])
+
+
 @pytest.mark.skipif(not _has_omegaconf, reason="requires omegaconf")
 def test_dreamer_v3_replay_capacity_validation(monkeypatch):
     from omegaconf import OmegaConf

--- a/test/rb/test_ensemble.py
+++ b/test/rb/test_ensemble.py
@@ -156,6 +156,63 @@ class TestEnsemble:
         assert restored_members[1][:]["value"].tolist() == [110, 111]
         assert restored.stats()["write_count"] == 6
 
+    @pytest.mark.parametrize(
+        "device",
+        [
+            "cpu",
+            pytest.param(
+                "cuda",
+                marks=[
+                    pytest.mark.gpu,
+                    pytest.mark.skipif(
+                        not torch.cuda.is_available(), reason="requires CUDA"
+                    ),
+                ],
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("submit", [False, True])
+    def test_conditional_update_groups_records_by_member(self, device, submit):
+        members = [self._make_routed_member(3) for _ in range(4)]
+        rb = ReplayBufferEnsemble(*members, routing_key="env_id")
+        env_id = torch.tensor([2, 0, 3, 1, 1, 3, 0, 2, 0, 1, 2, 3])
+        metadata = rb.extend(
+            TensorDict({"value": torch.zeros(12), "env_id": env_id}, [12])
+        )
+        # Reusing one slot of member 3 makes a handle stale.
+        rb.extend(
+            TensorDict({"value": torch.full((1,), -1.0), "env_id": env_id[2:3]}, [1])
+        )
+        # Records arrive in a shuffled member order; member 0 gets none.
+        rows = torch.tensor([5, 0, 3, 11, 7, 4, 9, 2])
+        handles = metadata.select("buffer_ids", "index")[rows]
+        generation = metadata["index_generation"][rows]
+        patch = {"value": (rows + 100).float().to(device)}
+        try:
+            if submit:
+                result = rb.submit_update_if_present(
+                    index=handles, generation=generation, patch=patch
+                ).result(timeout=5)
+            else:
+                result = rb.update_if_present(
+                    index=handles, generation=generation, patch=patch
+                )
+        finally:
+            rb.shutdown()
+
+        stale = handles["buffer_ids"] == 3
+        stale &= handles["index"] == metadata["index"][2]
+        assert stale.sum() == 1
+        assert result.updated.tolist() == (~stale).tolist()
+        expected = torch.zeros(12)
+        expected[rows] = (rows + 100).float()
+        expected[2] = -1.0
+        for member_id, member in enumerate(members):
+            positions = (env_id == member_id).nonzero().reshape(-1)
+            local = metadata["index"][positions]
+            stored = member[:]["value"][local]
+            assert stored.tolist() == expected[positions].tolist(), member_id
+
     @pytest.mark.parametrize("empty_member", [False, True])
     def test_checkpoint_drains_updates_and_restores_prefetch(
         self, monkeypatch, tmp_path, empty_member

--- a/test/rb/test_ensemble.py
+++ b/test/rb/test_ensemble.py
@@ -172,7 +172,10 @@ class TestEnsemble:
         ],
     )
     @pytest.mark.parametrize("submit", [False, True])
-    def test_conditional_update_groups_records_by_member(self, device, submit):
+    @pytest.mark.parametrize("tensordict_patch", [False, True])
+    def test_conditional_update_groups_records_by_member(
+        self, device, submit, tensordict_patch
+    ):
         members = [self._make_routed_member(3) for _ in range(4)]
         rb = ReplayBufferEnsemble(*members, routing_key="env_id")
         env_id = torch.tensor([2, 0, 3, 1, 1, 3, 0, 2, 0, 1, 2, 3])
@@ -188,6 +191,10 @@ class TestEnsemble:
         handles = metadata.select("buffer_ids", "index")[rows]
         generation = metadata["index_generation"][rows]
         patch = {"value": (rows + 100).float().to(device)}
+        if tensordict_patch:
+            handles = handles.to(device)
+            generation = generation.to(device)
+            patch = TensorDict(patch, batch_size=rows.shape)
         try:
             if submit:
                 result = rb.submit_update_if_present(
@@ -200,6 +207,7 @@ class TestEnsemble:
         finally:
             rb.shutdown()
 
+        handles = handles.cpu()
         stale = handles["buffer_ids"] == 3
         stale &= handles["index"] == metadata["index"][2]
         assert stale.sum() == 1

--- a/test/rb/test_rb_core.py
+++ b/test/rb/test_rb_core.py
@@ -1430,6 +1430,105 @@ def test_replay_buffer_shutdown_propagates_update_errors_and_is_idempotent():
         replay_buffer.sample(1)
 
 
+class _RecordingUpdateReplayBuffer(TensorDictReplayBuffer):
+    def __init__(self, **kwargs):
+        self.seen = []
+        super().__init__(**kwargs)
+
+    def update_if_present(self, **kwargs):
+        self.seen.append(kwargs)
+        return super().update_if_present(**kwargs)
+
+
+def test_submit_update_if_present_passes_cpu_inputs_through():
+    replay_buffer = _RecordingUpdateReplayBuffer(
+        storage=LazyTensorStorage(4),
+        writer=TensorDictRoundRobinWriter(track_generations=True),
+    )
+    index = replay_buffer.extend(TensorDict({"obs": torch.zeros(4)}, batch_size=[4]))
+    generation = replay_buffer.writer.generations_of(index)
+    patch = {"obs": torch.arange(4.0)}
+    try:
+        result = replay_buffer.submit_update_if_present(
+            index=index, generation=generation, patch=patch
+        ).result(timeout=5)
+        assert result.updated_count == 4
+        (seen,) = replay_buffer.seen
+        assert seen["index"] is index
+        assert seen["generation"] is generation
+        assert seen["patch"]["obs"] is patch["obs"]
+        assert torch.equal(replay_buffer[:]["obs"], patch["obs"])
+    finally:
+        replay_buffer.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.parametrize("patch_type", ["dict", "tensordict"])
+def test_submit_update_if_present_stages_cuda_inputs_for_cpu_storage(patch_type):
+    replay_buffer = _RecordingUpdateReplayBuffer(
+        storage=LazyTensorStorage(4),
+        writer=TensorDictRoundRobinWriter(track_generations=True),
+    )
+    index = replay_buffer.extend(
+        TensorDict({"obs": torch.zeros(4), "aux": torch.zeros(4, 2)}, batch_size=[4])
+    )
+    generation = replay_buffer.writer.generations_of(index)
+    obs = torch.arange(4.0, device="cuda")
+    aux = torch.arange(8.0, device="cuda").reshape(4, 2)
+    if patch_type == "dict":
+        patch = {"obs": obs, "aux": aux}
+    else:
+        patch = TensorDict({"obs": obs, "aux": aux}, batch_size=[4])
+    try:
+        # Work enqueued after submission must not be able to change what the
+        # update writes: the staged copies were ordered before it.
+        future = replay_buffer.submit_update_if_present(
+            index=index.cuda(), generation=generation.cuda(), patch=patch
+        )
+        obs.add_(100)
+        aux.add_(100)
+        assert future.result(timeout=5).updated_count == 4
+        (seen,) = replay_buffer.seen
+        staged = [seen["index"], seen["generation"]]
+        staged.extend(
+            seen["patch"].values()
+            if patch_type == "dict"
+            else seen["patch"].values(True, True)
+        )
+        for value in staged:
+            assert value.device.type == "cpu"
+            assert value.is_pinned()
+        assert torch.equal(replay_buffer[:]["obs"], torch.arange(4.0))
+        assert torch.equal(replay_buffer[:]["aux"], torch.arange(8.0).reshape(4, 2))
+    finally:
+        replay_buffer.shutdown()
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_submit_update_if_present_keeps_cuda_inputs_for_cuda_storage():
+    replay_buffer = _RecordingUpdateReplayBuffer(
+        storage=LazyTensorStorage(4, device="cuda"),
+        writer=TensorDictRoundRobinWriter(track_generations=True),
+    )
+    index = replay_buffer.extend(
+        TensorDict({"obs": torch.zeros(4, device="cuda")}, batch_size=[4])
+    )
+    generation = replay_buffer.writer.generations_of(index)
+    patch = {"obs": torch.arange(4.0, device="cuda")}
+    try:
+        result = replay_buffer.submit_update_if_present(
+            index=index, generation=generation, patch=patch
+        ).result(timeout=5)
+        assert result.updated_count == 4
+        (seen,) = replay_buffer.seen
+        assert seen["patch"]["obs"] is patch["obs"]
+        assert torch.equal(replay_buffer[:]["obs"], patch["obs"])
+    finally:
+        replay_buffer.shutdown()
+
+
 def _release_prefetch_when_futures_lock_is_held(
     replay_buffer, collate, operation_started, errors
 ):

--- a/torchrl/data/replay_buffers/replay_buffers/base.py
+++ b/torchrl/data/replay_buffers/replay_buffers/base.py
@@ -114,6 +114,14 @@ def _run_after_futures(futures: tuple[Future, ...], operation: Callable[[], T]) 
     return operation()
 
 
+def _run_after_events(
+    events: tuple[torch.cuda.Event, ...], operation: Callable[[], T]
+) -> T:
+    for event in events:
+        event.synchronize()
+    return operation()
+
+
 class ConditionalUpdateResult(TensorClass["nocast"]):
     """Result of :meth:`ReplayBuffer.update_if_present`.
 
@@ -1102,6 +1110,70 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             )
         return self._sampler.can_sample(self._storage, batch_size)
 
+    def _conditional_update_device(self) -> torch.device | None:
+        """Returns the device conditional patches are written to, when known."""
+        device = getattr(self._storage, "device", None)
+        return device if isinstance(device, torch.device) else None
+
+    def _stage_conditional_update(
+        self,
+        index: torch.Tensor | TensorDictBase,
+        generation: torch.Tensor,
+        patch: Mapping[NestedKey, torch.Tensor] | TensorDictBase,
+        version: int | torch.Tensor | None,
+    ) -> tuple[
+        torch.Tensor | TensorDictBase,
+        torch.Tensor,
+        Mapping[NestedKey, torch.Tensor] | TensorDictBase,
+        int | torch.Tensor | None,
+        tuple[torch.cuda.Event, ...],
+    ]:
+        """Copies CUDA inputs of a submitted update to a CPU storage without blocking.
+
+        :meth:`update_if_present` moves values to the storage device with a
+        blocking copy. Issued from the update thread, that copy waits for every
+        kernel enqueued on the stream since submission, typically the next
+        learner step, and every sample waiting on the update inherits the
+        delay. Enqueuing the copies on the caller's stream at submission time
+        orders them right after the work that produced the values; the update
+        thread then only waits for the returned events.
+        """
+        target = self._conditional_update_device()
+        if target is None or target.type != "cpu":
+            return index, generation, patch, version, ()
+        streams: dict[torch.device, torch.cuda.Stream] = {}
+
+        def stage(value):
+            if isinstance(value, TensorDictBase):
+                devices = {
+                    leaf.device
+                    for leaf in value.values(include_nested=True, leaves_only=True)
+                    if leaf.device.type == "cuda"
+                }
+            elif isinstance(value, torch.Tensor) and value.device.type == "cuda":
+                devices = {value.device}
+            else:
+                return value
+            if not devices:
+                return value
+            for device in devices:
+                streams.setdefault(device, torch.cuda.current_stream(device))
+            return value.to(target, non_blocking=True)
+
+        index = stage(index)
+        generation = stage(generation)
+        if isinstance(patch, TensorDictBase):
+            patch = stage(patch)
+        else:
+            patch = {key: stage(value) for key, value in patch.items()}
+        version = stage(version)
+        events = []
+        for stream in streams.values():
+            event = torch.cuda.Event()
+            event.record(stream)
+            events.append(event)
+        return index, generation, patch, version, tuple(events)
+
     @_maybe_delay_init
     def submit_update_if_present(
         self,
@@ -1124,6 +1196,11 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
         Callers must not mutate ``index``, ``generation``, ``patch`` or
         ``version`` in that interval. In particular, values backed by static
         CUDA-graph output buffers must be cloned before submission.
+
+        CUDA inputs destined for a CPU storage are copied to pinned host memory
+        on their current stream when this method is called, and the background
+        update waits for those copies. Work enqueued on the stream afterwards
+        therefore does not delay the update or the samples that depend on it.
 
         Keyword arguments have the same meaning as in
         :meth:`update_if_present`.
@@ -1162,6 +1239,9 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             raise NotImplementedError(
                 "submit_update_if_present is only supported by direct replay buffers."
             )
+        index, generation, patch, version, events = self._stage_conditional_update(
+            index, generation, patch, version
+        )
         operation = ft.partial(
             self.update_if_present,
             index=index,
@@ -1171,6 +1251,8 @@ class ReplayBuffer(metaclass=_RayServiceMetaClass):
             version=version,
             require_newer=require_newer,
         )
+        if events:
+            operation = ft.partial(_run_after_events, events, operation)
         with self._futures_lock:
             if self._service_shutdown:
                 raise RuntimeError("A shut down replay buffer cannot accept updates.")

--- a/torchrl/data/replay_buffers/replay_buffers/ensemble.py
+++ b/torchrl/data/replay_buffers/replay_buffers/ensemble.py
@@ -549,7 +549,7 @@ class ReplayBufferEnsemble(ReplayBuffer):
                 rows = order[start : start + count]
                 start += count
                 member_patch = (
-                    flat_patch[rows]
+                    flat_patch[rows.to(flat_patch.device or "cpu")]
                     if isinstance(flat_patch, TensorDictBase)
                     else {
                         key: value[rows.to(value.device)]

--- a/torchrl/data/replay_buffers/replay_buffers/ensemble.py
+++ b/torchrl/data/replay_buffers/replay_buffers/ensemble.py
@@ -441,6 +441,10 @@ class ReplayBufferEnsemble(ReplayBuffer):
             raise ValueError("add() expects a scalar TensorDict record.")
         return self.extend(data.unsqueeze(0))[0]
 
+    def _conditional_update_device(self) -> torch.device | None:
+        devices = {member._conditional_update_device() for member in self._rbs}
+        return devices.pop() if len(devices) == 1 else None
+
     def update_if_present(
         self,
         *,
@@ -451,7 +455,12 @@ class ReplayBufferEnsemble(ReplayBuffer):
         version: int | torch.Tensor | None = None,
         require_newer: bool = False,
     ) -> ConditionalUpdateResult:
-        """Routes a conditional update to the member named by each handle."""
+        """Routes a conditional update to the member named by each handle.
+
+        The patch moves to the members' common storage device once, before the
+        records are grouped by member, so the per-member updates never copy
+        across devices.
+        """
         if not isinstance(index, TensorDictBase):
             raise TypeError(
                 "ReplayBufferEnsemble conditional updates require routed index metadata."
@@ -500,12 +509,15 @@ class ReplayBufferEnsemble(ReplayBuffer):
                 "number of records."
             )
 
+        target_device = self._conditional_update_device()
         if isinstance(patch, TensorDictBase):
             if patch.batch_size != leading_shape:
                 raise ValueError(
                     "The patch batch size must match the routed index metadata."
                 )
             flat_patch = patch.reshape(-1)
+            if target_device is not None:
+                flat_patch = flat_patch.to(target_device)
         else:
             flat_patch = {}
             for key, value in patch.items():
@@ -514,9 +526,10 @@ class ReplayBufferEnsemble(ReplayBuffer):
                         f"Patch entry {key!r} must start with shape "
                         f"{tuple(leading_shape)}, got {tuple(value.shape)}."
                     )
-                flat_patch[key] = value.reshape(
-                    num_records, *value.shape[len(leading_shape) :]
-                )
+                value = value.reshape(num_records, *value.shape[len(leading_shape) :])
+                if target_device is not None:
+                    value = value.to(target_device)
+                flat_patch[key] = value
 
         updated = torch.zeros(
             num_records, dtype=torch.bool, device=flat_buffer_ids.device
@@ -524,16 +537,22 @@ class ReplayBufferEnsemble(ReplayBuffer):
         version_rejected = (
             torch.zeros_like(updated) if version_key is not None else None
         )
+        # One stable sort groups the records by member and keeps their
+        # submission order within each group.
+        order = flat_buffer_ids.argsort(stable=True)
+        counts = torch.bincount(flat_buffer_ids, minlength=len(self._rbs)).tolist()
         with self._replay_lock, self._write_lock:
-            for member_id, member_buffer in enumerate(self._rbs):
-                member_mask = flat_buffer_ids == member_id
-                if not member_mask.any():
+            start = 0
+            for member_buffer, count in zip(self._rbs, counts):
+                if not count:
                     continue
+                rows = order[start : start + count]
+                start += count
                 member_patch = (
-                    flat_patch[member_mask]
+                    flat_patch[rows]
                     if isinstance(flat_patch, TensorDictBase)
                     else {
-                        key: value[member_mask.to(value.device)]
+                        key: value[rows.to(value.device)]
                         for key, value in flat_patch.items()
                     }
                 )
@@ -541,18 +560,18 @@ class ReplayBufferEnsemble(ReplayBuffer):
                 if isinstance(version, torch.Tensor) and version.numel() > 1:
                     member_version = version.reshape(
                         num_records, *version.shape[len(leading_shape) :]
-                    )[member_mask.to(version.device)]
+                    )[rows.to(version.device)]
                 result = member_buffer.update_if_present(
-                    index=flat_local_index[member_mask.to(flat_local_index.device)],
-                    generation=flat_generation[member_mask.to(flat_generation.device)],
+                    index=flat_local_index[rows.to(flat_local_index.device)],
+                    generation=flat_generation[rows.to(flat_generation.device)],
                     patch=member_patch,
                     version_key=version_key,
                     version=member_version,
                     require_newer=require_newer,
                 )
-                updated[member_mask] = result.updated.to(updated.device)
+                updated[rows] = result.updated.to(updated.device)
                 if version_rejected is not None:
-                    version_rejected[member_mask] = result.version_rejected.to(
+                    version_rejected[rows] = result.version_rejected.to(
                         version_rejected.device
                     )
         return ConditionalUpdateResult(


### PR DESCRIPTION
Stack: #4305 → #4306 → #4307 → #4308; depends on #4306.

Enqueue CUDA→CPU replay copies at submission; the update thread waits on CUDA events, avoiding copies queued behind the next learner step. Also deduplicate coordinates and group ensemble writes with stable sorts.

```python
index, generation, patch = replay_context_update(sample, state, belief)
future = replay_buffer.submit_update_if_present(
    index=index, generation=generation, patch=patch
)
```

Validation: 28 focused CPU replay/Dreamer tests pass. CUDA validation pending.
