### PR TITLE
[BugFix] Async DreamerV3: explicit exploration, stored episode flags, cross-episode replay sequences

### DIFF
--- a/docs/source/reference/modules_inference_server.rst
+++ b/docs/source/reference/modules_inference_server.rst
@@ -135,9 +135,17 @@ In-place parameter copies preserve the captured graph; for example, use
 storage-replacing update raises an error and disables the graph, leaving the
 server on the safe eager path until it is stopped and prepared again. This
 avoids capturing while collector or environment threads are live. The
-interaction type is frozen to its effective value at capture time, including an ambient
-``set_interaction_type`` context; later requests using another type are
-rejected.
+interaction type is fixed at capture time: pass it to
+:meth:`~torchrl.modules.inference_server.InferenceServer.prepare_cudagraph`
+(:class:`~torchrl.collectors.AsyncBatchedCollector` passes its
+``exploration_type``), otherwise the graph is captured under the policy's
+default interaction type. The ambient ``set_interaction_type`` context is never
+consulted, neither at capture nor when serving: it is process-wide state that
+another thread, typically the learner's loss forward, may change at any time.
+Requests must carry the captured mode, which
+:class:`~torchrl.modules.inference_server.PolicyClientModule` stamps from its
+``interaction_type`` argument or, when none is given, from the caller's active
+context; requests stamped with another mode are rejected.
 
 CUDA operations using PyTorch's default generator advance its graph-safe state
 across replays. Custom generators must manage CUDA graph state explicitly, and

--- a/docs/source/reference/modules_inference_server.rst
+++ b/docs/source/reference/modules_inference_server.rst
@@ -138,10 +138,11 @@ avoids capturing while collector or environment threads are live. The
 interaction type is fixed at capture time: pass it to
 :meth:`~torchrl.modules.inference_server.InferenceServer.prepare_cudagraph`
 (:class:`~torchrl.collectors.AsyncBatchedCollector` passes its
-``exploration_type``), otherwise the graph is captured under the policy's
-default interaction type. The ambient ``set_interaction_type`` context is never
-consulted, neither at capture nor when serving: it is process-wide state that
-another thread, typically the learner's loss forward, may change at any time.
+``exploration_type``). Without an explicit mode, capture uses the mode stamped on
+the request specification, otherwise the ambient ``set_interaction_type``
+context, or the policy default when no context is active. Raw, unstamped requests
+also retain their ambient-context behavior. Pass an explicit mode when other
+threads may change this process-wide context.
 Requests must carry the captured mode, which
 :class:`~torchrl.modules.inference_server.PolicyClientModule` stamps from its
 ``interaction_type`` argument or, when none is given, from the caller's active

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -620,6 +620,10 @@ def _build_replay(
             sampler=sampler_type(
                 slice_len=sequence_records,
                 end_key=("next", "done"),
+                # The RSSM rollout resets its state wherever is_init is set,
+                # so samples must carry the collector's episode starts only,
+                # not the sampler's slice-start markers.
+                init_key=None,
             ),
             writer=TensorDictRoundRobinWriter(track_generations=True),
         )

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -614,12 +614,18 @@ def _build_replay(
         )
 
     sampler_type = StreamingSliceSampler if cfg.replay_buffer.online else SliceSampler
+    # Async collection stores one environment per stream: with the stream as
+    # the trajectory, sequences may span an episode end (the rollout resets on
+    # the stored is_init flags), so terminal transitions and episodes shorter
+    # than a sequence reach the learner.
+    traj_key = "env_index" if cfg.collector.backend == "async" else None
     members = [
         TensorDictReplayBuffer(
             storage=LazyTensorStorage(capacity, device=replay_device),
             sampler=sampler_type(
                 slice_len=sequence_records,
                 end_key=("next", "done"),
+                traj_key=traj_key,
                 # The RSSM rollout resets its state wherever is_init is set,
                 # so samples must carry the collector's episode starts only,
                 # not the sampler's slice-start markers.

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -552,6 +552,11 @@ def _build_collection(
         "postproc": replay_postproc,
         "post_collect_hook": post_collect_hook,
         "replay_buffer": replay_buffer,
+        "exploration_type": (
+            ExplorationType.RANDOM
+            if cfg.collector.exploration == "random"
+            else ExplorationType.MODE
+        ),
     }
     if collector_backend == "async":
         collector = AsyncBatchedCollector(
@@ -582,11 +587,6 @@ def _build_collection(
             policy_device=device,
             env_device="cpu",
             storing_device="cpu",
-            exploration_type=(
-                ExplorationType.RANDOM
-                if cfg.collector.exploration == "random"
-                else ExplorationType.MODE
-            ),
             **collector_kwargs,
         )
     if cfg.optimization.separate_policy_rng:

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2941,7 +2941,14 @@ def test_dreamer_v3_checkpoint_resume_processes(
                 assert not replay[stream][tails[stream]]["next", "terminated"].any()
             for _ in range(20):
                 sample = replay.sample().reshape(2, 4)
-                assert not sample["is_init"][:, 1:].any()
+                is_init = sample["is_init"].reshape(2, 4)
+                if collector_backend == "async":
+                    # Async streams cross episode ends: a reset follows every closed
+                    # record (the tail closed by the restart included), nothing else.
+                    done = sample["next", "done"].reshape(2, 4)
+                    assert torch.equal(is_init[:, 1:], done[:, :-1])
+                else:
+                    assert not is_init[:, 1:].any()
         finally:
             replay.shutdown()
 

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2410,6 +2410,66 @@ def test_dreamer_v3_native_stream_replay(monkeypatch, online, count_reset_record
         rb.shutdown()
 
 
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
+@pytest.mark.parametrize("online", [False, True])
+def test_dreamer_v3_replay_samples_keep_episode_starts(monkeypatch, online):
+    """Sampled is_init flags are the collector's episode starts, not slice starts.
+
+    The RSSM rollout zeroes state, belief and action wherever is_init is set;
+    a marker at every slice start would train each sequence from a zero state.
+    """
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py", run_name=f"dreamer_v3_episode_starts_{online}"
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.collector.num_envs = 1
+    cfg.replay_buffer.buffer_size = 64
+    cfg.replay_buffer.batch_size = 4
+    cfg.replay_buffer.seq_len = 7
+    cfg.replay_buffer.online = online
+    rb = example["_build_replay"](cfg, 1, torch.device("cpu"), torch.device("cpu"))
+    steps = 48
+    data = TensorDict(
+        {
+            "action": torch.zeros(1, steps, 2),
+            "is_init": torch.zeros(1, steps, 1, dtype=torch.bool),
+            "step": torch.arange(steps).reshape(1, steps),
+            "state": torch.zeros(1, steps, 3),
+            "belief": torch.zeros(1, steps, 3),
+            "next": {
+                "observation": torch.randn(1, steps, 3),
+                "reward": torch.zeros(1, steps, 1),
+                "done": torch.zeros(1, steps, 1, dtype=torch.bool),
+                "terminated": torch.zeros(1, steps, 1, dtype=torch.bool),
+                "truncated": torch.zeros(1, steps, 1, dtype=torch.bool),
+            },
+        },
+        [1, steps],
+    )
+    data["is_init"][:, 0] = True
+    try:
+        rb.extend(data)
+        seen_mid_slice_start = False
+        for _ in range(16):
+            sample = rb.sample().reshape(4, 8)
+            starts = sample["step"][:, 0]
+            expected = (starts == 0).reshape(4, 1, 1)
+            assert (sample["is_init"][:, :1] == expected).all()
+            assert not sample["is_init"][:, 1:].any()
+            seen_mid_slice_start |= bool((starts != 0).any())
+        assert seen_mid_slice_start
+    finally:
+        rb.shutdown()
+
+
 @pytest.mark.skipif(not _has_omegaconf, reason="requires omegaconf")
 def test_dreamer_v3_replay_capacity_validation(monkeypatch):
     from omegaconf import OmegaConf

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2470,6 +2470,73 @@ def test_dreamer_v3_replay_samples_keep_episode_starts(monkeypatch, online):
         rb.shutdown()
 
 
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
+@pytest.mark.parametrize("online", [False, True])
+def test_dreamer_v3_async_replay_sequences_cross_episode_ends(monkeypatch, online):
+    """Async streams sample sequences across episode ends.
+
+    Slices that stop at every done flag never hand the learner a terminal
+    transition (the extra record is dropped), nor any episode shorter than
+    a sequence. With the stream as the trajectory, both reach the learner
+    and the rollout resets on the stored is_init flags.
+    """
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py", run_name=f"dreamer_v3_cross_episode_{online}"
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.collector.backend = "async"
+    cfg.collector.num_envs = 1
+    cfg.replay_buffer.buffer_size = 64
+    cfg.replay_buffer.batch_size = 4
+    cfg.replay_buffer.seq_len = 7
+    cfg.replay_buffer.online = online
+    rb = example["_build_replay"](cfg, 1, torch.device("cpu"), torch.device("cpu"))
+    steps = 48
+    episode_len = 12
+    step = torch.arange(steps)
+    terminal = (step % episode_len) == episode_len - 1
+    data = TensorDict(
+        {
+            "action": torch.zeros(steps, 2),
+            "env_index": torch.zeros(steps, dtype=torch.long),
+            "is_init": ((step % episode_len) == 0).reshape(steps, 1),
+            "step": step,
+            "state": torch.zeros(steps, 3),
+            "belief": torch.zeros(steps, 3),
+            "next": {
+                "observation": torch.randn(steps, 3),
+                "reward": torch.zeros(steps, 1),
+                "done": terminal.reshape(steps, 1),
+                "terminated": terminal.reshape(steps, 1),
+                "truncated": torch.zeros(steps, 1, dtype=torch.bool),
+            },
+        },
+        [steps],
+    )
+    try:
+        rb.extend(data)
+        terminal_in_sequence = reset_in_sequence = False
+        for _ in range(16):
+            sample = rb.sample().reshape(4, 8)[:, :-1]
+            assert (sample["step"][:, 1:] - sample["step"][:, :-1] == 1).all()
+            terminal_in_sequence |= bool(sample["next", "terminated"].any())
+            reset_in_sequence |= bool(sample["is_init"][:, 1:].any())
+            expected_init = (sample["step"] % episode_len == 0).reshape(4, 7, 1)
+            assert (sample["is_init"] == expected_init).all()
+        assert terminal_in_sequence
+        assert reset_in_sequence
+    finally:
+        rb.shutdown()
+
+
 @pytest.mark.skipif(not _has_omegaconf, reason="requires omegaconf")
 def test_dreamer_v3_replay_capacity_validation(monkeypatch):
     from omegaconf import OmegaConf

--- a/test/rb/test_ensemble.py
+++ b/test/rb/test_ensemble.py
@@ -325,6 +325,53 @@ class TestEnsemble:
             release.set()
             replay.shutdown()
 
+    @pytest.mark.parametrize("sampler_type", [SliceSampler, StreamingSliceSampler])
+    def test_end_streams_with_per_stream_trajectory_key(self, sampler_type):
+        done_key = ("next", "done")
+
+        def make_member():
+            return TensorDictReplayBuffer(
+                storage=LazyTensorStorage(8),
+                writer=TensorDictRoundRobinWriter(track_generations=True),
+                sampler=sampler_type(
+                    slice_len=2, end_key=done_key, traj_key="env_index"
+                ),
+                batch_size=2,
+            )
+
+        def records(env_index):
+            return TensorDict(
+                {
+                    "env_index": torch.as_tensor(env_index),
+                    "value": torch.arange(len(env_index)),
+                    done_key: torch.zeros(len(env_index), 1, dtype=torch.bool),
+                },
+                [len(env_index)],
+            )
+
+        # One environment per member: the stream is the trajectory and its tail closes.
+        members = [make_member() for _ in range(2)]
+        replay = ReplayBufferEnsemble(*members, routing_key="env_index")
+        try:
+            replay.extend(records([0, 0, 0]))
+            replay.extend(records([1, 1]))
+            replay.end_streams()
+            assert members[0][:][done_key].flatten().tolist() == [False, False, True]
+            assert members[1][:][done_key].flatten().tolist() == [False, True]
+        finally:
+            replay.shutdown()
+
+        # Distinct ids within a member may be reused by restarted producers.
+        mixed = make_member()
+        mixed.extend(records([0, 1]))
+        replay = ReplayBufferEnsemble(mixed)
+        try:
+            with pytest.raises(RuntimeError, match="same trajectory id"):
+                replay.end_streams()
+            assert not mixed[:][done_key].any()
+        finally:
+            replay.shutdown()
+
     def test_routing_dim_preserves_member_order(self):
         members = [self._make_routed_member() for _ in range(2)]
         rb = ReplayBufferEnsemble(*members, routing_dim=1)

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -1303,6 +1303,62 @@ class TestSamplers:
                     end + 1
                 ].item(), f"slice starting at index {end + 1} missing is_init=True"
 
+    @pytest.mark.parametrize("sampler_cls", [SliceSampler, StreamingSliceSampler])
+    def test_slice_sampler_init_key_none_keeps_stored_flags(self, sampler_cls):
+        """init_key=None returns the stored is_init flags without slice-start markers."""
+        torch.manual_seed(0)
+        traj_lengths = [8, 12]
+        parts = []
+        for t_id, length in enumerate(traj_lengths):
+            init = torch.zeros(length, 1, dtype=torch.bool)
+            init[0] = True
+            parts.append(
+                TensorDict(
+                    {
+                        "traj": torch.full((length,), t_id, dtype=torch.int),
+                        "is_init": init,
+                        "step": torch.arange(length),
+                    },
+                    batch_size=[length],
+                )
+            )
+        data = torch.cat(parts)
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(data.numel()),
+            sampler=sampler_cls(slice_len=4, traj_key="traj", init_key=None),
+            batch_size=8,
+        )
+        rb.extend(data)
+        for _ in range(20):
+            sample = rb.sample()
+            stored = data["is_init"][sample["index"].reshape(-1)]
+            torch.testing.assert_close(sample["is_init"], stored)
+            starts = sample["step"].reshape(2, 4)[:, 0]
+            assert (sample["is_init"].reshape(2, 4)[:, 0] == (starts == 0)).all()
+
+    def test_slice_sampler_init_key_custom(self):
+        """A custom init_key receives the slice-start markers."""
+        torch.manual_seed(0)
+        data = TensorDict(
+            {
+                "traj": torch.repeat_interleave(torch.arange(2, dtype=torch.int), 10),
+                ("collector", "init"): torch.zeros(20, 1, dtype=torch.bool),
+            },
+            batch_size=[20],
+        )
+        rb = TensorDictReplayBuffer(
+            storage=LazyTensorStorage(20),
+            sampler=SliceSampler(
+                slice_len=5, traj_key="traj", init_key=("collector", "init")
+            ),
+            batch_size=10,
+        )
+        rb.extend(data)
+        sample = rb.sample()
+        assert "is_init" not in sample.keys(True)
+        assert sample["collector", "init"].reshape(2, 5)[:, 0].all()
+        assert not sample["collector", "init"].reshape(2, 5)[:, 1:].any()
+
     def test_slice_sampler_pad_output_no_is_init_no_marker(self):
         """Without is_init in the storage we don't introduce one out of thin air."""
         torch.manual_seed(0)

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -52,6 +52,7 @@ from torchrl.data import (
     TensorDictReplayBuffer,
     TensorDictRoundRobinWriter,
 )
+from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules.inference_server import (
     InferenceClient,
     InferenceDeviceConfig,
@@ -66,6 +67,10 @@ from torchrl.modules.inference_server import (
     SharedMemoryTransport,
     SlotTransport,
     ThreadingTransport,
+)
+from torchrl.modules.inference_server._client import (
+    _INTERACTION_TYPE_TO_CODE,
+    _NO_INTERACTION_TYPE_CODE,
 )
 from torchrl.modules.inference_server._config import _resolve_device_config
 from torchrl.modules.inference_server._monarch import MonarchTransport
@@ -150,6 +155,32 @@ class _BatchSizeModule(nn.Module):
 class _RandomModule(nn.Module):
     def forward(self, value):
         return torch.rand_like(value)
+
+
+class _InteractionTypeProbe(TensorDictModule):
+    """Stand-in for a probabilistic policy: records the sampling mode it runs under."""
+
+    def __init__(self):
+        super().__init__(
+            module=nn.Module(),  # placeholder
+            in_keys=["observation"],
+            out_keys=["action", "interaction_code"],
+        )
+
+    def forward(self, td: TensorDictBase) -> TensorDictBase:
+        observation = td.get("observation")
+        current = interaction_type()
+        code = (
+            _INTERACTION_TYPE_TO_CODE[current.value]
+            if current is not None
+            else _NO_INTERACTION_TYPE_CODE
+        )
+        td.set("action", torch.ones_like(observation))
+        return td.set("interaction_code", torch.full_like(observation, code))
+
+
+def _make_interaction_type_probe():
+    return _InteractionTypeProbe()
 
 
 # =============================================================================
@@ -2327,31 +2358,65 @@ class TestWeightSyncIntegration:
             result = client(TensorDict({}, batch_size=[1]))
             assert result["action"].item() == 0
 
+    def test_policy_client_explicit_interaction_type_wins_over_ambient_context(self):
+        transport = ThreadingTransport()
+        with InferenceServer(_InteractionTypeProbe(), transport, max_batch_size=4):
+            client = PolicyClientModule(
+                transport,
+                out_keys=["action", "interaction_code"],
+                interaction_type=InteractionType.RANDOM,
+            )
+            request = TensorDict({"observation": torch.zeros(1, dtype=torch.int32)})
+            with set_interaction_type(InteractionType.DETERMINISTIC):
+                result = client(request)
+            assert (
+                result["interaction_code"].item() == _INTERACTION_TYPE_TO_CODE["random"]
+            )
+            result = client(request)
+            assert (
+                result["interaction_code"].item() == _INTERACTION_TYPE_TO_CODE["random"]
+            )
+
+    def test_server_ignores_ambient_interaction_type_for_unstamped_requests(self):
+        transport = ThreadingTransport()
+        with InferenceServer(_InteractionTypeProbe(), transport, max_batch_size=4):
+            # A raw transport client attaches no interaction-type code; the
+            # serving thread's global says nothing about the request.
+            client = transport.client()
+            with set_interaction_type(InteractionType.RANDOM):
+                result = client(
+                    TensorDict({"observation": torch.zeros(1, dtype=torch.int32)})
+                )
+        assert result["interaction_code"].item() == _NO_INTERACTION_TYPE_CODE
+
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
-    def test_cudagraph_compares_effective_interaction_type(self):
-        class _InteractionValue(nn.Module):
-            def forward(self, observation):
-                value = 1 if interaction_type() is InteractionType.RANDOM else 0
-                return torch.full_like(observation, value)
-
-        policy = TensorDictModule(
-            _InteractionValue(), in_keys=["observation"], out_keys=["action"]
+    def test_cudagraph_captures_explicit_interaction_type(self):
+        request_spec = TensorDict({"observation": torch.zeros(1, dtype=torch.int32)})
+        server = InferenceServer(
+            _InteractionTypeProbe(),
+            transport="auto",
+            max_batch_size=1,
+            static_batch_size=1,
+            policy_device="cuda:0",
+            output_device="cpu",
         )
-        request_spec = TensorDict({"observation": torch.zeros(1)})
-        with set_interaction_type(InteractionType.RANDOM):
-            with InferenceServer(
-                policy,
-                transport="auto",
-                max_batch_size=1,
-                static_batch_size=1,
-                request_spec=request_spec,
-                policy_device="cuda:0",
-                output_device="cpu",
-            ) as server:
-                client = PolicyClientModule(server.transport, out_keys=["action"])
-                result = client(TensorDict({"observation": torch.ones(1)}))
-        assert result["action"].item() == 1
+        # The capture mode is explicit; the ambient context plays no role.
+        with set_interaction_type(InteractionType.DETERMINISTIC):
+            server.prepare_cudagraph(
+                request_spec, interaction_type=InteractionType.RANDOM
+            )
+        with server:
+            client = PolicyClientModule(
+                server.transport,
+                out_keys=["action", "interaction_code"],
+                interaction_type=InteractionType.RANDOM,
+            )
+            with set_interaction_type(InteractionType.DETERMINISTIC):
+                result = client(
+                    TensorDict({"observation": torch.ones(1, dtype=torch.int32)})
+                )
+        assert result["interaction_code"].item() == _INTERACTION_TYPE_TO_CODE["random"]
 
 
 # ---------------------------------------------------------------------------
@@ -2420,6 +2485,56 @@ def _make_bad_process_policy():
 def _make_slow_policy():
     time.sleep(30.0)
     return _make_counting_policy()
+
+
+def _toggle_deterministic_exploration(stop: threading.Event) -> None:
+    """Flip the process-wide interaction type the way a learner's loss forward does."""
+    while not stop.is_set():
+        with set_exploration_type(ExplorationType.DETERMINISTIC):
+            time.sleep(0.0005)
+        time.sleep(0.0005)
+
+
+def _collect_under_toggled_exploration(collector):
+    """Drain ``collector`` while another thread toggles the interaction type."""
+    stop = threading.Event()
+    toggler = threading.Thread(
+        target=_toggle_deterministic_exploration, args=(stop,), daemon=True
+    )
+    toggler.start()
+    try:
+        return list(collector)
+    finally:
+        stop.set()
+        toggler.join(timeout=5.0)
+        collector.shutdown()
+
+
+def _record_served_interaction_codes(monkeypatch) -> list[int]:
+    """Record the interaction code an in-process server resolves per batch."""
+    codes = []
+    original = InferenceServer._interaction_type_context
+
+    def record(server, batch):
+        context, batch, code = original(server, batch)
+        codes.append(code)
+        return context, batch, code
+
+    monkeypatch.setattr(InferenceServer, "_interaction_type_context", record)
+    return codes
+
+
+@pytest.fixture
+def restore_interaction_type():
+    """Reset tensordict's process-wide interaction type after the test.
+
+    The toggling thread and an in-process server thread enter and exit
+    ``set_interaction_type`` contexts on the same global; interleaved exits
+    can leave a stale value behind once both have stopped.
+    """
+    initial = interaction_type()
+    yield
+    set_interaction_type(initial).__enter__()
 
 
 class TestProcessInferenceServer:
@@ -3789,6 +3904,94 @@ class TestAsyncBatchedCollector:
             total += batch.numel()
         collector.shutdown()
         assert total >= 20
+
+    @pytest.mark.parametrize("exploration_type", [None, ExplorationType.MODE])
+    def test_exploration_type_ignores_process_wide_interaction_type(
+        self, exploration_type, monkeypatch, restore_interaction_type
+    ):
+        """Requests carry the collector's mode, not the toggled global one."""
+        served_codes = _record_served_interaction_codes(monkeypatch)
+        kwargs = (
+            {} if exploration_type is None else {"exploration_type": exploration_type}
+        )
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 4,
+            policy=_make_interaction_type_probe(),
+            frames_per_batch=16,
+            total_frames=256,
+            max_batch_size=4,
+            env_backend="threading",
+            **kwargs,
+        )
+        batches = _collect_under_toggled_exploration(collector)
+        expected = _INTERACTION_TYPE_TO_CODE[
+            (exploration_type or ExplorationType.RANDOM).value
+        ]
+        assert sum(batch.numel() for batch in batches) >= 256
+        # Every batch was homogeneous (a mixed batch raises) and used the
+        # collector's mode. The probe's own record is not checked here: the
+        # server thread's set_interaction_type is process-wide as well, so the
+        # toggling thread can still change what the forward observes.
+        assert served_codes and set(served_codes) == {expected}
+
+    def test_exploration_type_ignores_process_wide_interaction_type_process_server(
+        self, restore_interaction_type
+    ):
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 4,
+            policy_factory=_make_interaction_type_probe,
+            frames_per_batch=16,
+            total_frames=128,
+            env_backend="threading",
+            server_config=InferenceServerConfig(
+                service_backend="process", max_batch_size=4
+            ),
+            exploration_type=ExplorationType.MODE,
+        )
+        batches = _collect_under_toggled_exploration(collector)
+        # The server process owns its own interaction-type global, so the
+        # probe's record is exact there.
+        codes = torch.cat([batch["interaction_code"].reshape(-1) for batch in batches])
+        assert codes.unique().tolist() == [_INTERACTION_TYPE_TO_CODE["mode"]]
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    @pytest.mark.parametrize("service_backend", ["thread", "process"])
+    def test_static_batch_exploration_type_ignores_process_wide_interaction_type(
+        self, service_backend, monkeypatch, restore_interaction_type
+    ):
+        """The graph is captured under the collector's mode, which every request carries."""
+        served_codes = _record_served_interaction_codes(monkeypatch)
+        if service_backend == "process":
+            policy_kwargs = {"policy_factory": _make_interaction_type_probe}
+        else:
+            policy_kwargs = {"policy": _make_interaction_type_probe()}
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            frames_per_batch=8,
+            total_frames=64,
+            env_backend="threading",
+            server_config=InferenceServerConfig(
+                service_backend=service_backend, max_batch_size=2, static_batch_size=2
+            ),
+            device_config=InferenceDeviceConfig(
+                policy_device="cuda:0",
+                output_device="cpu",
+                env_device="cpu",
+                storing_device="cpu",
+            ),
+            **policy_kwargs,
+        )
+        batches = _collect_under_toggled_exploration(collector)
+        expected = _INTERACTION_TYPE_TO_CODE[ExplorationType.RANDOM.value]
+        assert sum(batch.numel() for batch in batches) >= 64
+        if service_backend == "thread":
+            assert served_codes and set(served_codes) == {expected}
+        else:
+            codes = torch.cat(
+                [batch["interaction_code"].reshape(-1) for batch in batches]
+            )
+            assert codes.unique().tolist() == [expected]
 
 
 # =============================================================================

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -152,6 +152,12 @@ class _BatchSizeModule(nn.Module):
         return value + value.shape[0]
 
 
+class _RecurrentEcho(nn.Module):
+    def forward(self, observation, state):
+        state = torch.tanh(state + observation)
+        return state.sum(-1, keepdim=True), state
+
+
 class _RandomModule(nn.Module):
     def forward(self, value):
         return torch.rand_like(value)
@@ -494,6 +500,43 @@ class TestInferenceServerCore:
                 request_spec=TensorDict({"observation": torch.zeros(1)}),
                 policy_device="cpu",
             )
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+    def test_static_batch_serves_policy_rewriting_its_inputs(self):
+        """Recurrent policies write their new state under the key they read it from.
+
+        Served through a captured CUDA graph, every request must still be
+        computed from its own inputs rather than from the batch the graph was
+        captured on.
+        """
+        transport = ThreadingTransport()
+        policy = TensorDictModule(
+            _RecurrentEcho(),
+            in_keys=["observation", "state"],
+            out_keys=["action", "state"],
+        )
+        request_spec = TensorDict(
+            {"observation": torch.zeros(3), "state": torch.zeros(3)}
+        )
+        with InferenceServer(
+            policy,
+            transport,
+            max_batch_size=4,
+            static_batch_size=4,
+            request_spec=request_spec,
+            policy_device="cuda:0",
+            output_device="cpu",
+        ):
+            client = transport.client()
+            for value in (1.0, -1.0, 0.5):
+                request = TensorDict(
+                    {"observation": torch.ones(3), "state": torch.full((3,), value)}
+                )
+                expected = policy(request.clone())
+                served = client(request.clone())
+                torch.testing.assert_close(served["action"], expected["action"])
+                torch.testing.assert_close(served["state"], expected["state"])
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -1191,17 +1191,20 @@ class TestPolicyClientModule:
         for lifecycle in ("start", "shutdown", "close", "flush"):
             assert not hasattr(restored, lifecycle)
 
-    def test_plain_callable_client_defers_errors(self):
+    @pytest.mark.parametrize("mode", [None, InteractionType.RANDOM])
+    def test_plain_callable_client_defers_errors(self, mode):
         """A plain-callable client defers exceptions to result()."""
 
         def failing_client(td):
             raise ValueError("local policy failure")
 
-        remote_policy = PolicyClientModule(failing_client)
-        future = remote_policy.submit(TensorDict({}))
-        assert future.done()
-        with pytest.raises(ValueError, match="local policy failure"):
-            future.result()
+        remote_policy = PolicyClientModule(failing_client, interaction_type=mode)
+        with set_interaction_type(InteractionType.DETERMINISTIC):
+            future = remote_policy.submit(TensorDict({}))
+            assert future.done()
+            with pytest.raises(ValueError, match="local policy failure"):
+                future.result()
+            assert interaction_type() is InteractionType.DETERMINISTIC
 
     def test_update_policy_weights_cascade_bumps_version(self):
         """The weight-sync cascade hook increments the policy version."""
@@ -2358,17 +2361,26 @@ class TestWeightSyncIntegration:
             result = client(TensorDict({}, batch_size=[1]))
             assert result["action"].item() == 0
 
-    def test_policy_client_explicit_interaction_type_wins_over_ambient_context(self):
+    @pytest.mark.parametrize("remote", [False, True])
+    def test_policy_client_explicit_interaction_type_wins_over_ambient_context(
+        self, remote
+    ):
         transport = ThreadingTransport()
-        with InferenceServer(_InteractionTypeProbe(), transport, max_batch_size=4):
+        policy = _InteractionTypeProbe()
+        with (
+            InferenceServer(policy, transport, max_batch_size=4)
+            if remote
+            else contextlib.nullcontext()
+        ):
             client = PolicyClientModule(
-                transport,
+                transport if remote else policy,
                 out_keys=["action", "interaction_code"],
                 interaction_type=InteractionType.RANDOM,
             )
             request = TensorDict({"observation": torch.zeros(1, dtype=torch.int32)})
             with set_interaction_type(InteractionType.DETERMINISTIC):
                 result = client(request)
+                assert interaction_type() is InteractionType.DETERMINISTIC
             assert (
                 result["interaction_code"].item() == _INTERACTION_TYPE_TO_CODE["random"]
             )
@@ -2377,42 +2389,44 @@ class TestWeightSyncIntegration:
                 result["interaction_code"].item() == _INTERACTION_TYPE_TO_CODE["random"]
             )
 
-    def test_server_ignores_ambient_interaction_type_for_unstamped_requests(self):
+    def test_server_preserves_ambient_interaction_type_for_unstamped_requests(self):
         transport = ThreadingTransport()
         with InferenceServer(_InteractionTypeProbe(), transport, max_batch_size=4):
-            # A raw transport client attaches no interaction-type code; the
-            # serving thread's global says nothing about the request.
+            # Raw clients retain their existing ambient-context behavior.
             client = transport.client()
             with set_interaction_type(InteractionType.RANDOM):
                 result = client(
                     TensorDict({"observation": torch.zeros(1, dtype=torch.int32)})
                 )
-        assert result["interaction_code"].item() == _NO_INTERACTION_TYPE_CODE
+        assert result["interaction_code"].item() == _INTERACTION_TYPE_TO_CODE["random"]
 
     @pytest.mark.gpu
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
-    def test_cudagraph_captures_explicit_interaction_type(self):
+    @pytest.mark.parametrize("explicit", [False, True])
+    def test_cudagraph_captures_interaction_type(self, explicit):
         request_spec = TensorDict({"observation": torch.zeros(1, dtype=torch.int32)})
         server = InferenceServer(
             _InteractionTypeProbe(),
             transport="auto",
             max_batch_size=1,
             static_batch_size=1,
+            request_spec=request_spec,
             policy_device="cuda:0",
             output_device="cpu",
         )
-        # The capture mode is explicit; the ambient context plays no role.
-        with set_interaction_type(InteractionType.DETERMINISTIC):
-            server.prepare_cudagraph(
-                request_spec, interaction_type=InteractionType.RANDOM
-            )
-        with server:
-            client = PolicyClientModule(
-                server.transport,
-                out_keys=["action", "interaction_code"],
-                interaction_type=InteractionType.RANDOM,
-            )
-            with set_interaction_type(InteractionType.DETERMINISTIC):
+        with set_interaction_type(
+            InteractionType.DETERMINISTIC if explicit else InteractionType.RANDOM
+        ):
+            if explicit:
+                server.prepare_cudagraph(
+                    request_spec, interaction_type=InteractionType.RANDOM
+                )
+            with server:
+                client = PolicyClientModule(
+                    server.transport,
+                    out_keys=["action", "interaction_code"],
+                    interaction_type=InteractionType.RANDOM if explicit else None,
+                )
                 result = client(
                     TensorDict({"observation": torch.ones(1, dtype=torch.int32)})
                 )

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -32,11 +32,13 @@ from torchrl._utils import (
     timeit,
 )
 from torchrl.collectors._base import BaseCollector
+from torchrl.collectors._constants import DEFAULT_EXPLORATION_TYPE
 from torchrl.collectors.utils import _maybe_normalize_replay_buffer_tensordict_device
 from torchrl.data.replay_buffers import ReplayBuffer
 from torchrl.data.utils import CloudpickleWrapper
 from torchrl.envs import AsyncEnvPool, EnvBase, EnvCreator
 from torchrl.envs.async_envs import _validate_cpu_affinity
+from torchrl.envs.utils import ExplorationType
 from torchrl.modules.inference_server import (
     InferenceDeviceConfig,
     InferenceServer,
@@ -506,6 +508,15 @@ class AsyncBatchedCollector(BaseCollector):
             start of every collection batch.  Defaults to ``False``.
         postproc (Callable, optional): post-processing transform applied to
             each collected batch before yielding.  Defaults to ``None``.
+        exploration_type (ExplorationType, optional): interaction mode used
+            when collecting data, one of
+            ``torchrl.envs.utils.ExplorationType.RANDOM``, ``MODE``, ``MEAN``
+            or ``DETERMINISTIC``. Every inference request is stamped with it
+            and, when ``static_batch_size`` is set, the CUDA graph is captured
+            under it, independently of the process-wide
+            :func:`~torchrl.envs.utils.set_exploration_type` context, which a
+            learner thread of the same process may change at any time.
+            Defaults to ``ExplorationType.RANDOM``.
         replay_buffer (ReplayBuffer, optional): replay buffer to extend in the
             collector's parent thread after post-processing. When provided,
             iteration yields ``None`` instead of full rollout batches.
@@ -595,6 +606,7 @@ class AsyncBatchedCollector(BaseCollector):
         ) = None,
         reset_at_each_iter: bool = False,
         postproc: Callable[[TensorDictBase], TensorDictBase] | None = None,
+        exploration_type: ExplorationType = DEFAULT_EXPLORATION_TYPE,
         replay_buffer: ReplayBuffer | None = None,
         post_collect_hook: Callable[[TensorDictBase], None] | None = None,
         yield_completed_trajectories: bool = False,
@@ -835,6 +847,11 @@ class AsyncBatchedCollector(BaseCollector):
         self.reset_at_each_iter = reset_at_each_iter
         self.yield_completed_trajectories = yield_completed_trajectories
         self._postproc = postproc
+        self.exploration_type = ExplorationType(
+            exploration_type
+            if exploration_type is not None
+            else DEFAULT_EXPLORATION_TYPE
+        )
         self.replay_buffer = replay_buffer
         self.verbose = verbose
 
@@ -889,11 +906,15 @@ class AsyncBatchedCollector(BaseCollector):
                         PolicyClientModule(
                             self._transport.client(),
                             max_inflight=self._max_inflight_per_env,
+                            interaction_type=self.exploration_type,
                         )
                         for _ in range(self._num_envs)
                     ]
                 if self._server.static_batch_size is not None:
-                    self._server.prepare_cudagraph(self._transport._request_slots[0])
+                    self._server.prepare_cudagraph(
+                        self._transport._request_slots[0],
+                        interaction_type=self.exploration_type,
+                    )
                 if not self._server.is_alive:
                     self._server.start()
 
@@ -990,13 +1011,16 @@ class AsyncBatchedCollector(BaseCollector):
                     PolicyClientModule(
                         self._transport.client(),
                         max_inflight=self._max_inflight_per_env,
+                        interaction_type=self.exploration_type,
                     )
                     for _ in range(self._num_envs)
                 ]
 
             if self._server.static_batch_size is not None:
                 request_spec = self._env_pool.fake_tensordict()[0]
-                self._server.prepare_cudagraph(request_spec)
+                self._server.prepare_cudagraph(
+                    request_spec, interaction_type=self.exploration_type
+                )
 
             # Start inference server
             if not self._server.is_alive:

--- a/torchrl/data/replay_buffers/replay_buffers/ensemble.py
+++ b/torchrl/data/replay_buffers/replay_buffers/ensemble.py
@@ -577,8 +577,10 @@ class ReplayBufferEnsemble(ReplayBuffer):
         Each member must hold one chronological stream in a one-dimensional
         tensor storage, with a generation-tracking round-robin writer and a
         :class:`SliceSampler` (including :class:`StreamingSliceSampler`) configured
-        to read ``end_key``. Trajectory-ID sampling is not supported by this
-        operation because restarted producers may reuse old IDs.
+        to read ``end_key``. A sampler with a ``traj_key`` is accepted only when
+        every record of the member carries the same trajectory id (a per-stream
+        key such as the environment index); with distinct ids, restarted
+        producers may reuse old ones and the call raises.
 
         Pending samples and conditional updates finish before tail selection.
         Tail patches keep write counts and slot generations unchanged. Existing
@@ -649,7 +651,6 @@ class ReplayBufferEnsemble(ReplayBuffer):
                     or not isinstance(writer, RoundRobinWriter)
                     or not writer.tracks_generations
                     or not isinstance(sampler, SliceSampler)
-                    or sampler.traj_key is not None
                     or end_key not in (sampler.end_keys or [sampler.end_key])
                 ):
                     raise RuntimeError(
@@ -658,6 +659,26 @@ class ReplayBufferEnsemble(ReplayBuffer):
                     )
                 if not len(member):
                     continue
+                if sampler.traj_key is not None:
+                    # One trajectory id per member (a per-stream key such as the
+                    # environment index) keeps the stream a single trajectory across
+                    # restarts. Distinct ids may be reused by restarted producers,
+                    # which a tail patch cannot separate.
+                    data = storage._storage
+                    trajectory = (
+                        data.get(sampler.traj_key, default=None)
+                        if is_tensor_collection(data)
+                        else None
+                    )
+                    if trajectory is None or not bool(
+                        (trajectory[: len(member)] == trajectory[0]).all()
+                    ):
+                        raise RuntimeError(
+                            "end_streams supports trajectory-keyed slice samplers only "
+                            "when every record of a member carries the same trajectory "
+                            "id (a per-stream key such as the environment index); "
+                            "restarted producers may otherwise reuse old ids."
+                        )
                 index = torch.tensor(
                     [(int(writer._cursor) - 1) % len(member)], device=storage.device
                 )

--- a/torchrl/data/replay_buffers/samplers/prioritized_slice.py
+++ b/torchrl/data/replay_buffers/samplers/prioritized_slice.py
@@ -129,6 +129,13 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
             This feature only works with :class:`~torchrl.data.replay_buffers.TensorDictReplayBuffer`
             instances (otherwise the truncated key is returned in the info dictionary
             returned by the :meth:`~torchrl.data.replay_buffers.ReplayBuffer.sample` method).
+        init_key (NestedKey, optional): If not ``None``, the sampler marks the
+            first step of every slice with ``True`` under this key (OR-ed with
+            the flags stored in the buffer, when present) so that recurrent
+            modules restart from the stored hidden state at each slice start.
+            Pass ``None`` to leave the stored flags untouched, as required by
+            models that reset their state wherever ``is_init`` is set, such as
+            the DreamerV3 RSSM rollout. Defaults to ``"is_init"``.
         strict_length (bool, optional): if ``False``, trajectories of length
             shorter than `slice_len` (or `batch_size // num_slices`) will be
             allowed to appear in the batch. If ``True``, trajectories shorted
@@ -215,6 +222,7 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
         trajectories: torch.Tensor | None = None,
         cache_values: bool = False,
         truncated_key: NestedKey | None = ("next", "truncated"),
+        init_key: NestedKey | None = "is_init",
         strict_length: bool = True,
         compile: bool | dict = False,
         span: bool | int | tuple[bool | int, bool | int] = False,
@@ -229,6 +237,7 @@ class PrioritizedSliceSampler(SliceSampler, PrioritizedSampler):
             traj_key=traj_key,
             cache_values=cache_values,
             truncated_key=truncated_key,
+            init_key=init_key,
             strict_length=strict_length,
             ends=ends,
             trajectories=trajectories,

--- a/torchrl/data/replay_buffers/samplers/slice.py
+++ b/torchrl/data/replay_buffers/samplers/slice.py
@@ -118,6 +118,13 @@ class SliceSampler(Sampler):
             This feature only works with :class:`~torchrl.data.replay_buffers.TensorDictReplayBuffer`
             instances (otherwise the truncated key is returned in the info dictionary
             returned by the :meth:`~torchrl.data.replay_buffers.ReplayBuffer.sample` method).
+        init_key (NestedKey, optional): If not ``None``, the sampler marks the
+            first step of every slice with ``True`` under this key (OR-ed with
+            the flags stored in the buffer, when present) so that recurrent
+            modules restart from the stored hidden state at each slice start.
+            Pass ``None`` to leave the stored flags untouched, as required by
+            models that reset their state wherever ``is_init`` is set, such as
+            the DreamerV3 RSSM rollout. Defaults to ``"is_init"``.
         strict_length (bool, optional): if ``False``, trajectories of length
             shorter than `slice_len` (or `batch_size // num_slices`) will be
             allowed to appear in the batch. If ``True``, trajectories shorted
@@ -384,6 +391,7 @@ class SliceSampler(Sampler):
         trajectories: torch.Tensor | None = None,
         cache_values: bool = False,
         truncated_key: NestedKey | None = ("next", "truncated"),
+        init_key: NestedKey | None = "is_init",
         strict_length: bool = True,
         pad_output: bool = False,
         compile: bool | dict = False,
@@ -436,6 +444,7 @@ class SliceSampler(Sampler):
         )
         self.traj_key = traj_key
         self.truncated_key = truncated_key
+        self.init_key = init_key
         self.cache_values = cache_values
         self._fetch_traj = True
         self.strict_length = strict_length
@@ -1305,10 +1314,15 @@ class SliceSampler(Sampler):
         We OR our markers with the storage's existing ``is_init`` so episode
         resets that fall *inside* a slice are preserved. If the storage
         doesn't carry an ``is_init`` field (no :class:`InitTracker`), we don't
-        introduce one — we'd be lying about real resets we can't see.
+        introduce one — we'd be lying about real resets we can't see. With
+        ``init_key=None`` the stored flags are returned untouched.
         """
+        if self.init_key is None:
+            return
         existing_is_init = (
-            st_index.get("is_init", default=None) if hasattr(st_index, "get") else None
+            st_index.get(self.init_key, default=None)
+            if hasattr(st_index, "get")
+            else None
         )
         if existing_is_init is None:
             return
@@ -1332,7 +1346,7 @@ class SliceSampler(Sampler):
             slice_starts = torch.zeros(num_slices, device=device, dtype=torch.long)
             slice_starts[1:] = seq_length.to(device).cumsum(0)[:-1].to(torch.long)
         init_marker[slice_starts] = True
-        info["is_init"] = init_marker | existing_is_init
+        info[self.init_key] = init_marker | existing_is_init
 
     @property
     def _used_traj_key(self):

--- a/torchrl/data/replay_buffers/samplers/slice_without_replacement.py
+++ b/torchrl/data/replay_buffers/samplers/slice_without_replacement.py
@@ -75,6 +75,13 @@ class SliceSamplerWithoutReplacement(SliceSampler, SamplerWithoutReplacement):
             This feature only works with :class:`~torchrl.data.replay_buffers.TensorDictReplayBuffer`
             instances (otherwise the truncated key is returned in the info dictionary
             returned by the :meth:`~torchrl.data.replay_buffers.ReplayBuffer.sample` method).
+        init_key (NestedKey, optional): If not ``None``, the sampler marks the
+            first step of every slice with ``True`` under this key (OR-ed with
+            the flags stored in the buffer, when present) so that recurrent
+            modules restart from the stored hidden state at each slice start.
+            Pass ``None`` to leave the stored flags untouched, as required by
+            models that reset their state wherever ``is_init`` is set, such as
+            the DreamerV3 RSSM rollout. Defaults to ``"is_init"``.
         strict_length (bool, optional): if ``False``, trajectories of length
             shorter than `slice_len` (or `batch_size // num_slices`) will be
             allowed to appear in the batch. If ``True``, trajectories shorted
@@ -217,6 +224,7 @@ class SliceSamplerWithoutReplacement(SliceSampler, SamplerWithoutReplacement):
         ends: torch.Tensor | None = None,
         trajectories: torch.Tensor | None = None,
         truncated_key: NestedKey | None = ("next", "truncated"),
+        init_key: NestedKey | None = "is_init",
         strict_length: bool = True,
         shuffle: bool = True,
         compile: bool | dict = False,
@@ -231,6 +239,7 @@ class SliceSamplerWithoutReplacement(SliceSampler, SamplerWithoutReplacement):
             traj_key=traj_key,
             cache_values=True,
             truncated_key=truncated_key,
+            init_key=init_key,
             strict_length=strict_length,
             ends=ends,
             trajectories=trajectories,

--- a/torchrl/data/replay_buffers/samplers/streaming_slice.py
+++ b/torchrl/data/replay_buffers/samplers/streaming_slice.py
@@ -49,6 +49,13 @@ class StreamingSliceSampler(SliceSampler):
         truncated_key (NestedKey, optional): key populated in sampling info at
             the final record of each sampled slice. Defaults to
             ``("next", "truncated")``.
+        init_key (NestedKey, optional): If not ``None``, the sampler marks the
+            first step of every slice with ``True`` under this key (OR-ed with
+            the flags stored in the buffer, when present) so that recurrent
+            modules restart from the stored hidden state at each slice start.
+            Pass ``None`` to leave the stored flags untouched, as required by
+            models that reset their state wherever ``is_init`` is set, such as
+            the DreamerV3 RSSM rollout. Defaults to ``"is_init"``.
         strict_length (bool, optional): whether uniform fallback sampling
             rejects trajectories shorter than ``slice_len``. Defaults to
             ``True``.
@@ -95,6 +102,7 @@ class StreamingSliceSampler(SliceSampler):
         traj_key: NestedKey | None = None,
         cache_values: bool = False,
         truncated_key: NestedKey | None = ("next", "truncated"),
+        init_key: NestedKey | None = "is_init",
         strict_length: bool = True,
         pad_output: bool = False,
         compile: bool | dict = False,
@@ -112,6 +120,7 @@ class StreamingSliceSampler(SliceSampler):
             traj_key=traj_key,
             cache_values=cache_values,
             truncated_key=truncated_key,
+            init_key=init_key,
             strict_length=strict_length,
             pad_output=pad_output,
             compile=compile,

--- a/torchrl/modules/inference_server/_client.py
+++ b/torchrl/modules/inference_server/_client.py
@@ -13,7 +13,7 @@ from typing import Any
 import torch
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
-from tensordict.nn.probabilistic import interaction_type
+from tensordict.nn.probabilistic import interaction_type, InteractionType
 from tensordict.utils import NestedKey
 
 from torchrl.modules.inference_server._transport import InferenceTransport
@@ -30,6 +30,33 @@ _INTERACTION_TYPE_TO_CODE = {
     "random": 3,
     "deterministic": 4,
 }
+
+
+def _stamp_interaction_type(
+    tensordict: TensorDictBase, mode: InteractionType | None
+) -> TensorDictBase:
+    """Return a shallow copy of ``tensordict`` carrying ``mode`` as a request code.
+
+    ``None`` stamps the sentinel code, which the server maps to the served
+    module's default interaction type. The key is always present so server
+    batches stay homogeneous in key structure.
+    """
+    code = (
+        _INTERACTION_TYPE_TO_CODE[mode.value]
+        if mode is not None
+        else _NO_INTERACTION_TYPE_CODE
+    )
+    tensordict = tensordict.clone(recurse=False)
+    tensordict.set(
+        _REMOTE_INTERACTION_TYPE_KEY,
+        torch.full(
+            tensordict.batch_size,
+            code,
+            dtype=torch.int8,
+            device=tensordict.device or torch.device("cpu"),
+        ),
+    )
+    return tensordict
 
 
 class _ImmediateFuture:
@@ -149,13 +176,24 @@ class PolicyClientModule(TensorDictModuleBase):
             freed when its request *completes* (including errors), not when
             ``result()`` is first called; a timed-out ``result()`` keeps the
             slot. Must be at least ``1``. ``None`` means unbounded.
+        interaction_type (InteractionType, optional): sampling mode stamped
+            on every request. Defaults to ``None``: the caller's active
+            :func:`~tensordict.nn.interaction_type` is read at submission
+            time. Pass an explicit mode whenever another thread of the
+            process may set the interaction type while requests are
+            submitted, since that context is process-wide (a learner
+            thread's loss forward would otherwise decide how the served
+            policy samples). :class:`~torchrl.collectors.AsyncBatchedCollector`
+            always passes its ``exploration_type``.
 
     .. note::
-        The caller's active :func:`tensordict.nn.interaction_type` is
-        automatically attached to every transport request, and the server
-        executes the remote policy under that exploration context -- exactly
-        as a local policy would see it. In-process (plain callable) clients
-        need no propagation since the caller's context is already active.
+        The interaction type travels with the request: the explicit
+        ``interaction_type`` or, when none is given, the caller's active
+        :func:`tensordict.nn.interaction_type` is attached to every transport
+        request, and the server executes the remote policy under it -- exactly
+        as a local policy would see it. The serving thread's own (process-wide)
+        context is never consulted. In-process (plain callable) clients need
+        no propagation since the caller's context is already active.
 
     .. note::
         Version tracking is an instance of the generic *service-stamped
@@ -214,6 +252,7 @@ class PolicyClientModule(TensorDictModuleBase):
         in_keys: Sequence[NestedKey] | None = None,
         out_keys: Sequence[NestedKey] | None = None,
         max_inflight: int | None = None,
+        interaction_type: InteractionType | None = None,
     ) -> None:
         super().__init__()
         if isinstance(client, (InferenceTransport, Service)):
@@ -227,6 +266,9 @@ class PolicyClientModule(TensorDictModuleBase):
         self.in_keys = list(in_keys or [])
         self.out_keys = list(out_keys or [])
         self.max_inflight = max_inflight
+        self.interaction_type = (
+            InteractionType(interaction_type) if interaction_type is not None else None
+        )
         self._inflight_sem = (
             threading.BoundedSemaphore(max_inflight)
             if max_inflight is not None
@@ -271,25 +313,15 @@ class PolicyClientModule(TensorDictModuleBase):
         release = self._acquire_inflight()
         submit = getattr(self.client, "submit", None)
         if submit is not None:
-            # Cross-boundary request: carry the caller's exploration context
-            # so the server-side forward behaves like a local call. The key
-            # is always attached (with a sentinel when no context is active)
-            # so server batches stay homogeneous in key structure.
-            current_interaction_type = interaction_type()
-            code = (
-                _INTERACTION_TYPE_TO_CODE[current_interaction_type.value]
-                if current_interaction_type is not None
-                else _NO_INTERACTION_TYPE_CODE
-            )
-            tensordict = tensordict.clone(recurse=False)
-            tensordict.set(
-                _REMOTE_INTERACTION_TYPE_KEY,
-                torch.full(
-                    tensordict.batch_size,
-                    code,
-                    dtype=torch.int8,
-                    device=tensordict.device or torch.device("cpu"),
-                ),
+            # Cross-boundary request: carry the exploration context so the
+            # server-side forward behaves like a local call. An explicit mode
+            # wins over the caller's ambient context, which is process-wide
+            # and may be changed by other threads at any time.
+            tensordict = _stamp_interaction_type(
+                tensordict,
+                self.interaction_type
+                if self.interaction_type is not None
+                else interaction_type(),
             )
         if submit is None:
             # The plain-callable path runs eagerly, so the request has

--- a/torchrl/modules/inference_server/_client.py
+++ b/torchrl/modules/inference_server/_client.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import contextlib
 import queue
 import threading
 from collections.abc import Callable, Sequence
@@ -13,7 +14,11 @@ from typing import Any
 import torch
 from tensordict.base import TensorDictBase
 from tensordict.nn import TensorDictModuleBase
-from tensordict.nn.probabilistic import interaction_type, InteractionType
+from tensordict.nn.probabilistic import (
+    interaction_type,
+    InteractionType,
+    set_interaction_type,
+)
 from tensordict.utils import NestedKey
 
 from torchrl.modules.inference_server._transport import InferenceTransport
@@ -192,8 +197,8 @@ class PolicyClientModule(TensorDictModuleBase):
         :func:`tensordict.nn.interaction_type` is attached to every transport
         request, and the server executes the remote policy under it -- exactly
         as a local policy would see it. The serving thread's own (process-wide)
-        context is never consulted. In-process (plain callable) clients need
-        no propagation since the caller's context is already active.
+        context is never consulted. In-process (plain callable) clients enter
+        the explicit context when given, otherwise retain the caller's context.
 
     .. note::
         Version tracking is an instance of the generic *service-stamped
@@ -327,7 +332,12 @@ class PolicyClientModule(TensorDictModuleBase):
             # The plain-callable path runs eagerly, so the request has
             # already completed here: free the slot immediately.
             try:
-                result = self.client(tensordict)
+                with (
+                    set_interaction_type(self.interaction_type)
+                    if self.interaction_type is not None
+                    else contextlib.nullcontext()
+                ):
+                    result = self.client(tensordict)
                 return _ImmediateFuture(result)
             except Exception as exc:
                 return _ImmediateFuture(exc)

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -24,7 +24,11 @@ import torch
 from tensordict import lazy_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn import CudaGraphModule
-from tensordict.nn.probabilistic import InteractionType, set_interaction_type
+from tensordict.nn.probabilistic import (
+    interaction_type,
+    InteractionType,
+    set_interaction_type,
+)
 from tensordict.utils import NestedKey
 from torch import nn
 
@@ -39,6 +43,7 @@ from torchrl._comm.backends import (
 from torchrl._comm.mailbox import _exit_on_parent_exit
 from torchrl._comm.ray_runtime import _RayRuntimeLease, _set_ray_client_liveness
 from torchrl.modules.inference_server._client import (
+    _INTERACTION_TYPE_TO_CODE,
     _NO_INTERACTION_TYPE_CODE,
     _REMOTE_INTERACTION_TYPE_KEY,
     _stamp_interaction_type,
@@ -825,10 +830,10 @@ class InferenceServer(metaclass=_InferenceServerMeta):
                 same mode (see
                 :class:`~torchrl.modules.inference_server.PolicyClientModule`).
                 Defaults to ``None``: the mode already stamped on
-                ``request_spec`` if any, otherwise the served module's default
-                interaction type. The ambient
-                :func:`~tensordict.nn.set_interaction_type` context is never
-                consulted; it is process-wide and may belong to another thread.
+                ``request_spec`` if any, otherwise the ambient
+                :func:`~tensordict.nn.set_interaction_type` context (or the
+                module default when no context is active). Pass an explicit
+                mode when other threads may change the ambient context.
         """
         if self.static_batch_size is None:
             return
@@ -863,6 +868,10 @@ class InferenceServer(metaclass=_InferenceServerMeta):
                     model_in_keys
                     if model_in_keys is not None
                     else batch.keys(include_nested=True, leaves_only=True)
+                )
+            elif interaction_code != captured_interaction_code:
+                raise RuntimeError(
+                    "The interaction type changed while preparing the CUDA graph."
                 )
             with interaction_context:
                 cudagraph_model(batch)
@@ -930,16 +939,18 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         return result_batch.set(self.policy_version_key, version)
 
     def _interaction_type_context(self, batch: TensorDictBase):
-        # The code stamped on the request is the only source of truth. The
-        # serving thread's ambient interaction type is tensordict's
-        # process-wide global, which belongs to whichever thread set it last
-        # (e.g. a learner's loss forward), so it is never consulted. Note that
-        # entering the returned context mutates that same global for the
-        # duration of the forward.
+        # Stamped requests ignore the ambient context; unstamped requests retain
+        # the standalone server's ambient-context behavior. Entering a stamped
+        # context still mutates tensordict's process-wide global during forward.
         code = batch.get(_REMOTE_INTERACTION_TYPE_KEY, default=None)
         if code is None:
-            # Unstamped request (e.g. a raw transport client): module default.
-            return set_interaction_type(None), batch, _NO_INTERACTION_TYPE_CODE
+            current_interaction_type = interaction_type()
+            interaction_code = (
+                _INTERACTION_TYPE_TO_CODE[current_interaction_type.value]
+                if current_interaction_type is not None
+                else _NO_INTERACTION_TYPE_CODE
+            )
+            return contextlib.nullcontext(), batch, interaction_code
         if not isinstance(code, torch.Tensor):
             interaction_code = int(code)
         else:

--- a/torchrl/modules/inference_server/_server.py
+++ b/torchrl/modules/inference_server/_server.py
@@ -24,11 +24,7 @@ import torch
 from tensordict import lazy_stack, TensorDict
 from tensordict.base import TensorDictBase
 from tensordict.nn import CudaGraphModule
-from tensordict.nn.probabilistic import (
-    interaction_type,
-    InteractionType,
-    set_interaction_type,
-)
+from tensordict.nn.probabilistic import InteractionType, set_interaction_type
 from tensordict.utils import NestedKey
 from torch import nn
 
@@ -43,9 +39,9 @@ from torchrl._comm.backends import (
 from torchrl._comm.mailbox import _exit_on_parent_exit
 from torchrl._comm.ray_runtime import _RayRuntimeLease, _set_ray_client_liveness
 from torchrl.modules.inference_server._client import (
-    _INTERACTION_TYPE_TO_CODE,
     _NO_INTERACTION_TYPE_CODE,
     _REMOTE_INTERACTION_TYPE_KEY,
+    _stamp_interaction_type,
 )
 from torchrl.modules.inference_server._config import (
     _resolve_device_config,
@@ -812,16 +808,36 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         )
 
     @torch.no_grad()
-    def prepare_cudagraph(self, request_spec: TensorDictBase) -> None:
+    def prepare_cudagraph(
+        self,
+        request_spec: TensorDictBase,
+        *,
+        interaction_type: InteractionType | None = None,
+    ) -> None:
         """Capture the configured static CUDA graph before server start.
 
         Args:
             request_spec (TensorDictBase): representative unbatched request.
+
+        Keyword Args:
+            interaction_type (InteractionType, optional): sampling mode the
+                graph is captured under; every request must then carry the
+                same mode (see
+                :class:`~torchrl.modules.inference_server.PolicyClientModule`).
+                Defaults to ``None``: the mode already stamped on
+                ``request_spec`` if any, otherwise the served module's default
+                interaction type. The ambient
+                :func:`~tensordict.nn.set_interaction_type` context is never
+                consulted; it is process-wide and may belong to another thread.
         """
         if self.static_batch_size is None:
             return
         if self.is_alive:
             raise RuntimeError("The CUDA graph must be prepared before server start.")
+        if interaction_type is not None:
+            request_spec = _stamp_interaction_type(
+                request_spec, InteractionType(interaction_type)
+            )
         self._init_weight_sync()
         self._cudagraph_request_spec = request_spec.clone()
         cudagraph_model = CudaGraphModule(
@@ -847,10 +863,6 @@ class InferenceServer(metaclass=_InferenceServerMeta):
                     model_in_keys
                     if model_in_keys is not None
                     else batch.keys(include_nested=True, leaves_only=True)
-                )
-            elif interaction_code != captured_interaction_code:
-                raise RuntimeError(
-                    "The interaction type changed while preparing the CUDA graph."
                 )
             with interaction_context:
                 cudagraph_model(batch)
@@ -918,15 +930,16 @@ class InferenceServer(metaclass=_InferenceServerMeta):
         return result_batch.set(self.policy_version_key, version)
 
     def _interaction_type_context(self, batch: TensorDictBase):
+        # The code stamped on the request is the only source of truth. The
+        # serving thread's ambient interaction type is tensordict's
+        # process-wide global, which belongs to whichever thread set it last
+        # (e.g. a learner's loss forward), so it is never consulted. Note that
+        # entering the returned context mutates that same global for the
+        # duration of the forward.
         code = batch.get(_REMOTE_INTERACTION_TYPE_KEY, default=None)
         if code is None:
-            current_interaction_type = interaction_type()
-            interaction_code = (
-                _INTERACTION_TYPE_TO_CODE[current_interaction_type.value]
-                if current_interaction_type is not None
-                else _NO_INTERACTION_TYPE_CODE
-            )
-            return contextlib.nullcontext(), batch, interaction_code
+            # Unstamped request (e.g. a raw transport client): module default.
+            return set_interaction_type(None), batch, _NO_INTERACTION_TYPE_CODE
         if not isinstance(code, torch.Tensor):
             interaction_code = int(code)
         else:
@@ -1393,15 +1406,29 @@ class ProcessInferenceServer:
         # Live mirror of the child's policy version ("q" = signed 64-bit).
         self._policy_version_value = self._ctx.Value("q", int(policy_version))
 
-    def prepare_cudagraph(self, request_spec: TensorDictBase) -> None:
+    def prepare_cudagraph(
+        self,
+        request_spec: TensorDictBase,
+        *,
+        interaction_type: InteractionType | None = None,
+    ) -> None:
         """Set the representative request used for child-process capture.
 
         Args:
             request_spec (TensorDictBase): representative unbatched request.
+
+        Keyword Args:
+            interaction_type (InteractionType, optional): sampling mode the
+                child process captures under, stamped on the stored request.
+                See :meth:`InferenceServer.prepare_cudagraph`.
         """
         if self.is_alive:
             raise RuntimeError(
                 "The process inference server must prepare its CUDA graph before start."
+            )
+        if interaction_type is not None:
+            request_spec = _stamp_interaction_type(
+                request_spec, InteractionType(interaction_type)
             )
         self._server_kwargs["request_spec"] = request_spec.clone()
 
@@ -1962,13 +1989,21 @@ class _RayInferenceServer(InferenceServer):
             raise RuntimeError("The Ray inference server is not alive.")
         return self
 
-    def prepare_cudagraph(self, request_spec: TensorDictBase) -> None:
+    def prepare_cudagraph(
+        self,
+        request_spec: TensorDictBase,
+        *,
+        interaction_type: InteractionType | None = None,
+    ) -> None:
         """Reject post-construction capture for the already-running Ray actor.
 
         Args:
             request_spec (TensorDictBase): unused representative request.
+
+        Keyword Args:
+            interaction_type (InteractionType, optional): unused sampling mode.
         """
-        del request_spec
+        del request_spec, interaction_type
         raise RuntimeError(
             "A Ray inference server captures inside its actor; pass request_spec "
             "when constructing InferenceServer."

--- a/torchrl/trainers/algorithms/configs/data.py
+++ b/torchrl/trainers/algorithms/configs/data.py
@@ -141,6 +141,7 @@ class PrioritizedSliceSamplerConfig(SamplerConfig):
     trajectories: Any = None
     cache_values: bool = False
     truncated_key: Any = ("next", "truncated")
+    init_key: Any = "is_init"
     strict_length: bool = True
     compile: Any = False
     span: Any = False
@@ -167,6 +168,7 @@ class SliceSamplerWithoutReplacementConfig(SamplerConfig):
     trajectories: Any = None
     cache_values: bool = False
     truncated_key: Any = ("next", "truncated")
+    init_key: Any = "is_init"
     strict_length: bool = True
     compile: Any = False
     span: Any = False
@@ -189,6 +191,7 @@ class SliceSamplerConfig(SamplerConfig):
     trajectories: Any = None
     cache_values: bool = False
     truncated_key: Any = ("next", "truncated")
+    init_key: Any = "is_init"
     strict_length: bool = True
     compile: Any = False
     span: Any = False
@@ -206,6 +209,7 @@ class StreamingSliceSamplerConfig(SamplerConfig):
     traj_key: Any = None
     cache_values: bool = False
     truncated_key: Any = ("next", "truncated")
+    init_key: Any = "is_init"
     strict_length: bool = True
     pad_output: bool = False
     compile: Any = False


### PR DESCRIPTION
Three fixes for asynchronous DreamerV3 training with `AsyncBatchedCollector` and the inference server, plus a regression test for CUDA-graph inference batches with recurrent policies.

## 1. Async requests were stamped with the process-wide interaction type

```python
# learner thread: every LossModule.forward sets the process-wide context (objectives/common.py)
with set_interaction_type(InteractionType.DETERMINISTIC):
    loss = loss_module(batch)

# collector threads, concurrently (PolicyClientModule.submit, before this PR)
request["interaction_type"] = interaction_type()  # DETERMINISTIC or RANDOM depending on timing

server.serve([request_a, request_b])
# RuntimeError: InferenceServer received a mixed interaction-type batch
# (with a captured CUDA graph: "requires the interaction type used during capture")
```

Fix: the collector owns the mode and stamps every request with it; CUDA capture uses the same explicit mode. Standalone ambient-mode behavior is preserved.

```python
collector = AsyncBatchedCollector(
    env_fns, policy=policy, frames_per_batch=256,
    exploration_type=ExplorationType.RANDOM,  # default
)
```

## 2. Slice samplers marked every sequence start as an episode start

```python
# SliceSampler._maybe_emit_init_marker (meant for recurrent modules that restart from a stored state)
info["is_init"] = slice_start | stored_is_init
sample.update(info)  # ReplayBufferEnsemble merges it into the sample

# RSSMRolloutV3 reads is_init as an episode reset
state = torch.where(is_init, 0, state)
belief = torch.where(is_init, 0, belief)
action = torch.where(is_init, 0, action)
# every training sequence started from a zero state with a zeroed first action;
# the stored warm start and its write-back never applied
```

Fix: `init_key` on `SliceSampler`, `StreamingSliceSampler`, `PrioritizedSliceSampler` and `SliceSamplerWithoutReplacement` (mirrored in the Hydra configs). The default `"is_init"` keeps the marker; `None` returns the stored flags untouched, which the DreamerV3 example uses.

```python
StreamingSliceSampler(slice_len=seq_len + 1, end_key=("next", "done"), init_key=None)
```

## 3. Terminal transitions never reached the learner

```python
sampler = StreamingSliceSampler(slice_len=seq_len + 1, end_key=("next", "done"))  # strict_length=True
sample = rb.sample().reshape(B, seq_len + 1)[:, :-1]  # the extra record only addresses write-back rows
# a slice never crosses a done flag, so a terminal record can only be the dropped last slot;
# episodes shorter than seq_len + 1 are never sampled at all
```

Fix: with async collection each stream holds one environment, so the stream is the trajectory: sequences may span episode ends and the rollout resets on the stored `is_init`.

```python
StreamingSliceSampler(
    slice_len=seq_len + 1, end_key=("next", "done"), traj_key="env_index", init_key=None
)
```

`ReplayBufferEnsemble.end_streams` (checkpoint resume) used to refuse every trajectory-keyed sampler because restarted producers may reuse ids. It now accepts a member whose records all carry one trajectory id, since reuse is then by construction and the tail is closed as for end-key samplers; members holding distinct ids still raise.

## 4. CUDA-graph inference batches ignored the inputs of a policy that rewrites its input keys

`tensordict.nn.CudaGraphModule` used to capture on a shallow copy of the input tensordict. A module that sets an output under one of its input keys replaced that entry of the static input during capture; replays then copied the new inputs into the replaced tensor (immediately overwritten by the graph) while the captured kernels kept reading the original buffer.

```python
class Recurrent(nn.Module):
    def forward(self, x, h):
        h = torch.tanh(h + x)
        return h.sum(-1, keepdim=True), h

td = lambda h: TensorDict({"x": torch.ones(4, 3), "h": torch.full((4, 3), h)}, [4]).to("cuda")
policy = TensorDictModule(Recurrent(), in_keys=["x", "h"], out_keys=["y", "h"])  # rewrites "h"
graphed = CudaGraphModule(policy, warmup=2, device="cuda:0")
for _ in range(3):
    graphed(td(0.0))
graphed(td(1.0))["y"] == graphed(td(-1.0))["y"] == policy(td(0.0))["y"]  # h was ignored
```

`RSSMStateEstimatorV3` writes `state` and `belief` under its input keys, so with `static_batch_size` the served DreamerV3 policy ignored `state`, `belief` and `previous_action` and acted from the reset state at every step (its belief equalled the direct call with `is_init=True`). Training degraded after about 2M environment steps, while the eager server learned normally.

The capture is fixed in tensordict (replays copy new inputs into the leaves the graph reads), so this PR adds no workaround: `test_static_batch_serves_policy_rewriting_its_inputs` serves such a policy through `InferenceServer(static_batch_size=...)` and checks every request against the eager module. The test needs a tensordict build with that fix; the next release pins one.

## Tests

- `test/test_inference_server.py`, `test/collectors`: explicit exploration stamping and capture; `test_static_batch_serves_policy_rewriting_its_inputs` (GPU).
- `test/rb/test_samplers.py`: `init_key=None` keeps the stored flags; a custom `init_key` receives the markers.
- `test/rb/test_ensemble.py`: `test_end_streams_with_per_stream_trajectory_key` (single-id members close, mixed-id members raise).
- `test/objectives/test_dreamer_v3.py`: `test_dreamer_v3_replay_samples_keep_episode_starts`, `test_dreamer_v3_async_replay_sequences_cross_episode_ends`; the checkpoint-resume test expects resets to follow closed records in async streams.

Generated with [Claude Code](https://claude.com/claude-code)
