### PR TITLE
[Performance] DreamerV3: freeze the setup heap before the training loop

### DIFF
--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -1202,6 +1202,8 @@ def main(cfg: DictConfig):
             },
         )
     finally:
+        # Let setup cycles be collected between Hydra multirun jobs.
+        gc.unfreeze()
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)
         try:

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import copy
 import functools as ft
+import gc
 import math
 import signal
 from collections.abc import Callable
@@ -1036,6 +1037,12 @@ def main(cfg: DictConfig):
             path = rotation.save(checkpoint, step=action_step, components=components)
             torchrl_logger.info("Saved DreamerV3 checkpoint to %s", path)
 
+    # Setup leaves a large heap (compiled learner, collector, replay) that
+    # every full collection re-traverses, while the collection loop below
+    # allocates enough (one unpickled transition per environment step) to
+    # schedule collections continuously. Freeze the setup objects so later
+    # collections only visit what the loop allocates.
+    gc.freeze()
     collection_timer = None
     try:
         for _ in collector:

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import copy
 import functools as ft
+import gc
 import importlib.util
 import json
 import os
@@ -20,6 +21,7 @@ import signal
 import subprocess
 import sys
 import time
+import weakref
 from pathlib import Path
 
 import pytest
@@ -2813,8 +2815,21 @@ def test_dreamer_v3_native_replay_collection_smoke(
     elif budget == "reset_records":
         cfg.collector.count_reset_records = True
         cfg.collector.total_frames = 18  # 16 actions under the configured horizon.
+    replay_refs = []
+    build_replay = example["_build_replay"]
+
+    def record_replay(*args, **kwargs):
+        replay = build_replay(*args, **kwargs)
+        replay_refs.append(weakref.ref(replay))
+        return replay
+
+    monkeypatch.setitem(
+        example["main"].__wrapped__.__globals__, "_build_replay", record_replay
+    )
     example["main"].__wrapped__(cfg)
     if custom:
+        gc.collect()
+        assert all(ref() is None for ref in replay_refs)
         records = [
             json.loads(line)
             for line in Path(cfg.logger.metrics_jsonl).read_text().splitlines()


### PR DESCRIPTION
Stack: #4305 → #4306 → #4307 → #4308; depends on #4307.

Freeze the DreamerV3 setup heap so cyclic GC stops rescanning it during training.

```python
# After learner, collector, and replay setup:
gc.freeze()
try:
    for _ in collector:
        ...
finally:
    gc.unfreeze()
```

Reported validation: CPU SOTA smoke and lint pass; local reproduction reduces GC time ~8×. Profiled GPU configuration still needs validation.
