### PR TITLE
[Feature] Fast asynchronous defaults for AsyncBatchedCollector and DreamerV3

### DIFF
--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -52,6 +52,11 @@ becomes public in #4272. They keep one environment per worker because that
 transport rejects grouped workers. The same workload and batching limits apply;
 these remain separate series alongside the grouped integrated curve.
 
+The fixed series pin what the collector now resolves on its own: the thread-server
+modes pass `transport="thread"` and the process-slot modes pass an explicit
+`transition_chunk_size` (`1` except for the chunked series), so a change of the
+collector defaults cannot move them.
+
 `async-process-slots-integrated` is the cumulative curve of the direct-transport
 pipeline, the counterpart of `async-shm-integrated`. It keeps one environment per
 worker (the transport rejects grouped workers), enables static inference batches

--- a/benchmarks/ASYNC_BENCHMARKS.md
+++ b/benchmarks/ASYNC_BENCHMARKS.md
@@ -53,7 +53,7 @@ transport rejects grouped workers. The same workload and batching limits apply;
 these remain separate series alongside the grouped integrated curve.
 
 The fixed series pin what the collector now resolves on its own: the thread-server
-modes pass `transport="thread"` and the process-slot modes pass an explicit
+modes pass `transport="driver"` and the process-slot modes pass an explicit
 `transition_chunk_size` (`1` except for the chunked series), so a change of the
 collector defaults cannot move them.
 

--- a/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
+++ b/benchmarks/ad_hoc/bench_dreamer_v3_learner.py
@@ -105,6 +105,10 @@ class _ReplayLearnerStep:
         records_per_stream = sequence_records * cfg.replay_buffer.batch_size
         cfg.replay_buffer.buffer_size = records_per_stream * num_streams
         cfg.replay_buffer.online = False
+        # The workload extends the batched layout of the synchronous collector;
+        # the example's default backend resolves to asynchronous collection on
+        # CPU and CUDA, which routes records by environment index instead.
+        cfg.collector.backend = "sync"
         self.replay_buffer = example["_build_replay"](
             cfg, num_streams, replay_device, device
         )

--- a/benchmarks/bench_collectors.py
+++ b/benchmarks/bench_collectors.py
@@ -828,6 +828,9 @@ def main() -> None:
                                 total_frames=-1,
                                 env_backend="multiprocessing",
                                 env_exchange=args.env_exchange,
+                                # Driver-mediated process server; process slots are
+                                # the separate backend below.
+                                transport="driver",
                                 server_config=InferenceServerConfig(
                                     service_backend="process",
                                     max_batch_size=max_batch_size,

--- a/benchmarks/dreamer_v3.yaml
+++ b/benchmarks/dreamer_v3.yaml
@@ -28,6 +28,9 @@ collector:
   # thread backend. Keep fixed after that bug is resolved; the collection-only
   # series covers batched inference.
   inference_max_batch_size: 1
+  # The harness sets inference_backend per series; chunking follows the
+  # collector default so the process series measures the shipped configuration.
+  transition_chunk_size: auto
   inference_min_batch_size: 1
   inference_timeout: 0.01
   inference_static_batch_size: null

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -195,9 +195,9 @@ def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None
                 # default is "auto".
                 process_options["transition_chunk_size"] = chunk_size
             else:
-                # The fixed thread-server series keep the driver-side server
+                # The fixed thread-server series keep the driver-mediated transport
                 # explicitly, so a change of the collector default cannot move them.
-                process_options["transport"] = "thread"
+                process_options["transport"] = "driver"
             collector = AsyncBatchedCollector(
                 factories,
                 policy_factory=policy_factory,

--- a/benchmarks/test_collectors_benchmark.py
+++ b/benchmarks/test_collectors_benchmark.py
@@ -191,8 +191,13 @@ def _benchmark_async_collection_pixels(benchmark, mode, regime, *, num_envs=None
                     num_slots=num_envs,
                 )
                 config["service_backend"] = "process"
-                if chunk_size > 1:
-                    process_options["transition_chunk_size"] = chunk_size
+                # Fixed series pin one transition per message; the collector
+                # default is "auto".
+                process_options["transition_chunk_size"] = chunk_size
+            else:
+                # The fixed thread-server series keep the driver-side server
+                # explicitly, so a change of the collector default cannot move them.
+                process_options["transport"] = "thread"
             collector = AsyncBatchedCollector(
                 factories,
                 policy_factory=policy_factory,

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -187,41 +187,48 @@ Kubernetes CPU Manager considerations.
   idle time.
 - Supports ``yield_completed_trajectories=True`` for episode-level yields.
 
-For many fixed-schema CPU environments, set ``env_backend="multiprocessing"``
-and ``env_exchange="shm"``. The collector then drains ready shared-memory slots
-in batches from one coordinator thread, while keeping faster environments
+For many fixed-schema CPU environments, set ``env_backend="multiprocessing"``.
+The default exchange (``env_exchange="auto"``) then uses shared memory whenever
+the environment schema allows, and the collector drains ready shared-memory
+slots in batches from one coordinator thread while keeping faster environments
 independent of slower ones. This path is intended for environments whose step
 latency dominates its millisecond-scale coordinator polling interval.
 
 When both environment stepping and inference should leave the driver process,
-pass a :class:`~torchrl.modules.inference_server.ProcessSlotTransport` together
-with ``env_backend="multiprocessing"`` and an
-:class:`~torchrl.modules.inference_server.InferenceServerConfig` whose
-``service_backend`` is ``"process"``. Each environment process then performs
-its own reset/infer/step loop against a fixed shared-memory inference slot; the
-driver receives completed transitions only. This mode bounds completed and
-in-flight transitions together to twice the environment count. Workers park
-before reserving capacity when the driver stops consuming, and ``pause()``
-still works with a full buffer. Environment workers are daemonic and both the
-workers and inference server exit if their owning process dies, including
-while environment or policy calls are blocked. Call ``shutdown()`` for normal
-cleanup; abrupt owner death cannot guarantee environment cleanup hooks run.
-Environment factories in this mode must not start multiprocessing children.
+pass ``transport="auto"`` together with ``env_backend="multiprocessing"`` and a
+``policy_factory``. The collector derives the fixed request and response
+layouts from one environment's ``fake_tensordict()`` and one policy pass, builds
+a :class:`~torchrl.modules.inference_server.ProcessSlotTransport` and serves the
+policy from a dedicated process. Each environment process then performs its own
+reset/infer/step loop against a fixed shared-memory inference slot; the driver
+receives completed transitions only. When the conditions do not hold (threaded
+environment workers, grouped workers, no ``policy_factory``, or a policy whose
+inputs the environment does not produce), the policy is served from a thread of
+the driver process and the reason is logged. A pre-built
+:class:`~torchrl.modules.inference_server.ProcessSlotTransport` can be passed
+instead; it implies the process inference server and multiprocessing workers.
+In v0.15 ``transport="auto"`` becomes the default; until then the collector
+emits a :class:`FutureWarning` when the default would change its behavior.
+This mode bounds completed and in-flight transitions together to twice the
+environment count. Workers park before reserving capacity when the driver stops
+consuming, and ``pause()`` still works with a full buffer. Environment workers
+are daemonic and both the workers and inference server exit if their owning
+process dies, including while environment or policy calls are blocked. Call
+``shutdown()`` for normal cleanup; abrupt owner death cannot guarantee
+environment cleanup hooks run. Environment factories in this mode must not start
+multiprocessing children.
 
-By default each worker sends every transition as its own message, and the
-driver unpickles, stacks and writes them one at a time. When many environments
-feed a replay buffer this per-transition work can leave the driver as the
-bottleneck while the environments wait for result capacity. Set
-``transition_chunk_size`` (for example ``64``) so that each worker accumulates
-that many consecutive transitions and sends them as one dense message. The
-driver then receives one message per chunk, concatenates whole chunks into each
-batch and performs a single routed replay write per batch, so its cost per
-transition is amortized over the chunk. Transitions reach the driver only once
-their chunk is complete, so pick a chunk size that keeps this delay acceptable
-for the environment step time; up to ``transition_chunk_size - 1`` transitions
-per environment remain in the worker while collection is paused or stopped.
-Chunked batches are dense :class:`~tensordict.TensorDict` instances whose
-``env_index`` is a tensor.
+With process workers, ``transition_chunk_size="auto"`` (the default) makes each
+worker accumulate ``frames_per_batch // num_envs`` consecutive transitions and
+send them as one dense message, so every batch holds one contiguous run per
+environment, the layout of the synchronous collectors, and a transition waits at
+most one batch. The driver then receives one message per chunk, concatenates
+whole chunks into each batch and performs a single routed replay write per
+batch, so its cost per transition is amortized over the chunk. Pass ``1`` to
+send every transition as soon as it completes, or a larger value to amortize
+further; up to ``transition_chunk_size - 1`` transitions per environment remain
+in the worker while collection is paused or stopped. Chunked batches are dense
+:class:`~tensordict.TensorDict` instances whose ``env_index`` is a tensor.
 
 Scaling ``Collector`` across local processes
 --------------------------------------------

--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -112,6 +112,7 @@ and a **policy** -- all internal wiring is handled automatically:
         frames_per_batch=200,
         total_frames=10000,
         max_batch_size=8,
+        env_backend="multiprocessing",
     )
 
     for data in collector:
@@ -207,8 +208,10 @@ inputs the environment does not produce), the policy is served from a thread of
 the driver process and the reason is logged. A pre-built
 :class:`~torchrl.modules.inference_server.ProcessSlotTransport` can be passed
 instead; it implies the process inference server and multiprocessing workers.
-In v0.15 ``transport="auto"`` becomes the default; until then the collector
-emits a :class:`FutureWarning` when the default would change its behavior.
+``transport="driver"`` keeps the driver-mediated path explicitly: coordinator
+threads relay requests to the transport derived from ``policy_backend``. In
+v0.15 ``transport="auto"`` becomes the default; until then the collector emits
+a :class:`FutureWarning` when the default would change its behavior.
 This mode bounds completed and in-flight transitions together to twice the
 environment count. Workers park before reserving capacity when the driver stops
 consuming, and ``pause()`` still works with a full buffer. Environment workers

--- a/docs/source/reference/modules_inference_server.rst
+++ b/docs/source/reference/modules_inference_server.rst
@@ -284,6 +284,7 @@ drive the collector-side transfers:
         create_env_fn=[make_env] * 8,
         policy=my_policy,
         frames_per_batch=200,
+        env_backend="multiprocessing",
         server_config=InferenceServerConfig(max_batch_size=8, timeout=0.005),
         device_config=InferenceDeviceConfig(
             policy_device="cuda:0",
@@ -367,6 +368,7 @@ creates the server, transport, and env pool automatically:
         frames_per_batch=200,
         total_frames=10_000,
         max_batch_size=8,
+        env_backend="multiprocessing",
     )
 
     for data in collector:

--- a/examples/collectors/async_batched_collector.py
+++ b/examples/collectors/async_batched_collector.py
@@ -53,6 +53,9 @@ def main():
         frames_per_batch=frames_per_batch,
         total_frames=total_frames,
         max_batch_size=num_envs,
+        # Environment workers as processes; the shared-memory exchange is picked
+        # automatically for this fixed-shape environment.
+        env_backend="multiprocessing",
         device="cpu",
     )
 

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -63,11 +63,20 @@ before uniform fallback; `false` uses regular uniform `SliceSampler` sampling.
 Both modes sample `seq_len + 1` transitions so the learner can train on the
 first `seq_len` and conditionally refresh the following records' latent state.
 
-Set `collector.backend=async` to use `AsyncBatchedCollector`; the default is the
-synchronous `Collector`. `collector.async_env_backend` selects `threading` or
-`multiprocessing` for asynchronous environments. In both cases collection
-post-processing, episode reporting, device normalization, and replay writes
-happen through the collector's standard replay integration.
+`collector.backend=auto` (the default) uses `AsyncBatchedCollector` with
+multiprocessing environment workers on CPU and CUDA training devices, and the
+synchronous `Collector` on other devices: MPS cannot run the acting policy in a
+server thread or share its weights with another process. `sync` and `async`
+force one of the two; an explicit `async` on MPS needs `collector.policy_device=cpu`.
+With the asynchronous collector,
+`collector.inference_backend=auto` (the default) serves the acting policy from a
+dedicated process that the environment workers reach directly whenever
+`collector.async_env_backend=multiprocessing` and `collector.envs_per_worker=1`,
+and from a thread of the training process otherwise; `thread` and `process`
+force one of the two. `collector.transition_chunk_size=auto` sends one
+contiguous run per environment and batch from each worker process. In both
+backends collection post-processing, episode reporting, device normalization,
+and replay writes happen through the collector's standard replay integration.
 
 For a three-seed median and interquartile reproduction run:
 
@@ -220,9 +229,7 @@ env:
   milestone_key: [episode, milestones]
   milestone_names: [started, completed]
 collector:
-  backend: async
   async_env_backend: multiprocessing
-  env_exchange: shm
   envs_per_worker: 4
 ```
 
@@ -246,7 +253,8 @@ episode. Their boolean vector must match `milestone_names`. Both synchronous and
 asynchronous runs log these flags with episode returns. Imagination runs only in
 latent state and does not require real sensor or milestone observations.
 
-Asynchronous collection supports `env_exchange`, `envs_per_worker`, a separate
+Asynchronous collection supports `env_exchange` (`auto` picks shared memory
+whenever the environment schema allows), `envs_per_worker`, a separate
 `policy_device`, and the existing inference batch size/timeout settings. Setting
 `inference_static_batch_size` enables fixed-size CUDA-graph policy batches and
 requires a CUDA policy device. The default maximum inference batch size remains

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -330,8 +330,12 @@ before new transitions arrive, and incomplete episode returns restart at zero.
 Initial reset records are counted again when reset-record reporting is enabled.
 Queued collector results that were not emitted are not checkpointed. The acting
 policy is rebuilt from the restored learner; when using a separate policy RNG,
-its saved module state and counter are then restored. Consequently resumed
-trajectories are not promised to match an uninterrupted run. Without a replay payload,
+its saved module state and counter are then restored. With process inference
+(`collector.inference_backend=auto` where it applies, or `process`), the
+inference process rebuilds the policy on its device and receives the restored
+weights before it serves the first request, but the separate policy RNG counter
+stays in the training process, so the served stream restarts from the seed.
+Consequently resumed trajectories are not promised to match an uninterrupted run. Without a replay payload,
 collection refills native replay before training continues, without accumulating
 a catch-up update burst. Counters and logger identity still continue.
 

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -15,10 +15,21 @@ env:
   milestone_names: []
 
 collector:
-  backend: sync  # one of: sync, async
-  async_env_backend: threading  # one of: threading, multiprocessing
-  env_exchange: queue
+  # auto runs asynchronous collection on CPU and CUDA training devices and the
+  # synchronous collector elsewhere (MPS cannot serve the policy off-thread).
+  backend: auto  # one of: auto, sync, async
+  async_env_backend: multiprocessing  # one of: threading, multiprocessing
+  env_exchange: auto  # one of: auto, queue, shm
   envs_per_worker: 1
+  # Where the acting policy runs with the async collector. auto serves it from a
+  # dedicated process that the environment workers reach directly when
+  # async_env_backend is multiprocessing with one environment per worker, and
+  # from a thread of this process otherwise; thread and process force one of the
+  # two.
+  inference_backend: auto  # one of: auto, thread, process
+  # Consecutive transitions per environment-worker message with the process
+  # backend; auto sends one contiguous run per environment and batch.
+  transition_chunk_size: auto
   policy_device: null
   inference_max_batch_size: null  # null uses num_envs
   inference_min_batch_size: 1

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -40,6 +40,7 @@ from torchrl.modules import (
     DreamerV3ImageDecoder,
     DreamerV3ImageEncoder,
     DreamerV3MLP,
+    DreamerV3SeededPolicy,
     RSSMStateEstimatorV3,
     SymExpTwoHot,
     WorldModelWrapper,
@@ -652,6 +653,39 @@ def build_actor(
         ),
     )
     return actor_model
+
+
+def build_serving_policy(
+    cfg: dict,
+    obs_dim: int,
+    action_dim: int,
+    pixels_shape: tuple[int, int, int] | None,
+    discrete: bool,
+) -> TensorDictModuleBase:
+    """Build the acting policy inside an inference server process.
+
+    A picklable zero-argument factory is made with :func:`functools.partial`
+    over the resolved configuration container; the server moves the policy to
+    its device and receives the learner's weights through the collector's
+    policy-update path.
+    """
+    cfg = OmegaConf.create(cfg)
+    world_model, *_ = build_world_model(
+        cfg=cfg,
+        obs_dim=obs_dim,
+        action_dim=action_dim,
+        pixels_shape=pixels_shape,
+        compile_rollout=False,
+    )
+    actor_model = build_actor(cfg=cfg, action_dim=action_dim, discrete=discrete)
+    policy = build_real_world_actor(
+        world_model=world_model,
+        actor_model=actor_model,
+        mixed_precision=cfg.optimization.mixed_precision,
+    )
+    if cfg.optimization.separate_policy_rng:
+        policy = DreamerV3SeededPolicy(policy, cfg.env.seed)
+    return policy
 
 
 def build_real_world_actor(

--- a/sota-implementations/dreamer_v3/dreamer_v3_agent.py
+++ b/sota-implementations/dreamer_v3/dreamer_v3_agent.py
@@ -661,28 +661,30 @@ def build_serving_policy(
     action_dim: int,
     pixels_shape: tuple[int, int, int] | None,
     discrete: bool,
+    device: torch.device | str,
 ) -> TensorDictModuleBase:
     """Build the acting policy inside an inference server process.
 
     A picklable zero-argument factory is made with :func:`functools.partial`
-    over the resolved configuration container; the server moves the policy to
-    its device and receives the learner's weights through the collector's
-    policy-update path.
+    over the resolved configuration container. The modules are created
+    directly on ``device``, the server's policy device, and receive the
+    learner's weights through the collector's policy-update path.
     """
     cfg = OmegaConf.create(cfg)
-    world_model, *_ = build_world_model(
-        cfg=cfg,
-        obs_dim=obs_dim,
-        action_dim=action_dim,
-        pixels_shape=pixels_shape,
-        compile_rollout=False,
-    )
-    actor_model = build_actor(cfg=cfg, action_dim=action_dim, discrete=discrete)
-    policy = build_real_world_actor(
-        world_model=world_model,
-        actor_model=actor_model,
-        mixed_precision=cfg.optimization.mixed_precision,
-    )
+    with torch.device(device):
+        world_model, *_ = build_world_model(
+            cfg=cfg,
+            obs_dim=obs_dim,
+            action_dim=action_dim,
+            pixels_shape=pixels_shape,
+            compile_rollout=False,
+        )
+        actor_model = build_actor(cfg=cfg, action_dim=action_dim, discrete=discrete)
+        policy = build_real_world_actor(
+            world_model=world_model,
+            actor_model=actor_model,
+            mixed_precision=cfg.optimization.mixed_precision,
+        )
     if cfg.optimization.separate_policy_rng:
         policy = DreamerV3SeededPolicy(policy, cfg.env.seed)
     return policy

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -985,8 +985,8 @@ def main(cfg: DictConfig):
     reset_records = int(run_state.get("reset_records", 0)) + num_envs
     record_step = action_step + reset_records if count_reset_records else action_step
     update_step = int(run_state.get("updates", 0))
-    running_training_return = torch.zeros(num_envs)
-    seen_stream = torch.zeros(num_envs, dtype=torch.bool)
+    running_training_return = torch.zeros(num_envs, device="cpu")
+    seen_stream = torch.zeros(num_envs, dtype=torch.bool, device="cpu")
     completed_episodes: list[tuple[int, int, float]] = []
     completed_milestones: list[list[bool]] = []
     milestone_key = _normalize_hydra_key(cfg.env.milestone_key)
@@ -1015,7 +1015,9 @@ def main(cfg: DictConfig):
         if env_index is None:
             # Report synchronous episodes in time-major, then environment order.
             is_init = is_init.reshape(num_envs, -1).t().reshape(-1)
-            env_index = torch.arange(num_envs).repeat(data.numel() // num_envs)
+            env_index = torch.arange(num_envs, device="cpu").repeat(
+                data.numel() // num_envs
+            )
         else:
             env_index = env_index.reshape(-1).cpu()
         batch_reset_prefix.clear()

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -36,6 +36,7 @@ from dreamer_v3_agent import (
     build_imagination_model,
     build_mb_env,
     build_real_world_actor,
+    build_serving_policy,
     build_value,
     build_world_model,
     DreamerV3BehaviorPolicySync,
@@ -299,8 +300,8 @@ def _validated_action_budget(cfg: DictConfig) -> int:
         raise ValueError(f"collector.num_envs must be positive, got {num_envs}.")
     if cfg.collector.backend not in ("sync", "async"):
         raise ValueError(
-            "collector.backend must be 'sync' or 'async', got "
-            f"{cfg.collector.backend!r}."
+            "collector.backend must be 'sync' or 'async' ('auto' is resolved from "
+            f"the training device before this check), got {cfg.collector.backend!r}."
         )
     if cfg.collector.backend == "sync" and cfg.collector.frames_per_batch % num_envs:
         raise ValueError(
@@ -474,6 +475,56 @@ def _build_learner(
     )
 
 
+def _resolve_collector_backend(cfg: DictConfig, device: torch.device) -> str:
+    """Resolve ``collector.backend``; ``auto`` picks asynchronous collection where it runs.
+
+    The asynchronous collector serves the acting policy from a server thread or
+    process. MPS cannot run the policy outside the main thread and cannot share
+    weights with another process, so it keeps the synchronous collector.
+    """
+    backend = cfg.collector.backend
+    if backend == "auto":
+        return "async" if device.type in ("cpu", "cuda") else "sync"
+    return backend
+
+
+def _process_inference_possible(cfg: DictConfig, device: torch.device) -> bool:
+    """Whether environment workers can reach a dedicated inference process directly.
+
+    The learner's weights cross the process boundary as shared CPU storage or
+    CUDA IPC handles, so other accelerators keep the policy in this process.
+    """
+    policy_device = torch.device(cfg.collector.policy_device or device)
+    return (
+        cfg.collector.async_env_backend == "multiprocessing"
+        and cfg.collector.envs_per_worker == 1
+        and policy_device.type in ("cpu", "cuda")
+        and device.type in ("cpu", "cuda")
+    )
+
+
+def _serves_rebuilt_policy(cfg: DictConfig, device: torch.device) -> bool:
+    """Whether the async collector rebuilds the acting policy from the configuration.
+
+    The rebuilt policy starts from its own initialization and receives the
+    learner's weights through the collector's policy-update path.
+    """
+    inference_backend = cfg.collector.inference_backend
+    return inference_backend == "process" or (
+        inference_backend == "auto" and _process_inference_possible(cfg, device)
+    )
+
+
+def _behavior_policy_weights(
+    cfg: DictConfig, learner: _Learner
+) -> TensorDictBase | TensorDictModuleBase:
+    """The learner's acting weights in the layout of the served policy."""
+    policy_weights = learner.real_world_actor
+    if cfg.optimization.separate_policy_rng:
+        return TensorDict({"module": TensorDict.from_module(policy_weights)}, [])
+    return policy_weights
+
+
 def _build_collection(
     cfg: DictConfig,
     device: torch.device,
@@ -483,6 +534,10 @@ def _build_collection(
     collector_action_frames: int,
     replay_buffer: ReplayBufferEnsemble,
     post_collect_hook: Callable[[TensorDictBase], None],
+    *,
+    obs_dim: int,
+    pixels_shape: tuple[int, int, int] | None,
+    discrete: bool,
 ) -> tuple[Collector | AsyncBatchedCollector, DreamerV3BehaviorPolicySync | None]:
     num_envs = cfg.collector.num_envs
     collector_backend = cfg.collector.backend
@@ -560,12 +615,42 @@ def _build_collection(
         ),
     }
     if collector_backend == "async":
+        inference_backend = cfg.collector.inference_backend
+        if inference_backend not in ("auto", "thread", "process"):
+            raise ValueError(
+                "collector.inference_backend must be 'auto', 'thread' or 'process', "
+                f"got {inference_backend!r}."
+            )
+        if inference_backend == "process" and not _process_inference_possible(
+            cfg, device
+        ):
+            raise ValueError(
+                "collector.inference_backend='process' requires "
+                "collector.async_env_backend=multiprocessing, "
+                "collector.envs_per_worker=1 and a CPU or CUDA policy device."
+            )
+        if _serves_rebuilt_policy(cfg, device):
+            # The inference process rebuilds the policy from the configuration
+            # and receives the learner's weights through update_policy_weights_.
+            policy_kwargs = {
+                "policy_factory": ft.partial(
+                    build_serving_policy,
+                    OmegaConf.to_container(cfg, resolve=True),
+                    obs_dim,
+                    action_dim,
+                    pixels_shape,
+                    discrete,
+                ),
+                "transport": "auto",
+            }
+        else:
+            policy_kwargs = {"policy": collector_policy, "transport": "thread"}
         collector = AsyncBatchedCollector(
             create_env_fns,
-            policy=collector_policy,
             env_backend=cfg.collector.async_env_backend,
             env_exchange=cfg.collector.env_exchange,
             envs_per_worker=cfg.collector.envs_per_worker,
+            transition_chunk_size=cfg.collector.transition_chunk_size,
             server_config=InferenceServerConfig(
                 max_batch_size=cfg.collector.inference_max_batch_size or num_envs,
                 min_batch_size=cfg.collector.inference_min_batch_size,
@@ -579,8 +664,16 @@ def _build_collection(
                 storing_device="cpu",
             ),
             policy_version_key=None,
+            **policy_kwargs,
             **collector_kwargs,
         )
+        if inference_backend == "process" and collector.server_backend != "process":
+            collector.shutdown()
+            raise RuntimeError(
+                "collector.inference_backend='process' could not serve the policy "
+                "from environment worker processes; see the torchrl log for the "
+                "reason."
+            )
     else:
         collector = Collector(
             SerialEnv(num_envs, create_env_fns),
@@ -615,11 +708,12 @@ def _build_replay(
         )
 
     sampler_type = StreamingSliceSampler if cfg.replay_buffer.online else SliceSampler
+    collector_backend = _resolve_collector_backend(cfg, device)
     # Async collection stores one environment per stream: with the stream as
     # the trajectory, sequences may span an episode end (the rollout resets on
     # the stored is_init flags), so terminal transitions and episodes shorter
     # than a sequence reach the learner.
-    traj_key = "env_index" if cfg.collector.backend == "async" else None
+    traj_key = "env_index" if collector_backend == "async" else None
     members = [
         TensorDictReplayBuffer(
             storage=LazyTensorStorage(capacity, device=replay_device),
@@ -644,8 +738,8 @@ def _build_replay(
         *members,
         p="sampleable",
         num_buffer_sampled=cfg.replay_buffer.batch_size,
-        routing_key="env_index" if cfg.collector.backend == "async" else None,
-        routing_dim=0 if cfg.collector.backend == "sync" else None,
+        routing_key="env_index" if collector_backend == "async" else None,
+        routing_dim=0 if collector_backend == "sync" else None,
         batch_size=cfg.replay_buffer.batch_size * sequence_records,
         generator=generator,
         pin_memory=replay_device.type == "cpu" and device.type == "cuda",
@@ -796,6 +890,12 @@ def main(cfg: DictConfig):
     replay_device = (
         torch.device(cfg.replay_buffer.device) if cfg.replay_buffer.device else device
     )
+    collector_backend = _resolve_collector_backend(cfg, device)
+    if collector_backend != cfg.collector.backend:
+        torchrl_logger.info(
+            "collector.backend=auto resolved to %s for %s.", collector_backend, device
+        )
+    cfg.collector.backend = collector_backend
     use_bfloat16 = cfg.optimization.mixed_precision and device.type == "cuda"
     compile_settings = resolve_compile_settings(cfg, device)
     torchrl_logger.info(
@@ -937,6 +1037,9 @@ def main(cfg: DictConfig):
         else -1,
         rb,
         post_collect_hook,
+        obs_dim=obs_dim,
+        pixels_shape=pixels_shape,
+        discrete=discrete,
     )
 
     history_steps: list[int] = []
@@ -1048,6 +1151,15 @@ def main(cfg: DictConfig):
         for _ in collector:
             if collection_timer is None:
                 collection_timer = timeit("dreamer_v3/collection", sync=False).start()
+                if isinstance(
+                    collector, AsyncBatchedCollector
+                ) and _serves_rebuilt_policy(cfg, device):
+                    # The served policy was rebuilt from the configuration and
+                    # only starts with the first batch; give it the learner's
+                    # weights before any update.
+                    collector.update_policy_weights_(
+                        _behavior_policy_weights(cfg, learner)
+                    )
             # The collector writes canonical transitions directly into replay.
             if behavior_policy_sync is not None:
                 behavior_policy_sync.apply_after_action()
@@ -1131,12 +1243,7 @@ def main(cfg: DictConfig):
                 update_step += 1
 
             if isinstance(collector, AsyncBatchedCollector):
-                policy_weights = learner.real_world_actor
-                if cfg.optimization.separate_policy_rng:
-                    policy_weights = TensorDict(
-                        {"module": TensorDict.from_module(policy_weights)}, []
-                    )
-                collector.update_policy_weights_(policy_weights)
+                collector.update_policy_weights_(_behavior_policy_weights(cfg, learner))
 
             if record_loss_history:
                 loss_history.append(batch_losses.cpu())

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -630,8 +630,9 @@ def _build_collection(
                 "collector.envs_per_worker=1 and a CPU or CUDA policy device."
             )
         if _serves_rebuilt_policy(cfg, device):
-            # The inference process rebuilds the policy from the configuration
-            # and receives the learner's weights through update_policy_weights_.
+            # The inference process rebuilds the policy from the configuration,
+            # directly on its device, and receives the learner's weights through
+            # update_policy_weights_.
             policy_kwargs = {
                 "policy_factory": ft.partial(
                     build_serving_policy,
@@ -640,6 +641,7 @@ def _build_collection(
                     action_dim,
                     pixels_shape,
                     discrete,
+                    torch.device(cfg.collector.policy_device or device),
                 ),
                 "transport": "auto",
             }
@@ -1041,6 +1043,14 @@ def main(cfg: DictConfig):
         pixels_shape=pixels_shape,
         discrete=discrete,
     )
+    if isinstance(collector, AsyncBatchedCollector) and _serves_rebuilt_policy(
+        cfg, device
+    ):
+        # The served policy was rebuilt from the configuration. The collector
+        # applies these weights, restored ones after a resume, when its server
+        # starts and before the first request, so no batch is collected with
+        # the factory's initialization.
+        collector.update_policy_weights_(_behavior_policy_weights(cfg, learner))
 
     history_steps: list[int] = []
     history_eval: list[torch.Tensor] = []
@@ -1151,15 +1161,6 @@ def main(cfg: DictConfig):
         for _ in collector:
             if collection_timer is None:
                 collection_timer = timeit("dreamer_v3/collection", sync=False).start()
-                if isinstance(
-                    collector, AsyncBatchedCollector
-                ) and _serves_rebuilt_policy(cfg, device):
-                    # The served policy was rebuilt from the configuration and
-                    # only starts with the first batch; give it the learner's
-                    # weights before any update.
-                    collector.update_policy_weights_(
-                        _behavior_policy_weights(cfg, learner)
-                    )
             # The collector writes canonical transitions directly into replay.
             if behavior_policy_sync is not None:
                 behavior_policy_sync.apply_after_action()

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -976,7 +976,9 @@ def main(cfg: DictConfig):
             checkpoint.load(resume_path, components={"replay"})
             rb.end_streams()
             replay_restored = True
-        replay_rng.set_state(torch.tensor(run_state["replay_rng"], dtype=torch.uint8))
+        replay_rng.set_state(
+            torch.tensor(run_state["replay_rng"], dtype=torch.uint8, device="cpu")
+        )
         rb.set_rng(replay_rng)
     action_offset = int(run_state.get("action_steps", 0))
     action_step = action_offset

--- a/sota-implementations/dreamer_v3/train.py
+++ b/sota-implementations/dreamer_v3/train.py
@@ -646,7 +646,7 @@ def _build_collection(
                 "transport": "auto",
             }
         else:
-            policy_kwargs = {"policy": collector_policy, "transport": "thread"}
+            policy_kwargs = {"policy": collector_policy, "transport": "driver"}
         collector = AsyncBatchedCollector(
             create_env_fns,
             env_backend=cfg.collector.async_env_backend,

--- a/test/modules/test_dreamer_components.py
+++ b/test/modules/test_dreamer_components.py
@@ -532,7 +532,28 @@ class TestDreamerV3Components:
                 for name, value in actor.named_parameters()
             )
 
-    def test_policy_rng_and_update_ratio_checkpoint(self, tmp_path):
+    @pytest.mark.parametrize(
+        "device",
+        [
+            "cpu",
+            pytest.param(
+                "mps",
+                marks=pytest.mark.skipif(
+                    not torch.backends.mps.is_available(), reason="needs MPS"
+                ),
+            ),
+            pytest.param(
+                "cuda",
+                marks=[
+                    pytest.mark.gpu,
+                    pytest.mark.skipif(
+                        not torch.cuda.is_available(), reason="needs CUDA"
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_policy_rng_and_update_ratio_checkpoint(self, tmp_path, device):
         policy = DreamerV3SeededPolicy(
             DreamerV3DiscreteActor(
                 6,
@@ -542,11 +563,11 @@ class TestDreamerV3Components:
                 in_keys=[("latent", "state"), ("latent", "belief")],
             ),
             seed=17,
-        )
+        ).to(device)
         data = TensorDict(
             {
-                ("latent", "state"): torch.randn(12, 4),
-                ("latent", "belief"): torch.randn(12, 2),
+                ("latent", "state"): torch.randn(12, 4, device=device),
+                ("latent", "belief"): torch.randn(12, 2, device=device),
             },
             [12],
         )
@@ -556,8 +577,18 @@ class TestDreamerV3Components:
         checkpoint = Checkpoint(policy=policy, schedule=schedule)
         checkpoint.save(tmp_path / "saved")
         caller_rng = torch.random.get_rng_state().clone()
+        accelerator_rngs = [
+            (torch.cuda, index) for index in range(torch.cuda.device_count())
+        ]
+        if torch.backends.mps.is_available():
+            accelerator_rngs.append((torch.mps, "mps"))
+        caller_accelerator_rngs = [
+            backend.get_rng_state(index).clone() for backend, index in accelerator_rngs
+        ]
         expected = [policy(data.clone())["action"] for _ in range(3)]
         assert torch.equal(torch.random.get_rng_state(), caller_rng)
+        for (backend, index), state in zip(accelerator_rngs, caller_accelerator_rngs):
+            assert torch.equal(backend.get_rng_state(index), state)
         updates = [schedule(i) for i in (8, 10, 15)]
         policy.reset_counter()
         checkpoint.load(tmp_path / "saved")

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2356,6 +2356,8 @@ def test_dreamer_v3_native_stream_replay(monkeypatch, online, count_reset_record
         run_name=f"dreamer_v3_native_replay_{online}",
     )
     cfg = OmegaConf.load(example_dir / "config.yaml")
+    # These checks build the batched layout of the synchronous collector.
+    cfg.collector.backend = "sync"
     cfg.collector.num_envs = 2
     cfg.collector.count_reset_records = count_reset_records
     cfg.collector.total_frames = 16
@@ -2432,6 +2434,8 @@ def test_dreamer_v3_replay_samples_keep_episode_starts(monkeypatch, online):
         example_dir / "train.py", run_name=f"dreamer_v3_episode_starts_{online}"
     )
     cfg = OmegaConf.load(example_dir / "config.yaml")
+    # These checks build the batched layout of the synchronous collector.
+    cfg.collector.backend = "sync"
     cfg.collector.num_envs = 1
     cfg.replay_buffer.buffer_size = 64
     cfg.replay_buffer.batch_size = 4
@@ -2684,6 +2688,8 @@ def test_dreamer_v3_native_replay_benchmark_step_cpu(monkeypatch):
         run_name="dreamer_v3_replay_benchmark_helpers_test",
     )
     cfg = OmegaConf.load(example_dir / "config.yaml")
+    # These checks build the batched layout of the synchronous collector.
+    cfg.collector.backend = "sync"
     cfg.replay_buffer.batch_size = 2
     cfg.replay_buffer.seq_len = 3
 
@@ -2911,6 +2917,9 @@ def test_dreamer_v3_checkpoint_resume_processes(
     cfg.optimization.train_ratio = 1.5
     cfg.optimization.checkpoint_include_replay = include_replay
     cfg.collector.backend = collector_backend
+    # The seeded policy state is checkpointed from the training process; a
+    # process-hosted acting policy keeps its own copy in the inference process.
+    cfg.collector.inference_backend = "thread"
     cfg.collector.num_envs = 2
     cfg.collector.frames_per_batch = 8
     cfg.collector.total_frames = 100_000 if terminate else 16
@@ -3075,6 +3084,66 @@ def test_dreamer_v3_checkpoint_resume_processes(
                     assert not is_init[:, 1:].any()
         finally:
             replay.shutdown()
+
+
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
+@pytest.mark.parametrize("separate_policy_rng", [False, True])
+def test_dreamer_v3_process_inference_collection_smoke(
+    monkeypatch, tmp_path, separate_policy_rng
+):
+    """A process-hosted inference server collects, trains and syncs weights."""
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py", run_name="dreamer_v3_process_inference"
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.optimization.device = "cpu"
+    cfg.optimization.separate_policy_rng = separate_policy_rng
+    cfg.optimization.updates_per_batch = 1
+    cfg.optimization.train_ratio = None
+    cfg.collector.backend = "async"
+    cfg.collector.async_env_backend = "multiprocessing"
+    cfg.collector.inference_backend = "process"
+    cfg.collector.envs_per_worker = 1
+    cfg.collector.num_envs = 2
+    cfg.collector.frames_per_batch = 8
+    cfg.collector.total_frames = 16
+    cfg.replay_buffer.buffer_size = 64
+    cfg.replay_buffer.batch_size = 2
+    cfg.replay_buffer.seq_len = 2
+    cfg.replay_buffer.warmup_factor = 1
+    cfg.env.backend = "custom"
+    cfg.env.factory = f"{__name__}:_DreamerV3TestEnv"
+    cfg.env.factory_kwargs = {"pixels": False, "discrete": False}
+    cfg.env.vector_key = ["sensors", "vector"]
+    cfg.env.pixels_key = None
+    cfg.env.milestone_key = ["episode", "milestones"]
+    cfg.env.milestone_names = ["started", "completed"]
+    cfg.logger.eval_every = 0
+    cfg.logger.train_every = 8
+    cfg.logger.output_plot = None
+    cfg.logger.backend = "csv"
+    cfg.logger.log_dir = str(tmp_path / "logs")
+    cfg.logger.metrics_jsonl = str(tmp_path / "metrics.jsonl")
+    example["main"].__wrapped__(cfg)
+    records = [
+        json.loads(line)
+        for line in Path(cfg.logger.metrics_jsonl).read_text().splitlines()
+    ]
+    assert records[-1]["total_action_steps"] == 16
+    assert records[-1]["updates"] > 0
+    assert any(record["type"] == "train_episode" for record in records)
+
+    cfg.collector.envs_per_worker = 2
+    with pytest.raises(ValueError, match="envs_per_worker=1"):
+        example["main"].__wrapped__(cfg)
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -3091,8 +3091,21 @@ def test_dreamer_v3_checkpoint_resume_processes(
     reason="requires hydra, omegaconf, and gym",
 )
 @pytest.mark.parametrize("separate_policy_rng", [False, True])
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        pytest.param(
+            "cuda:0",
+            marks=[
+                pytest.mark.gpu,
+                pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA"),
+            ],
+        ),
+    ],
+)
 def test_dreamer_v3_process_inference_collection_smoke(
-    monkeypatch, tmp_path, separate_policy_rng
+    monkeypatch, tmp_path, separate_policy_rng, device
 ):
     """A process-hosted inference server collects, trains and syncs weights."""
     from omegaconf import OmegaConf
@@ -3104,7 +3117,8 @@ def test_dreamer_v3_process_inference_collection_smoke(
         example_dir / "train.py", run_name="dreamer_v3_process_inference"
     )
     cfg = OmegaConf.load(example_dir / "config.yaml")
-    cfg.optimization.device = "cpu"
+    cfg.optimization.device = device
+    cfg.optimization.compile = "off"
     cfg.optimization.separate_policy_rng = separate_policy_rng
     cfg.optimization.updates_per_batch = 1
     cfg.optimization.train_ratio = None
@@ -3144,6 +3158,50 @@ def test_dreamer_v3_process_inference_collection_smoke(
     cfg.collector.envs_per_worker = 2
     with pytest.raises(ValueError, match="envs_per_worker=1"):
         example["main"].__wrapped__(cfg)
+
+
+@pytest.mark.skipif(
+    not (_has_hydra and _has_omegaconf and _has_gym),
+    reason="requires hydra, omegaconf, and gym",
+)
+@pytest.mark.parametrize("separate_policy_rng", [False, True])
+def test_dreamer_v3_behavior_policy_weights_match_served_policy(
+    monkeypatch, separate_policy_rng
+):
+    """The weights pushed to the inference process fit the rebuilt policy exactly.
+
+    A mismatch would surface as a key or shape error inside the server
+    process, not in the driver, so the layout is checked here directly.
+    """
+    from omegaconf import OmegaConf
+
+    repo_root = Path(__file__).parents[2]
+    example_dir = repo_root / "sota-implementations/dreamer_v3"
+    monkeypatch.syspath_prepend(str(example_dir))
+    example = runpy.run_path(
+        example_dir / "train.py", run_name="dreamer_v3_serving_layout"
+    )
+    cfg = OmegaConf.load(example_dir / "config.yaml")
+    cfg.optimization.device = "cpu"
+    cfg.optimization.compile = "off"
+    cfg.optimization.separate_policy_rng = separate_policy_rng
+    obs_dim, action_dim = 3, 1
+    learner = example["_build_learner"](cfg, torch.device("cpu"), obs_dim, action_dim)
+    served = example["build_serving_policy"](
+        OmegaConf.to_container(cfg, resolve=True),
+        obs_dim,
+        action_dim,
+        None,
+        False,
+        torch.device("cpu"),
+    )
+    weights = example["_behavior_policy_weights"](cfg, learner)
+    if isinstance(weights, torch.nn.Module):
+        weights = TensorDict.from_module(weights)
+    served_weights = TensorDict.from_module(served)
+    assert set(weights.keys(True, True)) == set(served_weights.keys(True, True))
+    for key, value in weights.items(True, True):
+        assert value.shape == served_weights[key].shape, key
 
 
 @pytest.mark.skipif(shutil.which("bash") is None, reason="requires bash")

--- a/test/objectives/test_dreamer_v3.py
+++ b/test/objectives/test_dreamer_v3.py
@@ -2841,8 +2841,11 @@ def test_dreamer_v3_native_replay_collection_smoke(
             for line in Path(cfg.logger.metrics_jsonl).read_text().splitlines()
         ]
         if budget == "time":
-            assert records[-1]["total_action_steps"] > 0
-            assert records[-1]["elapsed_seconds"] < 5
+            # The budget is checked after each batch, so an expired budget stops
+            # the run at the first batch. Wall time is not asserted: starting
+            # the inference and environment processes on a loaded CI runner
+            # can take longer than the budget itself.
+            assert records[-1]["total_action_steps"] == cfg.collector.frames_per_batch
         else:
             assert records[-1]["total_action_steps"] == 16
             assert (records[-1]["updates"] > 0) == (budget != "warmup")

--- a/test/rb/test_ensemble.py
+++ b/test/rb/test_ensemble.py
@@ -451,7 +451,8 @@ class TestEnsemble:
         assert members[0][:]["value"].tolist() == [0, 1]
         assert members[1][:]["value"].tolist() == [10, 11]
 
-    def test_sampleable_routing_groups_member_samples(self):
+    @pytest.mark.parametrize("default_device", ["cpu", "meta"])
+    def test_sampleable_routing_groups_member_samples(self, default_device):
         lengths = (1, 4, 8)
         samplers = [SliceSampler(slice_len=2) for _ in lengths]
         members = [
@@ -477,7 +478,8 @@ class TestEnsemble:
             generator=generator,
         )
 
-        index, _ = rb.sampler.sample(rb.storage, 2_000)
+        with torch.device(default_device):
+            index, _ = rb.sampler.sample(rb.storage, 2_000)
         counts = torch.bincount(index["buffer_ids"], minlength=3)
 
         assert counts[0] == 0

--- a/test/rb/test_ensemble.py
+++ b/test/rb/test_ensemble.py
@@ -437,17 +437,21 @@ class TestEnsemble:
         finally:
             replay.shutdown()
 
-    def test_routing_dim_preserves_member_order(self):
+    @pytest.mark.parametrize("default_device", ["cpu", "meta"])
+    def test_routing_dim_preserves_member_order(self, default_device):
         members = [self._make_routed_member() for _ in range(2)]
         rb = ReplayBufferEnsemble(*members, routing_dim=1)
         data = TensorDict(
             {"value": torch.tensor([[0, 10], [1, 11]])}, batch_size=[2, 2]
         )
 
-        metadata = rb.extend(data)
+        with torch.device(default_device):
+            metadata = rb.extend(data)
 
         assert metadata.batch_size == (4,)
         assert metadata["buffer_ids"].tolist() == [0, 1, 0, 1]
+        assert metadata["index"].tolist() == [0, 0, 1, 1]
+        assert metadata["index_generation"].tolist() == [0, 0, 0, 0]
         assert members[0][:]["value"].tolist() == [0, 1]
         assert members[1][:]["value"].tolist() == [10, 11]
 

--- a/test/rb/test_samplers.py
+++ b/test/rb/test_samplers.py
@@ -2259,32 +2259,40 @@ class TestStreamingSliceSampler:
         assert sample["collector", "mask"][:3].all()
         assert sample["collector", "mask"].shape == (6,)
 
-    def test_state_dict_restores_queue_and_pending_window(self):
-        rb = self._make_buffer()
-        rb.extend(
-            TensorDict(
-                {
-                    "obs": torch.arange(5),
-                    ("next", "done"): torch.zeros(5, 1, dtype=torch.bool),
-                },
-                [5],
+    @pytest.mark.parametrize("default_device", ["cpu", "meta"])
+    def test_state_dict_restores_queue_and_pending_window(self, default_device):
+        with torch.device(default_device):
+            rb = self._make_buffer()
+            rb.extend(
+                TensorDict(
+                    {
+                        "obs": torch.arange(5, device="cpu"),
+                        ("next", "done"): torch.zeros(
+                            5, 1, dtype=torch.bool, device="cpu"
+                        ),
+                    },
+                    [5],
+                    device="cpu",
+                )
             )
-        )
-        restored = self._make_buffer()
-        restored.load_state_dict(rb.state_dict())
-        restored.extend(
-            TensorDict(
-                {
-                    "obs": torch.arange(5, 6),
-                    ("next", "done"): torch.zeros(1, 1, dtype=torch.bool),
-                },
-                [1],
+            restored = self._make_buffer()
+            restored.load_state_dict(rb.state_dict())
+            restored.extend(
+                TensorDict(
+                    {
+                        "obs": torch.arange(5, 6, device="cpu"),
+                        ("next", "done"): torch.zeros(
+                            1, 1, dtype=torch.bool, device="cpu"
+                        ),
+                    },
+                    [1],
+                    device="cpu",
+                )
             )
-        )
 
-        sample = restored.sample()
+            sample = restored.sample()
 
-        assert sample["obs"].reshape(2, 3).tolist() == [[0, 1, 2], [3, 4, 5]]
+            assert sample["obs"].reshape(2, 3).tolist() == [[0, 1, 2], [3, 4, 5]]
 
     def test_seeded_uniform_fallback_is_deterministic(self):
         buffers = [

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -2802,6 +2802,26 @@ def _make_counting_policy():
     return _BatchCountingPolicy()
 
 
+class _ScaledCountingPolicy(TensorDictModule):
+    """Counting policy whose increment is a parameter, so weight pushes are visible."""
+
+    def __init__(self):
+        super().__init__(
+            module=nn.Module(),  # placeholder
+            in_keys=["observation"],
+            out_keys=["action"],
+        )
+        self.scale = nn.Parameter(torch.ones(()))
+
+    def forward(self, td: TensorDictBase) -> TensorDictBase:
+        obs = td.get("observation")
+        return td.set("action", torch.full_like(obs, int(self.scale.item())))
+
+
+def _make_scaled_counting_policy():
+    return _ScaledCountingPolicy()
+
+
 class _BadProcessPolicy(nn.Module):
     def forward(self, td: TensorDictBase) -> TensorDictBase:
         raise RuntimeError("process model crash")
@@ -4270,6 +4290,28 @@ class TestAsyncBatchedCollector:
                 frames_per_batch=4,
                 env_backend="multiprocessing",
             )
+            collector.shutdown()
+
+    def test_weights_pushed_before_start_reach_the_process_server(self):
+        """A policy rebuilt from a factory acts with pushed weights from its first step."""
+        trained = _ScaledCountingPolicy()
+        with torch.no_grad():
+            trained.scale.fill_(2.0)
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy_factory=_make_scaled_counting_policy,
+            transport="auto",
+            frames_per_batch=8,
+            total_frames=8,
+            env_backend="multiprocessing",
+        )
+        try:
+            assert collector.server_backend == "process"
+            # The server process does not exist yet; the update must wait for it.
+            collector.update_policy_weights_(trained)
+            batch = next(iter(collector))
+            assert batch["action"].eq(2).all()
+        finally:
             collector.shutdown()
 
     def test_process_slot_transport_implies_process_server_and_workers(self):

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -2802,6 +2802,18 @@ def _make_counting_policy():
     return _BatchCountingPolicy()
 
 
+class _MetadataCountingPolicy(_BatchCountingPolicy):
+    def __init__(self):
+        super().__init__()
+        self.out_keys = ["action", ("metadata", "label")]
+
+    def forward(self, td: TensorDictBase) -> TensorDictBase:
+        td = super().forward(td)
+        return td.set(
+            ("metadata", "label"), NonTensorData("example", batch_size=td.batch_size)
+        )
+
+
 class _ScaledCountingPolicy(TensorDictModule):
     """Counting policy whose increment is a parameter, so weight pushes are visible."""
 
@@ -4234,6 +4246,10 @@ class TestAsyncBatchedCollector:
                 },
                 "threads",
             ),
+            (
+                {"policy_factory": _MetadataCountingPolicy},
+                "NonTensorData",
+            ),
         ],
     )
     def test_auto_transport_falls_back_to_a_thread_server(
@@ -4253,7 +4269,13 @@ class TestAsyncBatchedCollector:
             assert collector.server_backend == "thread"
             assert collector._transition_chunk_size == 1
             assert reason in caplog.text
-            assert sum(batch.numel() for batch in collector) == 4
+            frames = 0
+            for batch in collector:
+                frames += batch.numel()
+                assert batch["action"].eq(1).all()
+                if options.get("policy_factory") is _MetadataCountingPolicy:
+                    assert all(row["metadata", "label"] == "example" for row in batch)
+            assert frames == 4
         finally:
             collector.shutdown()
 

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -14,6 +14,7 @@ import pickle
 import queue
 import threading
 import time
+import warnings
 
 import psutil
 import pytest
@@ -4322,6 +4323,25 @@ class TestAsyncBatchedCollector:
     def test_invalid_server_backend_raises(self):
         with pytest.raises(ValueError, match="backend"):
             InferenceServerConfig(service_backend="not-a-backend")
+
+    def test_default_env_backend_warns_before_the_multiprocessing_default(self):
+        with pytest.warns(FutureWarning, match="env_backend='multiprocessing'"):
+            collector = AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy=_make_counting_policy(),
+                frames_per_batch=4,
+            )
+        assert collector._env_backend == "threading"
+        collector.shutdown()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            collector = AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy=_make_counting_policy(),
+                frames_per_batch=4,
+                env_backend="threading",
+            )
+            collector.shutdown()
 
     def test_server_death_raises_instead_of_hanging(self):
         """Killing the server process surfaces an error in the iterator."""

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -8,6 +8,7 @@ import concurrent.futures
 import contextlib
 import functools as ft
 import importlib.util
+import logging
 import multiprocessing as mp
 import os
 import pickle
@@ -3970,6 +3971,9 @@ class TestAsyncBatchedCollector:
             frames_per_batch=12,
             total_frames=total_frames,
             env_backend="multiprocessing",
+            # One transition per message: the capacity accounting below counts
+            # transitions, not chunks.
+            transition_chunk_size=1,
             server_config=InferenceServerConfig(
                 service_backend="process", max_batch_size=num_envs
             ),
@@ -4163,6 +4167,128 @@ class TestAsyncBatchedCollector:
                 env_backend="threading",
             )
 
+    def test_auto_transport_serves_from_environment_processes(self):
+        """transport='auto' derives the slot layouts and picks process slots."""
+        num_envs = 2
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * num_envs,
+            policy_factory=_make_counting_policy,
+            transport="auto",
+            frames_per_batch=12,
+            total_frames=24,
+            env_backend="multiprocessing",
+        )
+        try:
+            assert collector._uses_process_env_workers
+            assert collector.server_backend == "process"
+            assert collector._transition_chunk_size == 12 // num_envs
+            frames = 0
+            for batch in collector:
+                frames += batch.numel()
+                assert batch["action"].eq(1).all()
+                assert "policy_version" in batch.keys()
+            assert frames == 24
+        finally:
+            collector.shutdown()
+
+    @pytest.mark.parametrize(
+        "options, reason",
+        [
+            ({"policy": _make_counting_policy()}, "policy_factory"),
+            (
+                {"policy_factory": _make_counting_policy, "envs_per_worker": 2},
+                "one environment per worker",
+            ),
+            (
+                {
+                    "policy_factory": _make_counting_policy,
+                    "env_backend": "threading",
+                },
+                "threads",
+            ),
+        ],
+    )
+    def test_auto_transport_falls_back_to_a_thread_server(
+        self, options, reason, caplog
+    ):
+        options = {"env_backend": "multiprocessing", **options}
+        with caplog.at_level(logging.INFO, logger="torchrl"):
+            collector = AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                transport="auto",
+                frames_per_batch=4,
+                total_frames=4,
+                **options,
+            )
+        try:
+            assert not collector._uses_process_env_workers
+            assert collector.server_backend == "thread"
+            assert collector._transition_chunk_size == 1
+            assert reason in caplog.text
+            assert sum(batch.numel() for batch in collector) == 4
+        finally:
+            collector.shutdown()
+
+    def test_auto_transport_falls_back_when_policy_inputs_are_missing(self, caplog):
+        policy = TensorDictModule(
+            lambda observation: observation + 1,
+            in_keys=["missing_key"],
+            out_keys=["action"],
+        )
+        with caplog.at_level(logging.INFO, logger="torchrl"):
+            collector = AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy_factory=lambda: policy,
+                transport="auto",
+                frames_per_batch=4,
+                env_backend="multiprocessing",
+            )
+        try:
+            assert not collector._uses_process_env_workers
+            assert "missing_key" in caplog.text
+        finally:
+            collector.shutdown()
+
+    def test_default_transport_warns_before_the_process_slot_default(self):
+        kwargs = {
+            "create_env_fn": [_counting_env_factory] * 2,
+            "policy_factory": _make_counting_policy,
+            "frames_per_batch": 4,
+            "env_backend": "multiprocessing",
+        }
+        with pytest.warns(FutureWarning, match="transport='auto'"):
+            collector = AsyncBatchedCollector(**kwargs)
+        collector.shutdown()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            collector = AsyncBatchedCollector(transport="thread", **kwargs)
+            collector.shutdown()
+            # Without a policy_factory the default cannot change, so no warning.
+            collector = AsyncBatchedCollector(
+                create_env_fn=[_counting_env_factory] * 2,
+                policy=_make_counting_policy(),
+                frames_per_batch=4,
+                env_backend="multiprocessing",
+            )
+            collector.shutdown()
+
+    def test_process_slot_transport_implies_process_server_and_workers(self):
+        """An explicit ProcessSlotTransport needs no server or env backend settings."""
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * 2,
+            policy_factory=_make_counting_policy,
+            transport=_counting_process_transport(2),
+            frames_per_batch=4,
+            total_frames=8,
+        )
+        try:
+            assert collector.server_backend == "process"
+            assert collector._env_backend == "multiprocessing"
+            assert collector._transition_chunk_size == 2
+            assert sum(batch.numel() for batch in collector) == 8
+        finally:
+            collector.shutdown()
+
     @pytest.mark.parametrize("failure", ["reset", "worker_death"])
     def test_process_slot_worker_failure_with_active_stream(self, failure):
         entered = mp.get_context("spawn").Event()
@@ -4291,6 +4417,10 @@ class TestAsyncBatchedCollector:
             (
                 {"device_config": InferenceDeviceConfig(env_device="cuda")},
                 "CPU env_device",
+            ),
+            (
+                {"device_config": InferenceDeviceConfig(policy_device="meta")},
+                "CPU or CUDA policy_device",
             ),
         ],
     )

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -1972,7 +1972,8 @@ class TestProcessSlotTransport:
             assert server.stats()["requests"] == 6
         assert all(result_queue.get(timeout=1.0) is True for _ in processes)
 
-    def test_batched_slot_io(self):
+    @pytest.mark.parametrize("default_device", ["cpu", "meta"])
+    def test_batched_slot_io(self, default_device):
         """Slots are gathered and scattered as batches, in the drained order."""
         request_spec = TensorDict({"agent": {"observation": torch.zeros(4)}})
         response_spec = TensorDict(
@@ -1981,7 +1982,8 @@ class TestProcessSlotTransport:
                 "policy_version": torch.zeros((), dtype=torch.long),
             }
         )
-        transport = ProcessSlotTransport(request_spec, response_spec, num_slots=4)
+        with torch.device(default_device):
+            transport = ProcessSlotTransport(request_spec, response_spec, num_slots=4)
         clients = [transport.client() for _ in range(4)]
         futures = [
             client.submit(
@@ -2000,7 +2002,8 @@ class TestProcessSlotTransport:
         assert requests.get(_REMOTE_INTERACTION_TYPE_KEY).shape == (4,)
         # Rows follow the given order, not the slot numbering, and the tail
         # rows of the staging batch stay untouched.
-        transport.gather_requests([2, 0], out=requests)
+        with torch.device(default_device):
+            transport.gather_requests([2, 0], out=requests)
         assert torch.equal(
             requests["agent", "observation"],
             torch.tensor([2.0, 0.0, 0.0, 0.0]).unsqueeze(-1).expand(4, 4),
@@ -2016,7 +2019,8 @@ class TestProcessSlotTransport:
         with pytest.raises(RuntimeError, match="batch size"):
             transport.resolve_batch([2, 0], responses[:3])
         assert not futures[2].done()
-        transport.resolve_batch([2, 0], responses[:2])
+        with torch.device(default_device):
+            transport.resolve_batch([2, 0], responses[:2])
         assert torch.equal(
             futures[2].result(timeout=1.0)["agent", "action"], torch.full((2,), 20.0)
         )

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -4306,12 +4306,12 @@ class TestAsyncBatchedCollector:
             "frames_per_batch": 4,
             "env_backend": "multiprocessing",
         }
-        with pytest.warns(FutureWarning, match="transport='auto'"):
+        with pytest.warns(FutureWarning, match="transport='driver'"):
             collector = AsyncBatchedCollector(**kwargs)
         collector.shutdown()
         with warnings.catch_warnings():
             warnings.simplefilter("error", FutureWarning)
-            collector = AsyncBatchedCollector(transport="thread", **kwargs)
+            collector = AsyncBatchedCollector(transport="driver", **kwargs)
             collector.shutdown()
             # Without a policy_factory the default cannot change, so no warning.
             collector = AsyncBatchedCollector(

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -4187,13 +4187,20 @@ class TestAsyncBatchedCollector:
                 env_backend="threading",
             )
 
-    def test_auto_transport_serves_from_environment_processes(self):
+    @pytest.mark.parametrize(
+        "batch_size, policy_version_key",
+        [((), "policy_version"), ((2,), ("collector", "policy_version"))],
+    )
+    def test_auto_transport_serves_from_environment_processes(
+        self, batch_size, policy_version_key
+    ):
         """transport='auto' derives the slot layouts and picks process slots."""
         num_envs = 2
         collector = AsyncBatchedCollector(
-            create_env_fn=[_counting_env_factory] * num_envs,
+            create_env_fn=[ft.partial(CountingEnv, batch_size=batch_size)] * num_envs,
             policy_factory=_make_counting_policy,
             transport="auto",
+            policy_version_key=policy_version_key,
             frames_per_batch=12,
             total_frames=24,
             env_backend="multiprocessing",
@@ -4206,7 +4213,8 @@ class TestAsyncBatchedCollector:
             for batch in collector:
                 frames += batch.numel()
                 assert batch["action"].eq(1).all()
-                assert "policy_version" in batch.keys()
+                assert batch[policy_version_key].shape == batch.batch_size
+                assert batch[policy_version_key].eq(0).all()
             assert frames == 24
         finally:
             collector.shutdown()

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -11,6 +11,7 @@ import os
 import queue
 import threading
 import time
+import warnings
 from collections import deque, OrderedDict
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Literal
@@ -509,7 +510,11 @@ class AsyncBatchedCollector(BaseCollector):
             environments and policy inference.  Specific overrides
             ``env_backend`` and ``policy_backend`` take precedence when set.
             One of ``"threading"``, ``"multiprocessing"``, ``"ray"``, or
-            ``"monarch"``.  Defaults to ``"threading"``.
+            ``"monarch"``.  Defaults to ``None``: environment workers run in
+            threads and inference uses the threading transport. In v0.15 the
+            environment-worker default changes to ``"multiprocessing"``; a
+            :class:`FutureWarning` is emitted until then when neither
+            ``backend`` nor ``env_backend`` is given.
         env_backend (str, optional): backend for the
             :class:`~torchrl.envs.AsyncEnvPool` that runs environments.  One
             of ``"threading"`` or ``"multiprocessing"``.  Falls back to
@@ -635,9 +640,8 @@ class AsyncBatchedCollector(BaseCollector):
         server_timeout: float | None = None,
         transport: InferenceTransport | None = None,
         device: torch.device | str | None = None,
-        backend: Literal[
-            "threading", "multiprocessing", "ray", "monarch"
-        ] = "threading",
+        backend: Literal["threading", "multiprocessing", "ray", "monarch"]
+        | None = None,
         env_backend: Literal["threading", "multiprocessing"] | None = None,
         env_exchange: Literal["queue", "shm", "auto"] = "queue",
         envs_per_worker: int = 1,
@@ -723,10 +727,25 @@ class AsyncBatchedCollector(BaseCollector):
         self._create_env_kwargs = create_env_kwargs
 
         # ---- resolve backends -------------------------------------------------
-        effective_env_backend = env_backend if env_backend is not None else backend
-        effective_policy_backend = (
-            policy_backend if policy_backend is not None else backend
-        )
+        if env_backend is not None:
+            effective_env_backend = env_backend
+        elif backend is not None:
+            effective_env_backend = backend
+        else:
+            warnings.warn(
+                "AsyncBatchedCollector runs environment workers in threads when "
+                "neither backend nor env_backend is given. In v0.15 this default "
+                "will change to env_backend='multiprocessing'. Pass "
+                "env_backend='threading' to keep the current behavior, or "
+                "env_backend='multiprocessing' to adopt the future default now.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            effective_env_backend = "threading"
+        if policy_backend is not None:
+            effective_policy_backend = policy_backend
+        else:
+            effective_policy_backend = backend if backend is not None else "threading"
         if effective_env_backend not in _ENV_BACKENDS:
             raise ValueError(
                 f"env_backend={effective_env_backend!r} is not supported. "

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -512,7 +512,8 @@ def _auto_process_slot_transport(
     response = output.select(*out_keys, strict=True).cpu()
     if policy_version_key is not None:
         response.set(
-            policy_version_key, torch.zeros(response.batch_size, dtype=torch.long)
+            policy_version_key,
+            torch.zeros(response.batch_size, dtype=torch.long, device=response.device),
         )
     try:
         transport = ProcessSlotTransport(request, response, num_slots=num_slots)

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -419,6 +419,97 @@ def _env_batch_loop(
             _put_result(result_queue, exc, shutdown_event)
 
 
+def _env_kwargs(create_env_kwargs, index: int) -> dict:
+    if create_env_kwargs is None:
+        return {}
+    if isinstance(create_env_kwargs, Mapping):
+        return dict(create_env_kwargs)
+    return dict(create_env_kwargs[index])
+
+
+def _process_slot_blocker(
+    *,
+    env_backend: str,
+    envs_per_worker: int,
+    policy_factory: Callable | None,
+    policy_backend: str | None,
+    server_backend: str,
+    policy_device: torch.device | None,
+    env_device: torch.device | None,
+    storing_device: torch.device | None,
+) -> str | None:
+    """Why environment workers cannot reach a dedicated inference process directly.
+
+    Returns ``None`` when a :class:`ProcessSlotTransport` can serve the
+    collector, otherwise a short reason for the log.
+    """
+    if env_backend != "multiprocessing":
+        return "environment workers are threads (env_backend='multiprocessing' is required)"
+    if envs_per_worker != 1:
+        return "the transport hosts one environment per worker process"
+    if policy_factory is None:
+        return (
+            "policy_factory is required to rebuild the policy in the inference process"
+        )
+    if policy_backend not in (None, "multiprocessing"):
+        return f"policy_backend={policy_backend!r} selects another inference transport"
+    if server_backend not in ("thread", "process"):
+        return f"service_backend={server_backend!r} selects another inference server"
+    if policy_device is not None and policy_device.type not in ("cpu", "cuda"):
+        # Weight updates cross process boundaries as shared CPU storage or CUDA IPC handles.
+        return (
+            f"policy_device={policy_device} cannot share weights with another process"
+        )
+    for name, target_device in (
+        ("env_device", env_device),
+        ("storing_device", storing_device),
+    ):
+        if target_device is not None and target_device.type != "cpu":
+            return f"{name}={target_device} is not a CPU device"
+    return None
+
+
+def _auto_process_slot_transport(
+    env_factory: Callable[..., EnvBase],
+    env_kwargs: dict,
+    policy: Callable,
+    *,
+    num_slots: int,
+    policy_version_key: NestedKey | None,
+) -> tuple[ProcessSlotTransport | None, str | None]:
+    """Derive fixed request and response layouts from one environment and one policy pass.
+
+    Returns the transport, or ``None`` with the reason the layouts could not be
+    derived.
+    """
+    in_keys = getattr(policy, "in_keys", None)
+    out_keys = getattr(policy, "out_keys", None)
+    if not in_keys or not out_keys:
+        return None, "the policy does not declare in_keys and out_keys"
+    env = env_factory(**env_kwargs)
+    try:
+        fake = env.fake_tensordict()
+    finally:
+        env.close()
+    missing = [key for key in in_keys if key not in fake.keys(True, True)]
+    if missing:
+        return None, f"the environment does not produce the policy inputs {missing}"
+    request = fake.select(*in_keys, strict=True).cpu()
+    try:
+        with torch.no_grad():
+            output = policy(request.clone().unsqueeze(0))
+    except Exception as err:  # noqa: BLE001
+        return None, f"the policy could not run on a sample request ({err!r})"
+    output = output.squeeze(0) if output.batch_dims else output
+    missing = [key for key in out_keys if key not in output.keys(True, True)]
+    if missing:
+        return None, f"the policy did not return its outputs {missing}"
+    response = output.select(*out_keys, strict=True).cpu()
+    if policy_version_key is not None:
+        response.set(policy_version_key, torch.zeros((), dtype=torch.long))
+    return ProcessSlotTransport(request, response, num_slots=num_slots), None
+
+
 class AsyncBatchedCollector(BaseCollector):
     """Asynchronous collector with env slots and a policy server.
 
@@ -452,7 +543,10 @@ class AsyncBatchedCollector(BaseCollector):
     processes whatever observations have accumulated.
 
     The user simply provides env factories and a policy; the collector
-    handles all wiring internally.
+    handles all wiring internally. With ``transport="auto"``, multiprocessing
+    environment workers and a ``policy_factory``, it also derives the fixed
+    request and response layouts and serves the policy from a dedicated
+    process that the workers reach directly.
 
     Args:
         create_env_fn (list[Callable[[], EnvBase]]): a list of callables, each
@@ -480,20 +574,31 @@ class AsyncBatchedCollector(BaseCollector):
             ``1`` (default) dispatches immediately.
         server_timeout (float, optional): seconds the server waits for work
             before dispatching a partial batch.  Defaults to ``0.01``.
-        transport (InferenceTransport, optional): a pre-built transport
-            object. When provided, it takes precedence over ``policy_backend``.
-            A :class:`~torchrl.modules.inference_server.ProcessSlotTransport`
-            together with multiprocessing environment and server backends runs
-            the complete acting loop in environment worker processes. When
-            ``None`` (default), a transport is created from the resolved
-            ``policy_backend``.
+        transport (InferenceTransport, "auto" or "thread", optional): the
+            inference transport. A pre-built transport object takes precedence
+            over ``policy_backend``; a
+            :class:`~torchrl.modules.inference_server.ProcessSlotTransport`
+            runs the complete acting loop in environment worker processes and
+            implies a process inference server and multiprocessing environment
+            workers. ``"auto"`` builds that transport when environment workers
+            are processes with one environment each and a ``policy_factory``
+            is given: the request and response layouts come from one
+            environment's ``fake_tensordict()`` and one policy pass. When
+            those conditions do not hold, or the layouts cannot be derived,
+            the policy is served from a thread of this process and the reason
+            is logged. ``"thread"`` always serves from a thread of this
+            process. ``None`` (default) behaves like ``"thread"`` and emits a
+            :class:`FutureWarning` when ``"auto"`` would pick process slots:
+            in v0.15 the default becomes ``"auto"``.
         device (torch.device or str, optional): device for policy inference
             (shorthand for ``InferenceDeviceConfig(policy_device=...)``).
             Defaults to ``None``.
         server_config (InferenceServerConfig, optional): structured server
             configuration: execution ``backend`` (``"thread"`` runs the serve
             loop in this process, ``"process"`` a dedicated server process
-            requiring ``policy_factory``), batching, optional static
+            requiring ``policy_factory``; a
+            :class:`~torchrl.modules.inference_server.ProcessSlotTransport`
+            turns ``"thread"`` into ``"process"``), batching, optional static
             CUDA-graph execution, and stats settings.
             Mutually exclusive with the ``max_batch_size``,
             ``min_batch_size``, and ``server_timeout`` keyword arguments.
@@ -523,16 +628,23 @@ class AsyncBatchedCollector(BaseCollector):
         env_exchange (str, optional): data exchange of a multiprocessing
             :class:`~torchrl.envs.AsyncEnvPool`, one of ``"queue"``, ``"shm"``
             or ``"auto"``. The shared-memory exchange also enables batched
-            coordination from one thread. Defaults to ``"queue"``.
+            coordination from one thread; ``"auto"`` selects it whenever the
+            environment schema allows. It does not apply when a
+            :class:`~torchrl.modules.inference_server.ProcessSlotTransport`
+            owns the worker exchange. Defaults to ``"auto"``.
         envs_per_worker (int, optional): Number of environments hosted by each
             multiprocessing worker. Grouped workers share one coordinator that
             drains ready environments without waiting for a complete group.
             Defaults to ``1``.
-        transition_chunk_size (int, optional): number of consecutive
+        transition_chunk_size (int or "auto", optional): number of consecutive
             transitions each environment worker process accumulates before
             sending them to the driver as one dense message. Requires a
             :class:`~torchrl.modules.inference_server.ProcessSlotTransport`.
-            ``1`` (default) sends every transition as soon as it completes.
+            ``"auto"`` (default) uses ``frames_per_batch // len(create_env_fn)``
+            with process workers, so each batch holds one contiguous run per
+            environment like the synchronous collectors and a transition waits
+            at most one batch; it resolves to ``1`` otherwise.
+            ``1`` sends every transition as soon as it completes.
             Larger values take the driver off the per-transition path: it
             receives one message per chunk, concatenates whole chunks into
             each batch and writes each batch to ``replay_buffer`` with a
@@ -542,7 +654,7 @@ class AsyncBatchedCollector(BaseCollector):
             ``transition_chunk_size - 1`` transitions per environment stay in
             the worker while collection is paused or stopped. Batches are then
             dense :class:`~tensordict.TensorDict` instances and ``env_index``
-            is a tensor. Defaults to ``1``.
+            is a tensor. Defaults to ``"auto"``.
         policy_backend (str, optional): backend for the inference transport
             used to communicate with the
             :class:`~torchrl.modules.InferenceServer`.  One of
@@ -638,14 +750,14 @@ class AsyncBatchedCollector(BaseCollector):
         max_batch_size: int | None = None,
         min_batch_size: int | None = None,
         server_timeout: float | None = None,
-        transport: InferenceTransport | None = None,
+        transport: InferenceTransport | Literal["auto", "thread"] | None = None,
         device: torch.device | str | None = None,
         backend: Literal["threading", "multiprocessing", "ray", "monarch"]
         | None = None,
         env_backend: Literal["threading", "multiprocessing"] | None = None,
-        env_exchange: Literal["queue", "shm", "auto"] = "queue",
+        env_exchange: Literal["queue", "shm", "auto"] = "auto",
         envs_per_worker: int = 1,
-        transition_chunk_size: int = 1,
+        transition_chunk_size: int | Literal["auto"] = "auto",
         policy_backend: (
             Literal["threading", "multiprocessing", "ray", "monarch"] | None
         ) = None,
@@ -703,11 +815,7 @@ class AsyncBatchedCollector(BaseCollector):
         self._env_device = _devices.env_device
         self._storing_device = _devices.storing_device
 
-        # ---- resolve policy ---------------------------------------------------
         self._policy_factory = policy_factory
-        if policy_factory is not None and server_backend != "process":
-            policy = policy_factory()
-        self._policy = policy
 
         # ---- env config -------------------------------------------------------
         if not isinstance(create_env_fn, Sequence):
@@ -727,10 +835,20 @@ class AsyncBatchedCollector(BaseCollector):
         self._create_env_kwargs = create_env_kwargs
 
         # ---- resolve backends -------------------------------------------------
+        explicit_transport = isinstance(transport, InferenceTransport)
+        if transport is not None and not explicit_transport:
+            if transport not in ("auto", "thread"):
+                raise ValueError(
+                    "transport must be an InferenceTransport, 'auto', 'thread' or "
+                    f"None, got {transport!r}."
+                )
         if env_backend is not None:
             effective_env_backend = env_backend
         elif backend is not None:
             effective_env_backend = backend
+        elif explicit_transport and isinstance(transport, ProcessSlotTransport):
+            # The transport only works with environment worker processes.
+            effective_env_backend = "multiprocessing"
         else:
             warnings.warn(
                 "AsyncBatchedCollector runs environment workers in threads when "
@@ -782,17 +900,15 @@ class AsyncBatchedCollector(BaseCollector):
                 "env_backend='multiprocessing'."
             )
         self._envs_per_worker = envs_per_worker
-        if (
+        if transition_chunk_size != "auto" and (
             isinstance(transition_chunk_size, bool)
             or not isinstance(transition_chunk_size, int)
             or transition_chunk_size < 1
         ):
             raise ValueError(
-                "transition_chunk_size must be a positive integer, got "
+                "transition_chunk_size must be a positive integer or 'auto', got "
                 f"{transition_chunk_size!r}."
             )
-        self._transition_chunk_size = transition_chunk_size
-        self._uses_chunked_results = transition_chunk_size > 1
         if worker_affinity is None:
             self._worker_affinity = None
         else:
@@ -821,29 +937,73 @@ class AsyncBatchedCollector(BaseCollector):
             if driver_affinity is not None
             else None
         )
-        self._server_backend = server_backend
-        if server_backend == "process":
-            if policy_backend not in (None, "multiprocessing"):
-                raise ValueError(
-                    "InferenceServerConfig(service_backend='process') requires "
-                    "policy_backend=None or 'multiprocessing'."
+        # ---- resolve the transport --------------------------------------------
+        # Environment worker processes can talk to a dedicated inference
+        # process directly when the policy can be rebuilt there and no tensor
+        # has to cross the driver on the action path.
+        blocker = _process_slot_blocker(
+            env_backend=effective_env_backend,
+            envs_per_worker=envs_per_worker,
+            policy_factory=policy_factory,
+            policy_backend=policy_backend,
+            server_backend=server_backend,
+            policy_device=policy_device,
+            env_device=self._env_device,
+            storing_device=self._storing_device,
+        )
+        probe_policy = None
+        if explicit_transport:
+            pass
+        elif transport == "auto":
+            if blocker is None:
+                probe_policy = policy_factory()
+                transport, blocker = _auto_process_slot_transport(
+                    self._create_env_fn[0],
+                    _env_kwargs(create_env_kwargs, 0),
+                    probe_policy,
+                    num_slots=self._num_envs,
+                    policy_version_key=policy_version_key,
                 )
-            effective_policy_backend = "multiprocessing"
-        self._policy_backend = effective_policy_backend
+            if blocker is not None:
+                transport = None
+                torchrl_logger.info(
+                    "AsyncBatchedCollector(transport='auto') serves the policy "
+                    "from a thread of this process: %s.",
+                    blocker,
+                )
+            else:
+                torchrl_logger.info(
+                    "AsyncBatchedCollector(transport='auto') serves the policy "
+                    "from a dedicated process that the %d environment worker "
+                    "processes reach directly.",
+                    self._num_envs,
+                )
+        elif transport is None:
+            if blocker is None:
+                warnings.warn(
+                    "AsyncBatchedCollector serves the policy from a thread of this "
+                    "process by default. In v0.15, when environment workers are "
+                    "processes and a policy_factory is given, the default will "
+                    "become transport='auto', which serves the policy from a "
+                    "dedicated process that the environment workers reach "
+                    "directly. Pass transport='thread' to keep the current "
+                    "behavior, or transport='auto' to adopt the future default now.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
+        else:  # transport == "thread"
+            transport = None
 
-        # ---- build transport --------------------------------------------------
-        if transport is None:
-            transport = _make_transport(
-                effective_policy_backend, num_slots=self._num_envs
-            )
-        self._transport = transport
-        self._uses_process_env_workers = isinstance(transport, ProcessSlotTransport)
-        if self._uses_chunked_results and not self._uses_process_env_workers:
-            raise ValueError(
-                "transition_chunk_size > 1 requires a ProcessSlotTransport so "
-                "that environment worker processes assemble the chunks."
-            )
-        if self._uses_process_env_workers:
+        uses_process_env_workers = isinstance(transport, ProcessSlotTransport)
+        if uses_process_env_workers:
+            if server_backend == "thread":
+                # The transport reaches a dedicated inference process by design.
+                server_backend = "process"
+            if policy_factory is None:
+                raise TypeError(
+                    "ProcessSlotTransport requires policy_factory so the policy "
+                    "can be constructed inside the inference server process."
+                )
             if envs_per_worker != 1:
                 raise ValueError("ProcessSlotTransport requires envs_per_worker=1.")
             if (
@@ -854,15 +1014,21 @@ class AsyncBatchedCollector(BaseCollector):
                     "ProcessSlotTransport requires both a process inference server "
                     "and env_backend='multiprocessing'."
                 )
-            if env_exchange != "queue":
+            if env_exchange == "shm":
                 raise ValueError(
                     "env_exchange does not apply when ProcessSlotTransport owns "
-                    "the environment-worker exchange; leave it as 'queue'."
+                    "the environment-worker exchange; leave it as 'auto'."
                 )
             if transport._num_slots < self._num_envs:
                 raise ValueError(
                     f"ProcessSlotTransport needs at least one slot per environment "
                     f"({self._num_envs}), but has {transport._num_slots}."
+                )
+            if policy_device is not None and policy_device.type not in ("cpu", "cuda"):
+                raise ValueError(
+                    "ProcessSlotTransport requires a CPU or CUDA policy_device so "
+                    f"weight updates can be shared with the inference process; got "
+                    f"{policy_device}."
                 )
             for name, target_device in (
                 ("env_device", self._env_device),
@@ -874,6 +1040,43 @@ class AsyncBatchedCollector(BaseCollector):
                         f"{target_device}. Keep CUDA policy execution in the "
                         "inference server process."
                     )
+        self._server_backend = server_backend
+        if server_backend == "process":
+            if policy_backend not in (None, "multiprocessing"):
+                raise ValueError(
+                    "InferenceServerConfig(service_backend='process') requires "
+                    "policy_backend=None or 'multiprocessing'."
+                )
+            effective_policy_backend = "multiprocessing"
+        self._policy_backend = effective_policy_backend
+        if transport is None:
+            transport = _make_transport(
+                effective_policy_backend, num_slots=self._num_envs
+            )
+        self._transport = transport
+        self._uses_process_env_workers = uses_process_env_workers
+
+        # ---- resolve the chunk size -------------------------------------------
+        if transition_chunk_size == "auto":
+            # One contiguous run per environment and batch, the layout of the
+            # synchronous collectors, so a transition waits at most one batch.
+            transition_chunk_size = (
+                max(1, frames_per_batch // self._num_envs)
+                if uses_process_env_workers
+                else 1
+            )
+        self._transition_chunk_size = transition_chunk_size
+        self._uses_chunked_results = transition_chunk_size > 1
+        if self._uses_chunked_results and not uses_process_env_workers:
+            raise ValueError(
+                "transition_chunk_size > 1 requires a ProcessSlotTransport so "
+                "that environment worker processes assemble the chunks."
+            )
+
+        # ---- resolve policy ---------------------------------------------------
+        if policy_factory is not None and server_backend != "process":
+            policy = probe_policy if probe_policy is not None else policy_factory()
+        self._policy = policy
 
         # ---- build inference server -------------------------------------------
         if server_backend == "process":
@@ -1270,6 +1473,11 @@ class AsyncBatchedCollector(BaseCollector):
                     request[1].set()
             finally:
                 self._pause_lock.release()
+
+    @property
+    def server_backend(self) -> str:
+        """The resolved inference server backend: ``"thread"``, ``"process"`` or ``"ray"``."""
+        return self._server_backend
 
     @property
     def env(self) -> AsyncEnvPool:

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -598,8 +598,11 @@ class AsyncBatchedCollector(BaseCollector):
             environment's ``fake_tensordict()`` and one policy pass. When
             those conditions do not hold, or the layouts cannot be derived,
             the policy is served from a thread of this process and the reason
-            is logged. ``"thread"`` always serves from a thread of this
-            process. ``None`` (default) behaves like ``"thread"`` and emits a
+            is logged. ``"driver"`` always relays requests through the
+            driver's coordinator threads to the transport derived from
+            ``policy_backend`` (a thread server by default, a process server
+            with ``service_backend="process"``). ``None`` (default) behaves like
+            ``"driver"`` and emits a
             :class:`FutureWarning` when ``"auto"`` would pick process slots:
             in v0.15 the default becomes ``"auto"``.
         device (torch.device or str, optional): device for policy inference
@@ -744,6 +747,7 @@ class AsyncBatchedCollector(BaseCollector):
         ...     policy=policy,
         ...     frames_per_batch=200,
         ...     total_frames=1000,
+        ...     env_backend="multiprocessing",
         ... )
         >>> for batch in collector:
         ...     print(batch.shape)
@@ -762,7 +766,7 @@ class AsyncBatchedCollector(BaseCollector):
         max_batch_size: int | None = None,
         min_batch_size: int | None = None,
         server_timeout: float | None = None,
-        transport: InferenceTransport | Literal["auto", "thread"] | None = None,
+        transport: InferenceTransport | Literal["auto", "driver"] | None = None,
         device: torch.device | str | None = None,
         backend: Literal["threading", "multiprocessing", "ray", "monarch"]
         | None = None,
@@ -849,9 +853,9 @@ class AsyncBatchedCollector(BaseCollector):
         # ---- resolve backends -------------------------------------------------
         explicit_transport = isinstance(transport, InferenceTransport)
         if transport is not None and not explicit_transport:
-            if transport not in ("auto", "thread"):
+            if transport not in ("auto", "driver"):
                 raise ValueError(
-                    "transport must be an InferenceTransport, 'auto', 'thread' or "
+                    "transport must be an InferenceTransport, 'auto', 'driver' or "
                     f"None, got {transport!r}."
                 )
         if env_backend is not None:
@@ -998,12 +1002,12 @@ class AsyncBatchedCollector(BaseCollector):
                     "processes and a policy_factory is given, the default will "
                     "become transport='auto', which serves the policy from a "
                     "dedicated process that the environment workers reach "
-                    "directly. Pass transport='thread' to keep the current "
+                    "directly. Pass transport='driver' to keep the current "
                     "behavior, or transport='auto' to adopt the future default now.",
                     FutureWarning,
                     stacklevel=2,
                 )
-        else:  # transport == "thread"
+        else:  # transport == "driver"
             transport = None
 
         uses_process_env_workers = isinstance(transport, ProcessSlotTransport)

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import contextlib
 import functools as ft
+import itertools
 import multiprocessing as mp
 import os
 import queue
@@ -495,9 +496,13 @@ def _auto_process_slot_transport(
     if missing:
         return None, f"the environment does not produce the policy inputs {missing}"
     request = fake.select(*in_keys, strict=True).cpu()
+    reference = None
+    if isinstance(policy, torch.nn.Module):
+        reference = next(itertools.chain(policy.parameters(), policy.buffers()), None)
+    probe_device = reference.device if reference is not None else torch.device("cpu")
     try:
         with torch.no_grad():
-            output = policy(request.clone().unsqueeze(0))
+            output = policy(request.clone().unsqueeze(0).to(probe_device))
     except Exception as err:  # noqa: BLE001
         return None, f"the policy could not run on a sample request ({err!r})"
     output = output.squeeze(0) if output.batch_dims else output
@@ -1152,6 +1157,8 @@ class AsyncBatchedCollector(BaseCollector):
         self._replay_lock = threading.Lock()
         self._replay_thread: threading.Thread | None = None
         self._replay_error: Exception | None = None
+        # Weights received before a process server started; applied at start.
+        self._pending_weights: TensorDictBase | None = None
 
         # Per-env trajectory accumulators (for yield_completed_trajectories)
         self._yield_queues: list[deque] = [deque() for _ in range(self._num_envs)]
@@ -1196,6 +1203,7 @@ class AsyncBatchedCollector(BaseCollector):
                     )
                 if not self._server.is_alive:
                     self._server.start()
+                self._apply_pending_weights()
 
                 create_env_kwargs = self._create_env_kwargs
                 if create_env_kwargs is None:
@@ -1305,6 +1313,7 @@ class AsyncBatchedCollector(BaseCollector):
             # Start inference server
             if not self._server.is_alive:
                 self._server.start()
+            self._apply_pending_weights()
 
             # Start coordinator threads. Shared slots can be drained safely in
             # ready batches, avoiding one Python thread and one clone per env.
@@ -1535,11 +1544,24 @@ class AsyncBatchedCollector(BaseCollector):
         weights = weights.detach().clone()
         update_model_weights = getattr(self._server, "update_model_weights", None)
         if update_model_weights is not None:
+            if not self._server.is_alive:
+                # The server process starts with the first iteration. Keep the
+                # latest weights and apply them right after it starts, before
+                # any request is served, so a policy rebuilt from a factory acts
+                # with the trainer's weights from the first step.
+                self._pending_weights = weights
+                return
             update_model_weights(weights)
         else:
             self._server.update_model(
                 ft.partial(WeightStrategy().apply_weights, weights=weights)
             )
+
+    def _apply_pending_weights(self) -> None:
+        if self._pending_weights is None:
+            return
+        weights, self._pending_weights = self._pending_weights, None
+        self._server.update_model_weights(weights)
 
     # ------------------------------------------------------------------
     # Rollout: drain the result queue

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -511,7 +511,9 @@ def _auto_process_slot_transport(
         return None, f"the policy did not return its outputs {missing}"
     response = output.select(*out_keys, strict=True).cpu()
     if policy_version_key is not None:
-        response.set(policy_version_key, torch.zeros((), dtype=torch.long))
+        response.set(
+            policy_version_key, torch.zeros(response.batch_size, dtype=torch.long)
+        )
     return ProcessSlotTransport(request, response, num_slots=num_slots), None
 
 

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -514,7 +514,11 @@ def _auto_process_slot_transport(
         response.set(
             policy_version_key, torch.zeros(response.batch_size, dtype=torch.long)
         )
-    return ProcessSlotTransport(request, response, num_slots=num_slots), None
+    try:
+        transport = ProcessSlotTransport(request, response, num_slots=num_slots)
+    except (TypeError, ValueError) as err:
+        return None, f"the request/response layouts cannot use process slots ({err!r})"
+    return transport, None
 
 
 class AsyncBatchedCollector(BaseCollector):

--- a/torchrl/data/replay_buffers/replay_buffers/ensemble.py
+++ b/torchrl/data/replay_buffers/replay_buffers/ensemble.py
@@ -325,7 +325,7 @@ class ReplayBufferEnsemble(ReplayBuffer):
             id_shape = [1] * data.ndim
             id_shape[routing_dim] = data.shape[routing_dim]
             buffer_ids = (
-                torch.arange(data.shape[routing_dim], device=data.device)
+                torch.arange(data.shape[routing_dim], device=data.device or "cpu")
                 .reshape(id_shape)
                 .expand(data.batch_size)
                 .reshape(-1)
@@ -382,7 +382,9 @@ class ReplayBufferEnsemble(ReplayBuffer):
                 if isinstance(member_index, tuple):
                     member_index = torch.stack(member_index, -1)
                 else:
-                    member_index = torch.as_tensor(member_index)
+                    member_index = torch.as_tensor(
+                        member_index, device=buffer_ids.device
+                    )
                 if member_index.ndim == 0:
                     member_index = member_index.unsqueeze(0)
                 member_index = member_index.to(buffer_ids.device)

--- a/torchrl/data/replay_buffers/samplers/ensemble.py
+++ b/torchrl/data/replay_buffers/samplers/ensemble.py
@@ -123,18 +123,13 @@ class SamplerEnsemble(Sampler):
             if isinstance(self.p, str):
                 counts = torch.tensor(
                     [
-                        float(
-                            torch.as_tensor(
-                                sampler._sampleable_count(
-                                    member_storage, sub_batch_size
-                                )
-                            ).item()
-                        )
+                        float(sampler._sampleable_count(member_storage, sub_batch_size))
                         for member_storage, sampler in zip(
                             storage._storages, self._samplers
                         )
                     ],
                     dtype=torch.float,
+                    device=self._rng.device if self._rng is not None else "cpu",
                 )
                 if not counts.any():
                     raise RuntimeError(

--- a/torchrl/data/replay_buffers/samplers/streaming_slice.py
+++ b/torchrl/data/replay_buffers/samplers/streaming_slice.py
@@ -128,9 +128,9 @@ class StreamingSliceSampler(SliceSampler):
             use_gpu=use_gpu,
         )
         self._queued_slices = collections.deque()
-        self._pending_indices = torch.empty(0, dtype=torch.long)
-        self._pending_versions = torch.empty(0, dtype=torch.long)
-        self._slot_versions = torch.empty(0, dtype=torch.long)
+        self._pending_indices = torch.empty(0, dtype=torch.long, device="cpu")
+        self._pending_versions = torch.empty(0, dtype=torch.long, device="cpu")
+        self._slot_versions = torch.empty(0, dtype=torch.long, device="cpu")
         self._last_traj = None
         self._last_was_done = False
 
@@ -138,7 +138,7 @@ class StreamingSliceSampler(SliceSampler):
         if self._slot_versions.numel() >= min_size:
             return
         size = min(capacity, max(min_size, 2 * self._slot_versions.numel(), 1024))
-        versions = torch.zeros(size, dtype=torch.long)
+        versions = torch.zeros(size, dtype=torch.long, device="cpu")
         versions[: self._slot_versions.numel()] = self._slot_versions
         self._slot_versions = versions
 
@@ -161,7 +161,9 @@ class StreamingSliceSampler(SliceSampler):
             raise RuntimeError(
                 "StreamingSliceSampler requires one-dimensional write indices."
             )
-        storage_index = torch.as_tensor(index, dtype=torch.long).reshape(-1)
+        storage_index = torch.as_tensor(index, dtype=torch.long, device="cpu").reshape(
+            -1
+        )
         if not storage_index.numel():
             return
         if storage_index.numel() > storage.max_size:
@@ -182,8 +184,8 @@ class StreamingSliceSampler(SliceSampler):
         if self._pending_indices.numel() and not torch.equal(
             self._slot_versions[self._pending_indices], self._pending_versions
         ):
-            self._pending_indices = torch.empty(0, dtype=torch.long)
-            self._pending_versions = torch.empty(0, dtype=torch.long)
+            self._pending_indices = torch.empty(0, dtype=torch.long, device="cpu")
+            self._pending_versions = torch.empty(0, dtype=torch.long, device="cpu")
 
         data = storage.get(storage_index)
         if not isinstance(data, TensorDictBase):
@@ -200,7 +202,7 @@ class StreamingSliceSampler(SliceSampler):
             if trajectory is not None:
                 trajectory = trajectory.reshape(num_records, -1).cpu()
 
-        done = torch.zeros(num_records, dtype=torch.bool)
+        done = torch.zeros(num_records, dtype=torch.bool, device="cpu")
         boundary_keys = self.end_keys or (self.end_key,)
         for key in boundary_keys:
             value = data.get(key, default=None)
@@ -227,7 +229,7 @@ class StreamingSliceSampler(SliceSampler):
             combined_indices = torch.cat((self._pending_indices, indices))
             combined_versions = torch.cat((self._pending_versions, occurrence_versions))
             combined_done = torch.cat(
-                (torch.zeros(pending_size, dtype=torch.bool), done)
+                (torch.zeros(pending_size, dtype=torch.bool, device="cpu"), done)
             )
         else:
             pending_size = 0
@@ -237,15 +239,20 @@ class StreamingSliceSampler(SliceSampler):
 
         starts = torch.cat(
             (
-                torch.zeros(1, dtype=torch.long),
+                torch.zeros(1, dtype=torch.long, device="cpu"),
                 boundary_before.nonzero().flatten() + pending_size,
             )
         ).unique(sorted=True)
         stops = torch.cat(
-            (starts[1:], torch.tensor([combined_indices.numel()], dtype=torch.long))
+            (
+                starts[1:],
+                torch.tensor(
+                    [combined_indices.numel()], dtype=torch.long, device="cpu"
+                ),
+            )
         )
-        self._pending_indices = torch.empty(0, dtype=torch.long)
-        self._pending_versions = torch.empty(0, dtype=torch.long)
+        self._pending_indices = torch.empty(0, dtype=torch.long, device="cpu")
+        self._pending_versions = torch.empty(0, dtype=torch.long, device="cpu")
         for segment_id, (start, stop) in enumerate(
             zip(starts.tolist(), stops.tolist())
         ):
@@ -339,8 +346,8 @@ class StreamingSliceSampler(SliceSampler):
 
     def _end_stream(self, index: torch.Tensor, *, storage: Storage) -> None:
         super()._end_stream(index, storage=storage)
-        self._pending_indices = torch.empty(0, dtype=torch.long)
-        self._pending_versions = torch.empty(0, dtype=torch.long)
+        self._pending_indices = torch.empty(0, dtype=torch.long, device="cpu")
+        self._pending_versions = torch.empty(0, dtype=torch.long, device="cpu")
         self._last_traj = None
         self._last_was_done = True
 
@@ -348,9 +355,9 @@ class StreamingSliceSampler(SliceSampler):
         super()._empty()
         self._cache.clear()
         self._queued_slices.clear()
-        self._pending_indices = torch.empty(0, dtype=torch.long)
-        self._pending_versions = torch.empty(0, dtype=torch.long)
-        self._slot_versions = torch.empty(0, dtype=torch.long)
+        self._pending_indices = torch.empty(0, dtype=torch.long, device="cpu")
+        self._pending_versions = torch.empty(0, dtype=torch.long, device="cpu")
+        self._slot_versions = torch.empty(0, dtype=torch.long, device="cpu")
         self._last_traj = None
         self._last_was_done = False
 
@@ -360,8 +367,12 @@ class StreamingSliceSampler(SliceSampler):
             queued_indices = torch.stack(queued_indices)
             queued_versions = torch.stack(queued_versions)
         else:
-            queued_indices = torch.empty((0, self.slice_len), dtype=torch.long)
-            queued_versions = torch.empty((0, self.slice_len), dtype=torch.long)
+            queued_indices = torch.empty(
+                (0, self.slice_len), dtype=torch.long, device="cpu"
+            )
+            queued_versions = torch.empty(
+                (0, self.slice_len), dtype=torch.long, device="cpu"
+            )
         return {
             "slot_versions": self._slot_versions.clone(),
             "queued_indices": queued_indices,
@@ -371,11 +382,11 @@ class StreamingSliceSampler(SliceSampler):
             "last_traj": (
                 self._last_traj.clone()
                 if self._last_traj is not None
-                else torch.empty(0)
+                else torch.empty(0, device="cpu")
             ),
-            "has_last_traj": torch.tensor(self._last_traj is not None),
-            "last_was_done": torch.tensor(self._last_was_done),
-            "slice_len": torch.tensor(self.slice_len),
+            "has_last_traj": torch.tensor(self._last_traj is not None, device="cpu"),
+            "last_was_done": torch.tensor(self._last_was_done, device="cpu"),
+            "slice_len": torch.tensor(self.slice_len, device="cpu"),
         }
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
@@ -385,17 +396,17 @@ class StreamingSliceSampler(SliceSampler):
                 f"Cannot restore slice_len={slice_len} into a "
                 f"slice_len={self.slice_len} StreamingSliceSampler."
             )
-        self._slot_versions = state_dict["slot_versions"].clone()
+        self._slot_versions = state_dict["slot_versions"].cpu().clone()
         self._queued_slices = collections.deque(
             zip(
-                state_dict["queued_indices"].clone().unbind(0),
-                state_dict["queued_versions"].clone().unbind(0),
+                state_dict["queued_indices"].cpu().clone().unbind(0),
+                state_dict["queued_versions"].cpu().clone().unbind(0),
             )
         )
-        self._pending_indices = state_dict["pending_indices"].clone()
-        self._pending_versions = state_dict["pending_versions"].clone()
+        self._pending_indices = state_dict["pending_indices"].cpu().clone()
+        self._pending_versions = state_dict["pending_versions"].cpu().clone()
         self._last_traj = (
-            state_dict["last_traj"].clone()
+            state_dict["last_traj"].cpu().clone()
             if bool(state_dict["has_last_traj"])
             else None
         )

--- a/torchrl/data/replay_buffers/writers/round_robin.py
+++ b/torchrl/data/replay_buffers/writers/round_robin.py
@@ -189,7 +189,7 @@ class RoundRobinWriter(Writer):
             self._ensure_generation(capacity, int(index) + 1, device)
             self._generation[int(index)] += 1
         else:
-            index = torch.as_tensor(index, dtype=torch.long).reshape(-1)
+            index = torch.as_tensor(index, dtype=torch.long, device=device).reshape(-1)
             if index.numel() == 0:
                 return
             capacity = self._storage._max_size_along_dim0(batched_data=data)
@@ -222,7 +222,9 @@ class RoundRobinWriter(Writer):
             and index.shape[-1] == self._storage.ndim
         ):
             index = index[..., 0]
-        index = torch.as_tensor(index, dtype=torch.long)
+        index = torch.as_tensor(
+            index, dtype=torch.long, device=getattr(index, "device", "cpu")
+        )
         if self._generation is None:
             return torch.full(index.shape, -1, dtype=torch.int64, device=index.device)
         idx = index.to(self._generation.device)
@@ -303,7 +305,7 @@ class RoundRobinWriter(Writer):
             batch_size = len(tree_leaves(data)[0])
         if batch_size == 0:
             raise RuntimeError(f"Expected at least one element in extend. Got {data=}")
-        device = data.device if hasattr(data, "device") else None
+        device = getattr(data, "device", None) or "cpu"
         max_size_along0 = self._storage._max_size_along_dim0(batched_data=data)
         index = (
             torch.arange(
@@ -503,7 +505,7 @@ class TensorDictRoundRobinWriter(RoundRobinWriter):
     def extend(self, data: Sequence) -> torch.Tensor:
         cur_size = self._cursor
         batch_size = len(data)
-        device = data.device if hasattr(data, "device") else None
+        device = getattr(data, "device", None) or "cpu"
         max_size_along_dim0 = self._storage._max_size_along_dim0(batched_data=data)
         index = (
             torch.arange(
@@ -518,9 +520,7 @@ class TensorDictRoundRobinWriter(RoundRobinWriter):
         if not is_tensorclass(data):
             data.set(
                 "index",
-                expand_as_right(
-                    torch.as_tensor(index, device=data.device, dtype=torch.long), data
-                ),
+                expand_as_right(index, data),
             )
         # Replicate index requires the shape of the storage to be known
         # Other than that, a "flat" (1d) index is ok to write the data

--- a/torchrl/modules/inference_server/_process_slot.py
+++ b/torchrl/modules/inference_server/_process_slot.py
@@ -296,6 +296,7 @@ class ProcessSlotTransport(InferenceTransport):
                     request_spec.batch_size,
                     _NO_INTERACTION_TYPE_CODE,
                     dtype=torch.int8,
+                    device="cpu",
                 ),
             )
         self._request_slots = _make_slot_bank(
@@ -453,7 +454,7 @@ class ProcessSlotTransport(InferenceTransport):
                 f"Cannot gather {num_slots} request slots into a batch of "
                 f"{out.batch_size[0]} rows."
             )
-        index = torch.tensor(slots, dtype=torch.long)
+        index = torch.tensor(slots, dtype=torch.long, device="cpu")
         for key, bank in self._request_slots.items(
             include_nested=True, leaves_only=True
         ):
@@ -472,9 +473,9 @@ class ProcessSlotTransport(InferenceTransport):
         """
         if not slots:
             return
-        self._response_slots[torch.tensor(slots, dtype=torch.long)] = results.select(
-            *self._response_keys, strict=True
-        )
+        self._response_slots[
+            torch.tensor(slots, dtype=torch.long, device="cpu")
+        ] = results.select(*self._response_keys, strict=True)
         for slot in slots:
             self._response_status[slot] = 0
             self._response_events[slot].set()

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -619,11 +619,17 @@ class DreamerV3SeededPolicy(TensorDictModuleBase):
         reference = tensordict.get("state", None)
         if reference is None:
             reference = tensordict.get(self.in_keys[0])
-        devices = [reference.device] if reference.device.type == "cuda" else []
-        with torch.random.fork_rng(devices=devices):
+        device = reference.device
+        devices = [device] if device.type != "cpu" else []
+        with torch.random.fork_rng(devices=devices, device_type=device.type):
             rng = np.random.default_rng(seed=[self.seed, self.counter, 0])
             words = rng.integers(0, np.iinfo(np.uint32).max, (2,), np.uint32)
-            torch.manual_seed((int(words[0]) << 32) | int(words[1]))
+            seed = (int(words[0]) << 32) | int(words[1])
+            torch.random.default_generator.manual_seed(seed)
+            if devices:
+                getattr(torch, device.type).set_rng_state(
+                    torch.Generator(device=device).manual_seed(seed).get_state(), device
+                )
             self.counter += 1
             return self.module(tensordict)
 


### PR DESCRIPTION
## Description

Makes the fast asynchronous configuration the one users get without parametrizing the collector by hand, and announces the two released defaults that change in v0.15.

**Collector (`AsyncBatchedCollector`)**

- `transport="auto"`: when environment workers are processes with one environment each and a `policy_factory` is given, the collector derives the fixed request and response layouts from one environment's `fake_tensordict()` and one policy pass, builds a `ProcessSlotTransport` and serves the policy from a dedicated process that the workers reach directly. When a condition does not hold (threaded or grouped workers, no `policy_factory`, a policy whose inputs the environment does not produce, a policy device whose weights cannot be shared across processes), it serves the policy from a thread of the driver process and logs the reason. `transport="driver"` keeps the driver-mediated path explicitly: coordinator threads relay requests to the transport derived from `policy_backend`.
- `transition_chunk_size="auto"` (new default): with process workers, each worker sends `frames_per_batch // num_envs` consecutive transitions per message, so every batch holds one contiguous run per environment like the synchronous collectors and a transition waits at most one batch. It resolves to `1` otherwise.
- `env_exchange="auto"` (new default): shared memory whenever the environment schema allows, as `AsyncEnvPool` will default to in v0.15. The setting is ignored, rather than rejected, when a `ProcessSlotTransport` owns the worker exchange.
- A `ProcessSlotTransport` implies the process inference server and multiprocessing environment workers, so `service_backend` and `env_backend` no longer have to be repeated. It requires a CPU or CUDA policy device.
- New read-only `server_backend` property with the resolved server backend.

**Warnings for v0.15** (`FutureWarning`, only when the caller relied on the default)

- Environment workers: `backend=None` now, `threading` today; `env_backend="multiprocessing"` becomes the default in v0.15. The first commit contains only this change so it can be cherry-picked onto `release/0.14.0`.
- `transport=None`: behaves like `"driver"` today; in v0.15 it becomes `"auto"`. The warning is emitted only when `"auto"` would pick process slots, that is when the behavior will actually change.

**DreamerV3 example**

- `collector.backend=auto` (default): asynchronous collection on CPU and CUDA training devices, the synchronous collector elsewhere. MPS cannot run the acting policy in a server thread (Metal command buffer assertion, reproduced with the previous `async` settings too) and cannot share weights with another process.
- `collector.async_env_backend=multiprocessing`, `env_exchange=auto`, `inference_backend=auto` and `transition_chunk_size=auto` are the new defaults. `inference_backend=auto` rebuilds the acting policy inside the inference process through a picklable factory whenever process inference is possible and pushes the learner's weights right after the first collected batch; `thread` and `process` force one of the two.
- The `examples/collectors/async_batched_collector.py` example, the documentation snippets and the class docstring pass `env_backend="multiprocessing"` explicitly; the examples CI runs with `FutureWarning` as an error.
- Supersedes #4304, whose manual `ProcessSlotTransport` wiring is now done by the collector.

**Benchmarks**: the fixed series pin `transport="driver"` and an explicit `transition_chunk_size`, so the changed collector defaults cannot move the recorded trends; the integrated series follow the defaults as intended. The DreamerV3 benchmark workload gains the example's new key.

## Motivation and Context

The released defaults are the slowest configuration on every axis of the async benchmark dashboard (threaded env workers, queue exchange, per-transition messages, thread server). The process-slot path with chunked results measures 1.6x (CPU) to 2.8x (GPU) the throughput of the unchunked process slots, which are themselves 2x the shared-memory thread path and 12x the queue path. Getting there required five settings that encode one decision; the collector can take that decision itself and fall back safely.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [x] Example (update in the folder of examples)

## Checklist

- [x] I have read the CONTRIBUTION guide (required)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (required for a bug fix or a new feature).
- [x] I have updated the documentation accordingly.

## Tests

- `test/test_inference_server.py::TestAsyncBatchedCollector`: `test_auto_transport_serves_from_environment_processes`, `test_auto_transport_falls_back_to_a_thread_server`, `test_auto_transport_falls_back_when_policy_inputs_are_missing`, `test_default_transport_warns_before_the_process_slot_default`, `test_default_env_backend_warns_before_the_multiprocessing_default`, `test_process_slot_transport_implies_process_server_and_workers`, `test_weights_pushed_before_start_reach_the_process_server`, plus a policy-device case in `test_process_slots_reject_unsupported_collection`. The unchunked bookkeeping test pins `transition_chunk_size=1`.
- `test/objectives/test_dreamer_v3.py`: `test_dreamer_v3_process_inference_collection_smoke` (both `separate_policy_rng` settings on CPU and, in the GPU jobs, on `cuda:0`; and the `envs_per_worker` error), `test_dreamer_v3_behavior_policy_weights_match_served_policy`; the checkpoint-resume test keeps the thread server because the seeded policy state is checkpointed from the training process. The time-budget smoke test asserts that an expired budget stops the run at the first batch instead of bounding wall time, which process startup on a loaded runner exceeded.

## Validation

- `test/test_inference_server.py::TestAsyncBatchedCollector` passes locally (the whole class plus the new tests).
- `test/objectives/test_dreamer_v3.py` passes locally on CPU, where the default now resolves to asynchronous collection with process inference.
- The DreamerV3 smoke configuration from the SOTA CI list runs on CPU with process inference (`AsyncBatchedCollector(transport='auto') serves the policy from a dedicated process`) and on an MPS machine with the synchronous fallback; with the previous `async` settings that machine aborted in Metal.
- The fixed `async-shm`, `async-process-slots` and `async-process-slots-integrated` benchmark modes run locally with `-W error::FutureWarning`; the integrated series records `64 transitions/message` on this revision.
- The first commit is self-contained for a cherry-pick onto `release/0.14.0`: it only changes the `backend` default to `None`, adds the warning and its test.


## Review follow-ups from the process-inference recipe review

The review of the earlier recipe-side wiring (#4304, now superseded here) asked for four things; this PR addresses them at the library level where possible.

- **First-batch weight freshness, including after a resume.** `AsyncBatchedCollector.update_policy_weights_` called before a process server has started now keeps the weights and applies them right after the server starts and before any request is served (`_apply_pending_weights`). The example pushes the learner's weights, restored ones after a resume, right after building the collector, so no batch is collected with the factory's initialization. Test: `test_weights_pushed_before_start_reach_the_process_server`. The README's resume section states what is and is not carried into the inference process (weights yes, the separate policy RNG counter no).
- **Weight-layout invariant.** `test_dreamer_v3_behavior_policy_weights_match_served_policy` checks, for both `separate_policy_rng` settings, that the keys and shapes of `_behavior_policy_weights` equal the rebuilt served policy's parameter tree, so a wrapper change fails in the driver rather than as a key error inside the server process.
- **Device of the rebuilt policy.** `build_serving_policy` now creates the modules directly on the server's policy device (`with torch.device(device)`), following the device-placement rule proposed in #4314, instead of building on CPU and moving. The collector's layout probe runs the policy pass on the device of the policy's own parameters and moves only the resulting layout to CPU. The process-inference smoke test gained a `cuda:0` parameter (marked `gpu`), so the GPU serving path with `separate_policy_rng=True` is covered by the GPU CI jobs.
- **Dead `env_exchange="queue"`.** Gone: the collector ignores the exchange setting when a `ProcessSlotTransport` owns the worker exchange and only rejects an explicit `shm`.

CUDA-graph inference batches stay opt-in: they broke learning for this policy because of the CudaGraphModule input-rebinding bug, now fixed on tensordict main, and they were slower than eager in the collector benchmark.

Generated with [Claude Code](https://claude.com/claude-code)
