### PR TITLE
[Test] Baseline benchmarks for async collectors and DreamerV3

### DIFF
--- a/.github/async-benchmark-requirements.txt
+++ b/.github/async-benchmark-requirements.txt
@@ -1,6 +1,7 @@
 # Pinned async trend v1 dependencies: CPython 3.10, Linux x86-64, CUDA 12.6.
 # Use stable wheels so a cache eviction cannot depend on expired nightly wheels.
 # TensorDict source is pinned in benchmarks.yml; bump the trend version with this lock.
+antlr4-python3-runtime==4.9.3
 cloudpickle==3.1.2
 cmake==4.4.0
 cuda-bindings==12.9.7
@@ -10,6 +11,7 @@ exceptiongroup==1.3.1
 filelock==3.32.5
 fsspec==2026.7.0
 hoptorch==0.1.4
+hydra-core==1.3.6
 importlib-metadata==9.0.0
 iniconfig==2.3.0
 jinja2==3.1.6
@@ -33,6 +35,7 @@ nvidia-nccl-cu12==2.29.3
 nvidia-nvjitlink-cu12==12.9.86
 nvidia-nvshmem-cu12==3.4.5
 nvidia-nvtx-cu12==12.6.77
+omegaconf==2.3.1
 orjson==3.11.9
 packaging==26.2
 pluggy==1.6.0
@@ -45,6 +48,7 @@ pytest==9.1.1
 pytest-benchmark==5.2.3
 pytest-timeout==2.4.0
 pyvers==0.2.3
+pyyaml==6.0.3
 setuptools==83.0.0
 setuptools-scm==10.2.0
 sympy==1.14.0

--- a/.github/benchmark-requirements.txt
+++ b/.github/benchmark-requirements.txt
@@ -5,6 +5,7 @@ absl-py==2.5.0
 accelerate==1.14.0
 ale-py==0.8.1
 annotated-doc==0.0.4
+antlr4-python3-runtime==4.9.3
 anyio==4.14.2
 attrs==26.1.0
 autorom==0.4.2
@@ -36,6 +37,7 @@ hoptorch==0.1.4
 httpcore==1.0.9
 httpx==0.28.1
 huggingface-hub==1.23.0
+hydra-core==1.3.6
 idna==3.18
 importlib-metadata==9.0.0
 importlib-resources==7.1.0
@@ -71,6 +73,7 @@ nvidia-nccl-cu12==2.29.3
 nvidia-nvjitlink-cu12==12.9.86
 nvidia-nvshmem-cu12==3.4.5
 nvidia-nvtx-cu12==12.6.77
+omegaconf==2.3.1
 orjson==3.11.9
 packaging==26.2
 pandas==2.3.3

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -108,9 +108,22 @@ jobs:
           deb [snapshot=20260907T000000Z] http://security.ubuntu.com/ubuntu/ jammy-security main universe
           APT
             APT_OPTIONS=(-o Dir::Etc::sourcelist=/tmp/benchmark-sources.list -o Dir::Etc::sourceparts=-)
-            apt-get "${APT_OPTIONS[@]}" update
-            apt-get "${APT_OPTIONS[@]}" install -y --no-install-recommends \
-              git gcc g++ make cmake libpython3.10-dev
+            # The snapshot service answers 502/503 intermittently. A failed
+            # install left git missing and failed every later step of the
+            # push-triggered runs, so retry before giving up.
+            for attempt in 1 2 3 4 5 6; do
+              if apt-get "${APT_OPTIONS[@]}" update \
+                && apt-get "${APT_OPTIONS[@]}" install -y --no-install-recommends \
+                  git gcc g++ make cmake libpython3.10-dev; then
+                break
+              fi
+              if [ "$attempt" = 6 ]; then
+                echo "Installing system packages from the snapshot failed after $attempt attempts" >&2
+                exit 1
+              fi
+              sleep 30
+            done
+            command -v git
           else
             apt-get update -y
             apt-get install software-properties-common cmake -y
@@ -177,7 +190,7 @@ jobs:
             python -m pip install -c /tmp/torch-constraints.txt "pybind11[global]"
             python -m pip install -c /tmp/torch-constraints.txt cloudpickle packaging importlib_metadata numpy orjson "pyvers>=0.2.3,<0.3.0"
             python -m pip install --no-deps git+https://github.com/pytorch/tensordict
-            python -m pip install -c /tmp/torch-constraints.txt safetensors tqdm pandas numpy matplotlib ray psutil
+            python -m pip install -c /tmp/torch-constraints.txt safetensors tqdm pandas numpy matplotlib ray psutil hydra-core omegaconf
 
             bash .github/unittest/helpers/assert_torch_version.sh nightly
             bash .github/unittest/helpers/assert_torch_tensordict_versions.sh nightly
@@ -221,7 +234,8 @@ jobs:
               python -m pytest -v --rank 0 --timeout=300 --benchmark-only \
                 --benchmark-save-data --benchmark-json "async-${repeat}.json" \
                 test_envs_benchmark.py test_collectors_benchmark.py \
-                -k 'async_env_pool or async_collection_pixels'
+                test_dreamer_v3_benchmark.py \
+                -k 'async_env_pool or async_collection_pixels or dreamer_v3_async'
             done
           else
             python -m pytest -vvv --rank 0 --timeout=240 --benchmark-only \

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'torchrl/**'
       - 'benchmarks/**'
+      - 'sota-implementations/dreamer_v3/**'
       - '.github/workflows/benchmarks.yml'
       - '.github/async-benchmark-requirements.txt'
       - '.github/scripts/summarize_async_benchmarks.py'

--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -1,8 +1,9 @@
 # Continuous async environment benchmarks
 
 The [Continuous Benchmark workflow](https://github.com/pytorch/rl/actions/workflows/benchmarks.yml)
-runs the short async suite after each main-branch merge touching TorchRL or
-benchmarks. The full suite still runs through the nightly orchestrator.
+runs the short async suite after each main-branch merge touching TorchRL,
+benchmarks or the DreamerV3 example. The full suite still runs through the nightly
+orchestrator.
 The [async trend dashboard](https://pytorch.org/rl/dev/bench/async/) appears after
 the first successful main run. Each point links to its source commit. Branch
 runs produce the same summary and downloadable artifacts without publishing to
@@ -82,17 +83,22 @@ individual changes and detect regressions.
 
 `test_dreamer_v3_async_training[backend-ratio]` (`test_dreamer_v3_benchmark.py`)
 measures the `sota-implementations/dreamer_v3` example end to end. The example
-runs unmodified in a child process, so changes to its training loop, replay
-write-back, inference wiring or process setup show up here without a dedicated
-micro-benchmark. The workload is `bench_dreamer_v3_env.py`: eight environment
-processes producing 3 x 64 x 64 uint8 pixels, an 8-float vector and three boolean
+runs unmodified in a child process using the fixed `dreamer_v3.yaml` benchmark
+configuration, independent of the example defaults. Changes to its training loop,
+replay write-back and inference wiring show up here. The workload is
+`bench_dreamer_v3_env.py`: eight environment processes producing 3 x 64 x 64 uint8
+pixels, an 8-float vector and three boolean
 milestones, with one-millisecond steps, six discrete actions and episode lengths
 staggered by environment index. Collection is asynchronous with shared-memory
 exchange and one environment per worker; the learner runs eagerly on the GPU
 (`optimization.compile=off`) with a small network configuration, replay batches of
-16 sequences of 32 records and replay context write-back enabled.
+16 sequences of 32 records and replay context write-back enabled. Inference is
+limited to one request per batch: the current thread backend can mix exploration
+contexts while the learner runs, causing larger batches to fail. Keep this limit
+fixed after the bug is resolved; the collection-only series measures batched
+inference.
 
-| Series | Learner updates per collected record | Emphasis |
+| Series | Learner updates per collected batch | Emphasis |
 | --- | --- | --- |
 | `ratio2` | `train_ratio=2`: one update per 256-transition batch | collection path, driver overhead |
 | `ratio16` | `train_ratio=16`: eight updates per batch | learner step, replay sampling and write-back |
@@ -107,10 +113,9 @@ two warm-up rounds of 1,024 environment steps pass unmeasured, then five
 measured rounds each wait for the next 1,024 steps to be logged. Setup, process
 startup, replay warm-up and the final shutdown stay outside the measurement.
 The summary reports frames per second like the other series; the raw JSON adds
-learner updates per second, updates per round and the process-tree RSS. The
-pinned lock adds `hydra-core` and `omegaconf` for the example; no other series
-imports them, so the v1 trend continues. CUDA-graph inference batches stay
-disabled in this workload.
+learner updates per second, total measured updates and the process-tree RSS. The
+pinned lock includes `hydra-core` and `omegaconf` for the example. CUDA-graph
+inference batches stay disabled in this workload.
 
 ## Reading results
 
@@ -158,7 +163,8 @@ To rerun the complete nightly workload, choose `suite: full`.
 Merging a pull request that carries the `benchmarks/trigger` label dispatches
 the full suite on main immediately (`benchmarks_post_merge.yml`), so the merge
 gets a trend point without waiting for the nightly sample. The short async
-suite still runs on every main merge touching `torchrl/` or `benchmarks/`.
+suite also runs on main merges touching `torchrl/`, `benchmarks/` or
+`sota-implementations/dreamer_v3/`.
 
 Locally, install `benchmarks/requirements.txt` and run from the repository:
 
@@ -174,11 +180,10 @@ Repeat in three separate processes with filenames `async-1.json` through
 `async-3.json`, then run
 `python .github/scripts/summarize_async_benchmarks.py <results-directory> --summary summary.md`.
 
-Merge this benchmark/CI change before #4269 to record the current eager baseline.
-Then review #4269, #4271 and #4272 in order. Their graph, grouping and coordination
-changes appear against the continuing eager series. Replay integration follows
-#4273, #4274 and #4275; it must retain these collection workloads and introduce
-separately named replay-inclusive series if the measured operation changes.
+Merge the benchmark additions and record a successful main-branch run before
+merging #4304, #4305, #4306, #4307 or #4308. Keep the workload fixed while those
+changes land; the process-inference series starts when #4304 exposes its config
+option, alongside the continuing thread-inference baseline.
 
 ## CI health and publication
 

--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -51,6 +51,16 @@ becomes public in #4272. They keep one environment per worker because that
 transport rejects grouped workers. The same workload and batching limits apply;
 these remain separate series alongside the grouped integrated curve.
 
+`async-process-slots-integrated` is the cumulative curve of the direct-transport
+pipeline, the counterpart of `async-shm-integrated`. It keeps one environment per
+worker (the transport rejects grouped workers), enables static inference batches
+on GPU when that option is available, and sends 64 transitions per worker message
+once `AsyncBatchedCollector` accepts `transition_chunk_size`; before that it
+matches `async-process-slots`. Each point records its configuration in the
+`execution` field, so a step in this series can be attributed to the option that
+changed. Use the fixed `async-process-slots*` series to separate the individual
+changes.
+
 `test_async_collection_pixels_64_envs[mode]` adds a separate CUDA acceptance
 comparison for `async-shm` and `async-process-slots`: 64 environments, one per
 worker, with the same CNN plus two 1024-wide layers, one-millisecond environment
@@ -67,6 +77,40 @@ measurement budget remain fixed. Each point records the execution configuration
 in its tooltip, summary and raw JSON. These explicit configuration transitions
 show the combined pipeline as features land; use the fixed modes to separate
 individual changes and detect regressions.
+
+## DreamerV3 training series
+
+`test_dreamer_v3_async_training[backend-ratio]` (`test_dreamer_v3_benchmark.py`)
+measures the `sota-implementations/dreamer_v3` example end to end. The example
+runs unmodified in a child process, so changes to its training loop, replay
+write-back, inference wiring or process setup show up here without a dedicated
+micro-benchmark. The workload is `bench_dreamer_v3_env.py`: eight environment
+processes producing 3 x 64 x 64 uint8 pixels, an 8-float vector and three boolean
+milestones, with one-millisecond steps, six discrete actions and episode lengths
+staggered by environment index. Collection is asynchronous with shared-memory
+exchange and one environment per worker; the learner runs eagerly on the GPU
+(`optimization.compile=off`) with a small network configuration, replay batches of
+16 sequences of 32 records and replay context write-back enabled.
+
+| Series | Learner updates per collected record | Emphasis |
+| --- | --- | --- |
+| `ratio2` | `train_ratio=2`: one update per 256-transition batch | collection path, driver overhead |
+| `ratio16` | `train_ratio=16`: eight updates per batch | learner step, replay sampling and write-back |
+
+`thread` serves the acting policy from the training process; `process` serves it
+from a dedicated inference process and skips until the example exposes
+`collector.inference_backend`. The series are CUDA-only.
+
+Throughput is read from the example's own metrics log (`logger.metrics_jsonl`,
+one `train` record per 256-transition batch): after the first learner update,
+two warm-up rounds of 1,024 environment steps pass unmeasured, then five
+measured rounds each wait for the next 1,024 steps to be logged. Setup, process
+startup, replay warm-up and the final shutdown stay outside the measurement.
+The summary reports frames per second like the other series; the raw JSON adds
+learner updates per second, updates per round and the process-tree RSS. The
+pinned lock adds `hydra-core` and `omegaconf` for the example; no other series
+imports them, so the v1 trend continues. CUDA-graph inference batches stay
+disabled in this workload.
 
 ## Reading results
 
@@ -121,7 +165,8 @@ Locally, install `benchmarks/requirements.txt` and run from the repository:
 ```sh
 OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 PYTHONHASHSEED=0 python -m pytest \
   benchmarks/test_envs_benchmark.py benchmarks/test_collectors_benchmark.py \
-  -k 'async_env_pool or async_collection_pixels' --timeout=300 \
+  benchmarks/test_dreamer_v3_benchmark.py \
+  -k 'async_env_pool or async_collection_pixels or dreamer_v3_async' --timeout=300 \
   --benchmark-only --benchmark-save-data --benchmark-json=async-1.json
 ```
 

--- a/benchmarks/bench_dreamer_v3_env.py
+++ b/benchmarks/bench_dreamer_v3_env.py
@@ -1,0 +1,102 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Fixed fake image-and-vector workload for the DreamerV3 training benchmark.
+
+The environment is importable by name from environment worker processes and by
+the example's ``env.factory`` option (``bench_dreamer_v3_env:make_env``). Keep
+its observation layout and step cost stable: the continuous benchmark compares
+revisions on this exact workload (see ASYNC_BENCHMARKS.md).
+"""
+from __future__ import annotations
+
+import time
+
+import torch
+from tensordict import TensorDict
+
+from torchrl.data import Bounded, Composite, OneHot, Unbounded
+from torchrl.envs import EnvBase
+
+PIXEL_SHAPE = (3, 64, 64)
+VECTOR_DIM = 8
+NUM_MILESTONES = 3
+
+
+class FakePixelEnv(EnvBase):
+    """Uint8 pixels, a float vector and boolean milestones with a fixed step cost.
+
+    Episode lengths are staggered by ``env_index`` so resets are not
+    synchronized across environments. Rewards depend on the chosen action, so
+    the learner sees a non-degenerate target.
+    """
+
+    def __init__(
+        self,
+        *,
+        seed: int | None = None,
+        env_index: int = 0,
+        num_envs: int = 1,
+        episode_length: int = 200,
+        num_actions: int = 6,
+        step_latency_s: float = 0.001,
+    ):
+        super().__init__(device="cpu", batch_size=torch.Size([]))
+        self.observation_spec = Composite(
+            pixels=Bounded(0, 255, PIXEL_SHAPE, dtype=torch.uint8),
+            vector=Unbounded((VECTOR_DIM,)),
+            obtained=Unbounded((NUM_MILESTONES,), dtype=torch.bool),
+            shape=(),
+        )
+        self.action_spec = OneHot(num_actions, dtype=torch.float32)
+        self.reward_spec = Unbounded((1,))
+        self.episode_length = episode_length + 7 * (env_index % max(num_envs, 1))
+        self.step_latency_s = step_latency_s
+        self._t = 0
+        self._set_seed(seed)
+
+    def _set_seed(self, seed: int | None):
+        self.rng = torch.Generator().manual_seed(0 if seed is None else int(seed))
+
+    def _observation(self) -> TensorDict:
+        return TensorDict(
+            {
+                "pixels": torch.randint(
+                    0, 256, PIXEL_SHAPE, generator=self.rng, dtype=torch.uint8
+                ),
+                "vector": torch.randn(VECTOR_DIM, generator=self.rng),
+                "obtained": torch.tensor(
+                    [
+                        self._t > self.episode_length // 4,
+                        self._t > self.episode_length // 2,
+                        self._t > 3 * self.episode_length // 4,
+                    ]
+                ),
+            },
+            [],
+        )
+
+    def _reset(self, tensordict=None, **kwargs) -> TensorDict:
+        self._t = 0
+        observation = self._observation()
+        observation.set("done", torch.zeros(1, dtype=torch.bool))
+        observation.set("terminated", torch.zeros(1, dtype=torch.bool))
+        return observation
+
+    def _step(self, tensordict: TensorDict) -> TensorDict:
+        if self.step_latency_s > 0:
+            time.sleep(self.step_latency_s)
+        self._t += 1
+        observation = self._observation()
+        action = tensordict["action"].float().argmax(-1, keepdim=True)
+        observation.set("reward", 0.1 * action.float())
+        done = torch.tensor([self._t >= self.episode_length])
+        observation.set("done", done)
+        observation.set("terminated", done)
+        return observation
+
+
+def make_env(*, seed, env_index, num_envs, **kwargs) -> FakePixelEnv:
+    """``env.factory`` entry point of the DreamerV3 example."""
+    return FakePixelEnv(seed=seed, env_index=env_index, num_envs=num_envs, **kwargs)

--- a/benchmarks/bench_dreamer_v3_env.py
+++ b/benchmarks/bench_dreamer_v3_env.py
@@ -5,7 +5,7 @@
 """Fixed fake image-and-vector workload for the DreamerV3 training benchmark.
 
 The environment is importable by name from environment worker processes and by
-the example's ``env.factory`` option (``bench_dreamer_v3_env:make_env``). Keep
+the example's ``env.factory`` option (``bench_dreamer_v3_env:FakePixelEnv``). Keep
 its observation layout and step cost stable: the continuous benchmark compares
 revisions on this exact workload (see ASYNC_BENCHMARKS.md).
 """
@@ -95,8 +95,3 @@ class FakePixelEnv(EnvBase):
         observation.set("done", done)
         observation.set("terminated", done)
         return observation
-
-
-def make_env(*, seed, env_index, num_envs, **kwargs) -> FakePixelEnv:
-    """``env.factory`` entry point of the DreamerV3 example."""
-    return FakePixelEnv(seed=seed, env_index=env_index, num_envs=num_envs, **kwargs)

--- a/benchmarks/dreamer_v3.yaml
+++ b/benchmarks/dreamer_v3.yaml
@@ -1,0 +1,132 @@
+# Fixed workload for test_dreamer_v3_benchmark.py.
+# Keep independent of the example defaults so their changes cannot move the baseline.
+# Changing this workload requires a new benchmark series.
+env:
+  backend: custom
+  name: fake-pixels
+  task: null
+  seed: 0
+  use_seed: true
+  max_episode_steps: 1000  # Keep above the staggered episode lengths.
+  factory: bench_dreamer_v3_env:FakePixelEnv
+  factory_kwargs:
+    episode_length: 200
+    num_actions: 6
+    step_latency_s: 0.001
+  vector_key: vector
+  pixels_key: pixels
+  milestone_key: obtained
+  milestone_names: [quarter, half, three_quarters]
+
+collector:
+  backend: async
+  async_env_backend: multiprocessing
+  env_exchange: shm
+  envs_per_worker: 1
+  policy_device: null
+  # Single-request inference avoids mixed exploration contexts in the current
+  # thread backend. Keep fixed after that bug is resolved; the collection-only
+  # series covers batched inference.
+  inference_max_batch_size: 1
+  inference_min_batch_size: 1
+  inference_timeout: 0.01
+  inference_static_batch_size: null
+  num_envs: 8
+  frames_per_batch: 256
+  total_frames: -1
+  count_reset_records: false
+  exploration: random
+
+replay_buffer:
+  device: cpu
+  buffer_size: 16384
+  batch_size: 16
+  seq_len: 32
+  online: true
+  warmup_factor: 1
+
+networks:
+  rnn_hidden_dim: 256
+  num_categoricals: 8
+  num_classes: 8
+  unimix: 0.01
+  recurrent_model: block_gru
+  num_blocks: 8
+  dynamics_layers: 1
+  prior_layers: 2
+  posterior_layers: 1
+  norm_eps: 0.0001
+  decoder_event_dims: null
+  num_reward_bins: 255
+  num_value_bins: 255
+  hidden_dim: 128
+  encoder_layers: 1
+  decoder_layers: 1
+  reward_layers: 1
+  actor_layers: 2
+  value_layers: 2
+  policy_min_std: 0.1
+  policy_max_std: 1.0
+  image_depth: 16
+  image_mults: [2, 3, 4, 4]
+  image_kernel_size: 5
+  image_decoder_blocks: 8
+
+optimization:
+  device: cuda:0
+  deferred_policy_sync: false
+  separate_policy_rng: false
+  mixed_precision: false
+  compile: 'off'  # Exclude compilation time and its variance.
+  compile_train_step: null
+  compile_train_step_mode: default
+  compile_rssm: null
+  rssm_scan_unroll: 8
+  cudagraph_train_step: null
+  sync_timers: false
+  collection_warmup_seconds: 0
+  max_time: 600.0  # Safety ceiling; the harness stops after its measured rounds.
+  checkpoint_dir: null
+  checkpoint_every: 1000
+  checkpoint_keep_last: 2
+  checkpoint_include_replay: false
+  resume_from: null
+  lr: 4.0e-05
+  optimizer_eps: 1.0e-20
+  adaptive_grad_clip: 0.3
+  warmup_steps: 1000
+  updates_per_batch: 8
+  train_ratio: 2
+  imagination_horizon: 15
+  continuation_horizon: 333
+  use_reinforce: true
+  return_normalization_rate: 0.01
+  return_normalization_min_scale: 1.0
+  slow_critic_regularization: 1.0
+  slow_critic_tau: 0.02
+  replay_value_loss_weight: 0.3
+  free_bits: 1.0
+  dynamic_loss_weight: 1.0
+  representation_loss_weight: 0.1
+  gamma: 1.0
+  lmbda: 0.95
+
+logger:
+  train_every: 256
+  eval_every: 0
+  eval_episodes: 3
+  output_plot: null
+  metrics_jsonl: metrics.jsonl
+  backend: null
+  log_dir: logs
+  project: torchrl-dreamer-v3
+  entity: null
+  base_url: null
+  exp_name: null
+  group: null
+  tags: []
+  mode: online
+
+hydra:
+  job:
+    chdir: false

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -8,3 +8,5 @@ pandas
 numpy
 matplotlib
 psutil
+hydra-core
+omegaconf

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -70,6 +70,7 @@ class _ResetLatencyPixelEnv(PixelMockEnv):
         "async-shm-integrated",
         "async-shm-grouped",
         "async-process-slots",
+        "async-process-slots-integrated",
         pytest.param("async-shm-static", marks=pytest.mark.gpu),
         pytest.param("async-process-slots-static", marks=pytest.mark.gpu),
     ],
@@ -98,12 +99,24 @@ def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None
     use_process = mode.startswith("async-process-slots")
     if use_process and not hasattr(inference_server, "ProcessSlotTransport"):
         pytest.skip("Direct process slots are not available on this revision")
-    integrated = mode == "async-shm-integrated"
+    integrated = mode in ("async-shm-integrated", "async-process-slots-integrated")
     use_static = mode in ("async-shm-static", "async-process-slots-static") or (
         integrated and device != "cpu" and has_static
     )
     group_size = (
-        4 if mode == "async-shm-grouped" or (integrated and has_grouping) else 1
+        4
+        if mode == "async-shm-grouped"
+        or (mode == "async-shm-integrated" and has_grouping)
+        else 1
+    )
+    # The direct-transport curve adopts chunked worker results once the
+    # collector accepts them; one transition per message before that.
+    chunk_size = (
+        64
+        if mode == "async-process-slots-integrated"
+        and "transition_chunk_size"
+        in inspect.signature(AsyncBatchedCollector).parameters
+        else 1
     )
     if use_static:
         if device == "cpu":
@@ -173,6 +186,8 @@ def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None
                     num_slots=num_envs,
                 )
                 config["service_backend"] = "process"
+                if chunk_size > 1:
+                    process_options["transition_chunk_size"] = chunk_size
             collector = AsyncBatchedCollector(
                 factories,
                 policy_factory=policy_factory,
@@ -219,6 +234,7 @@ def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None
             execution=(
                 f"{'graph' if use_static else 'eager'}; {group_size} envs/worker"
                 + ("; process acting" if use_process else "")
+                + (f"; {chunk_size} transitions/message" if chunk_size > 1 else "")
             ),
             num_envs=num_envs,
             frames_per_batch=frames_per_batch,

--- a/benchmarks/test_dreamer_v3_benchmark.py
+++ b/benchmarks/test_dreamer_v3_benchmark.py
@@ -1,0 +1,298 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Continuous benchmark of the DreamerV3 example's asynchronous training loop.
+
+The example runs unmodified in a child process on a fixed fake pixel workload
+(``bench_dreamer_v3_env.py``). Throughput is read from the example's own
+metrics log, so setup, process startup and replay warm-up stay outside the
+measured rounds. See ASYNC_BENCHMARKS.md ("DreamerV3 training series") before
+changing any input.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import psutil
+import pytest
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_DIR = REPO_ROOT / "sota-implementations" / "dreamer_v3"
+BENCHMARK_DIR = Path(__file__).resolve().parent
+
+NUM_ENVS = 8
+FRAMES_PER_BATCH = 256
+ROUND_FRAMES = 1024
+WARMUP_ROUNDS = 2
+MEASURED_ROUNDS = 5
+START_TIMEOUT_S = 180.0
+ROUND_TIMEOUT_S = 120.0
+
+# Runs the example's entry point without Hydra's command line, as the
+# checkpoint-resume test does.
+_RUNNER = """\
+from __future__ import annotations
+import runpy
+import sys
+from pathlib import Path
+from omegaconf import OmegaConf
+if __name__ == "__main__":
+    sys.path.insert(0, sys.argv[3])
+    sys.path.insert(0, str(Path(sys.argv[1]).parent))
+    example = runpy.run_path(sys.argv[1])
+    example["main"].__wrapped__(OmegaConf.load(sys.argv[2]))
+"""
+
+
+def _benchmark_config(
+    *, inference_backend: str, train_ratio: float, device: str, metrics: Path
+):
+    from omegaconf import OmegaConf
+
+    cfg = OmegaConf.load(EXAMPLE_DIR / "config.yaml")
+    if inference_backend != "thread" and "inference_backend" not in cfg.collector:
+        pytest.skip(
+            "collector.inference_backend is not available in the example on this revision"
+        )
+    # Keep these inputs stable across merges: they define the series.
+    cfg.env.backend = "custom"
+    cfg.env.name = "fake-pixels"
+    cfg.env.factory = "bench_dreamer_v3_env:make_env"
+    cfg.env.factory_kwargs = {
+        "episode_length": 200,
+        "num_actions": 6,
+        "step_latency_s": 0.001,
+    }
+    # Episode lengths are set by the environment; the step limit must not cut them.
+    cfg.env.max_episode_steps = 1000
+    cfg.env.vector_key = "vector"
+    cfg.env.pixels_key = "pixels"
+    cfg.env.milestone_key = "obtained"
+    cfg.env.milestone_names = ["quarter", "half", "three_quarters"]
+    cfg.collector.backend = "async"
+    cfg.collector.async_env_backend = "multiprocessing"
+    cfg.collector.env_exchange = "shm"
+    cfg.collector.envs_per_worker = 1
+    cfg.collector.num_envs = NUM_ENVS
+    cfg.collector.frames_per_batch = FRAMES_PER_BATCH
+    cfg.collector.total_frames = -1
+    if inference_backend != "thread":
+        cfg.collector.inference_backend = inference_backend
+    cfg.replay_buffer.device = "cpu"
+    cfg.replay_buffer.buffer_size = NUM_ENVS * 2048
+    cfg.replay_buffer.batch_size = 16
+    cfg.replay_buffer.seq_len = 32
+    cfg.replay_buffer.online = True
+    cfg.replay_buffer.warmup_factor = 1
+    cfg.networks.rnn_hidden_dim = 256
+    cfg.networks.num_categoricals = 8
+    cfg.networks.num_classes = 8
+    cfg.networks.hidden_dim = 128
+    cfg.networks.encoder_layers = 1
+    cfg.networks.decoder_layers = 1
+    cfg.networks.actor_layers = 2
+    cfg.networks.value_layers = 2
+    cfg.networks.image_depth = 16
+    cfg.optimization.device = device
+    # The eager learner keeps the series free of compilation time and its variance.
+    cfg.optimization.compile = "off"
+    cfg.optimization.train_ratio = train_ratio
+    # Safety ceiling only: the benchmark stops the run after the measured rounds.
+    cfg.optimization.max_time = 600.0
+    cfg.logger.backend = None
+    cfg.logger.metrics_jsonl = str(metrics)
+    cfg.logger.train_every = FRAMES_PER_BATCH
+    cfg.logger.eval_every = 0
+    cfg.logger.output_plot = None
+    return cfg
+
+
+class _MetricsTail:
+    """Incrementally read the example's JSON-lines metrics file."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._offset = 0
+        self._partial = b""
+        self.latest_train: dict | None = None
+
+    def poll(self) -> dict | None:
+        if not self.path.exists():
+            return self.latest_train
+        with self.path.open("rb") as handle:
+            handle.seek(self._offset)
+            chunk = handle.read()
+        self._offset += len(chunk)
+        lines = (self._partial + chunk).split(b"\n")
+        self._partial = lines.pop()
+        for line in lines:
+            if line.strip():
+                record = json.loads(line)
+                if record.get("type") == "train":
+                    self.latest_train = record
+        return self.latest_train
+
+
+def _log_tail(path: Path, lines: int = 40) -> str:
+    if not path.exists():
+        return ""
+    return "\n".join(path.read_text(errors="replace").splitlines()[-lines:])
+
+
+def _wait_for_train_record(tail, process, log_path, predicate, timeout_s):
+    deadline = time.monotonic() + timeout_s
+    while True:
+        record = tail.poll()
+        if record is not None and predicate(record):
+            return record
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"The example exited with code {process.returncode}:\n"
+                f"{_log_tail(log_path)}"
+            )
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"The example made no progress within {timeout_s} s:\n"
+                f"{_log_tail(log_path)}"
+            )
+        time.sleep(0.002)
+
+
+def _stop(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    children = []
+    try:
+        children = psutil.Process(process.pid).children(recursive=True)
+    except psutil.Error:
+        pass
+    # The example finishes the current batch and shuts its collector down.
+    process.send_signal(signal.SIGTERM)
+    try:
+        process.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=30)
+    for child in children:
+        try:
+            child.kill()
+        except psutil.Error:
+            pass
+
+
+def _run_training_benchmark(
+    benchmark, *, inference_backend: str, train_ratio: float, device: str, tmp_path
+):
+    for module in ("hydra", "omegaconf"):
+        if importlib.util.find_spec(module) is None:
+            pytest.skip(f"The DreamerV3 example requires {module}")
+    metrics = tmp_path / "metrics.jsonl"
+    cfg = _benchmark_config(
+        inference_backend=inference_backend,
+        train_ratio=train_ratio,
+        device=device,
+        metrics=metrics,
+    )
+    from omegaconf import OmegaConf
+
+    config_path = tmp_path / "config.yaml"
+    OmegaConf.save(cfg, config_path)
+    runner = tmp_path / "run_example.py"
+    runner.write_text(_RUNNER)
+    log_path = tmp_path / "example.log"
+    tail = _MetricsTail(metrics)
+    with log_path.open("w") as log:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(runner),
+                str(EXAMPLE_DIR / "train.py"),
+                str(config_path),
+                str(BENCHMARK_DIR),
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            cwd=str(tmp_path),
+        )
+    try:
+        first = _wait_for_train_record(
+            tail,
+            process,
+            log_path,
+            lambda record: record["updates"] > 0,
+            START_TIMEOUT_S,
+        )
+        start = first["environment_steps"] + WARMUP_ROUNDS * ROUND_FRAMES
+        warm = _wait_for_train_record(
+            tail,
+            process,
+            log_path,
+            lambda record: record["environment_steps"] >= start,
+            WARMUP_ROUNDS * ROUND_TIMEOUT_S,
+        )
+        progress = {"target": start + ROUND_FRAMES, "updates": warm["updates"]}
+        measured_start = time.perf_counter()
+        updates_before = progress["updates"]
+
+        def measured_round():
+            record = _wait_for_train_record(
+                tail,
+                process,
+                log_path,
+                lambda record: record["environment_steps"] >= progress["target"],
+                ROUND_TIMEOUT_S,
+            )
+            progress["target"] += ROUND_FRAMES
+            progress["updates"] = record["updates"]
+
+        benchmark.pedantic(measured_round, rounds=MEASURED_ROUNDS, iterations=1)
+        measured_seconds = time.perf_counter() - measured_start
+        updates = progress["updates"] - updates_before
+        rss = 0
+        try:
+            tree = psutil.Process(process.pid)
+            rss = sum(
+                member.memory_info().rss
+                for member in [tree, *tree.children(recursive=True)]
+            )
+        except psutil.Error:
+            pass
+        benchmark.extra_info.update(
+            execution=(
+                f"eager learner on {device}; {inference_backend} inference; "
+                f"train ratio {train_ratio:g}; {NUM_ENVS} envs"
+            ),
+            num_envs=NUM_ENVS,
+            frames_per_batch=FRAMES_PER_BATCH,
+            transitions=ROUND_FRAMES,
+            warmup_rounds=WARMUP_ROUNDS,
+            measured_rounds=MEASURED_ROUNDS,
+            learner_updates=updates,
+            learner_updates_per_s=updates / measured_seconds,
+            process_tree_rss_bytes=rss,
+        )
+    finally:
+        _stop(process)
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+@pytest.mark.parametrize("train_ratio", [2, 16], ids=["ratio2", "ratio16"])
+@pytest.mark.parametrize("inference_backend", ["thread", "process"])
+def test_dreamer_v3_async_training(benchmark, inference_backend, train_ratio, tmp_path):
+    """Fixed end-to-end training series; see ASYNC_BENCHMARKS.md before changing inputs."""
+    _run_training_benchmark(
+        benchmark,
+        inference_backend=inference_backend,
+        train_ratio=train_ratio,
+        device="cuda:0",
+        tmp_path=tmp_path,
+    )

--- a/benchmarks/test_dreamer_v3_benchmark.py
+++ b/benchmarks/test_dreamer_v3_benchmark.py
@@ -14,104 +14,55 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Literal
 
 import psutil
 import pytest
 import torch
 
+_has_hydra = importlib.util.find_spec("hydra") is not None
+_has_omegaconf = importlib.util.find_spec("omegaconf") is not None
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EXAMPLE_DIR = REPO_ROOT / "sota-implementations" / "dreamer_v3"
 BENCHMARK_DIR = Path(__file__).resolve().parent
 
-NUM_ENVS = 8
-FRAMES_PER_BATCH = 256
 ROUND_FRAMES = 1024
 WARMUP_ROUNDS = 2
 MEASURED_ROUNDS = 5
 START_TIMEOUT_S = 180.0
 ROUND_TIMEOUT_S = 120.0
 
-# Runs the example's entry point without Hydra's command line, as the
-# checkpoint-resume test does.
-_RUNNER = """\
-from __future__ import annotations
-import runpy
-import sys
-from pathlib import Path
-from omegaconf import OmegaConf
-if __name__ == "__main__":
-    sys.path.insert(0, sys.argv[3])
-    sys.path.insert(0, str(Path(sys.argv[1]).parent))
-    example = runpy.run_path(sys.argv[1])
-    example["main"].__wrapped__(OmegaConf.load(sys.argv[2]))
-"""
-
 
 def _benchmark_config(
-    *, inference_backend: str, train_ratio: float, device: str, metrics: Path
+    *,
+    inference_backend: Literal["thread", "process"],
+    train_ratio: float,
+    device: str,
+    metrics: Path,
 ):
+    if not (_has_hydra and _has_omegaconf):
+        pytest.skip("The DreamerV3 example requires hydra-core and omegaconf")
     from omegaconf import OmegaConf
 
-    cfg = OmegaConf.load(EXAMPLE_DIR / "config.yaml")
-    if inference_backend != "thread" and "inference_backend" not in cfg.collector:
+    example_cfg = OmegaConf.load(EXAMPLE_DIR / "config.yaml")
+    has_backend = "inference_backend" in example_cfg.collector
+    if inference_backend != "thread" and not has_backend:
         pytest.skip(
             "collector.inference_backend is not available in the example on this revision"
         )
-    # Keep these inputs stable across merges: they define the series.
-    cfg.env.backend = "custom"
-    cfg.env.name = "fake-pixels"
-    cfg.env.factory = "bench_dreamer_v3_env:make_env"
-    cfg.env.factory_kwargs = {
-        "episode_length": 200,
-        "num_actions": 6,
-        "step_latency_s": 0.001,
-    }
-    # Episode lengths are set by the environment; the step limit must not cut them.
-    cfg.env.max_episode_steps = 1000
-    cfg.env.vector_key = "vector"
-    cfg.env.pixels_key = "pixels"
-    cfg.env.milestone_key = "obtained"
-    cfg.env.milestone_names = ["quarter", "half", "three_quarters"]
-    cfg.collector.backend = "async"
-    cfg.collector.async_env_backend = "multiprocessing"
-    cfg.collector.env_exchange = "shm"
-    cfg.collector.envs_per_worker = 1
-    cfg.collector.num_envs = NUM_ENVS
-    cfg.collector.frames_per_batch = FRAMES_PER_BATCH
-    cfg.collector.total_frames = -1
-    if inference_backend != "thread":
+    cfg = OmegaConf.load(BENCHMARK_DIR / "dreamer_v3.yaml")
+    if has_backend:
         cfg.collector.inference_backend = inference_backend
-    cfg.replay_buffer.device = "cpu"
-    cfg.replay_buffer.buffer_size = NUM_ENVS * 2048
-    cfg.replay_buffer.batch_size = 16
-    cfg.replay_buffer.seq_len = 32
-    cfg.replay_buffer.online = True
-    cfg.replay_buffer.warmup_factor = 1
-    cfg.networks.rnn_hidden_dim = 256
-    cfg.networks.num_categoricals = 8
-    cfg.networks.num_classes = 8
-    cfg.networks.hidden_dim = 128
-    cfg.networks.encoder_layers = 1
-    cfg.networks.decoder_layers = 1
-    cfg.networks.actor_layers = 2
-    cfg.networks.value_layers = 2
-    cfg.networks.image_depth = 16
     cfg.optimization.device = device
-    # The eager learner keeps the series free of compilation time and its variance.
-    cfg.optimization.compile = "off"
     cfg.optimization.train_ratio = train_ratio
-    # Safety ceiling only: the benchmark stops the run after the measured rounds.
-    cfg.optimization.max_time = 600.0
-    cfg.logger.backend = None
     cfg.logger.metrics_jsonl = str(metrics)
-    cfg.logger.train_every = FRAMES_PER_BATCH
-    cfg.logger.eval_every = 0
-    cfg.logger.output_plot = None
     return cfg
 
 
@@ -189,11 +140,13 @@ def _stop(process: subprocess.Popen) -> None:
 
 
 def _run_training_benchmark(
-    benchmark, *, inference_backend: str, train_ratio: float, device: str, tmp_path
+    benchmark,
+    *,
+    inference_backend: Literal["thread", "process"],
+    train_ratio: float,
+    device: str,
+    tmp_path: Path,
 ):
-    for module in ("hydra", "omegaconf"):
-        if importlib.util.find_spec(module) is None:
-            pytest.skip(f"The DreamerV3 example requires {module}")
     metrics = tmp_path / "metrics.jsonl"
     cfg = _benchmark_config(
         inference_backend=inference_backend,
@@ -205,22 +158,28 @@ def _run_training_benchmark(
 
     config_path = tmp_path / "config.yaml"
     OmegaConf.save(cfg, config_path)
-    runner = tmp_path / "run_example.py"
-    runner.write_text(_RUNNER)
     log_path = tmp_path / "example.log"
     tail = _MetricsTail(metrics)
     with log_path.open("w") as log:
         process = subprocess.Popen(
             [
                 sys.executable,
-                str(runner),
                 str(EXAMPLE_DIR / "train.py"),
-                str(config_path),
-                str(BENCHMARK_DIR),
+                "--config-path",
+                str(tmp_path),
+                "--config-name",
+                "config",
+                f"hydra.run.dir={tmp_path}",
             ],
             stdout=log,
             stderr=subprocess.STDOUT,
             cwd=str(tmp_path),
+            env={
+                **os.environ,
+                "PYTHONPATH": os.pathsep.join(
+                    [str(BENCHMARK_DIR), os.environ.get("PYTHONPATH", "")]
+                ),
+            },
         )
     try:
         first = _wait_for_train_record(
@@ -268,10 +227,11 @@ def _run_training_benchmark(
         benchmark.extra_info.update(
             execution=(
                 f"eager learner on {device}; {inference_backend} inference; "
-                f"train ratio {train_ratio:g}; {NUM_ENVS} envs"
+                f"train ratio {train_ratio:g}; {cfg.collector.num_envs} envs; "
+                f"inference batch <= {cfg.collector.inference_max_batch_size}"
             ),
-            num_envs=NUM_ENVS,
-            frames_per_batch=FRAMES_PER_BATCH,
+            num_envs=cfg.collector.num_envs,
+            frames_per_batch=cfg.collector.frames_per_batch,
             transitions=ROUND_FRAMES,
             warmup_rounds=WARMUP_ROUNDS,
             measured_rounds=MEASURED_ROUNDS,
@@ -296,3 +256,7 @@ def test_dreamer_v3_async_training(benchmark, inference_backend, train_ratio, tm
         device="cuda:0",
         tmp_path=tmp_path,
     )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])


### PR DESCRIPTION
Establish continuous baselines before #4304, #4305, #4306, #4307 and #4308 merge.

- Add an integrated process-slot collection series that adopts static inference and chunked results as those options become available.
- Benchmark the DreamerV3 training loop on a fixed pixel workload, with low/high training ratios and thread/process inference. Process inference skips until the example supports it.
- Pin the training configuration independently of example defaults, trigger benchmarks on DreamerV3 changes, add the required Hydra dependencies, and retry snapshot package installation failures.

The training series uses an eager CUDA learner and inference batches of one to avoid the current mixed exploration-context failure. Batched inference remains covered by the collector series. Startup, warm-up and shutdown are excluded from timing. Workload and measurement details are in [`benchmarks/ASYNC_BENCHMARKS.md`](https://github.com/pytorch/rl/blob/async-collector-benchmark/benchmarks/ASYNC_BENCHMARKS.md).

Validation: 10 reporting tests, formatting/lint, environment checks, and a CPU `thread-ratio2` harness run with five measured rounds, 20 learner updates and graceful shutdown. [CUDA validation is running](https://github.com/pytorch/rl/actions/runs/34331912977).

Merge this first, then wait for a successful main-branch baseline before merging the follow-ups.
