### PR TITLE
[Doc] Agent rule: create tensors and modules on their target device

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,20 +95,16 @@ Strongly encouraged (not mandatory):
 
 ### 6b. Device placement
 
-- **Create tensors and modules directly on their target device.** Pass
-  `device=` to factory functions and constructors (`torch.zeros(...,
-  device=device)`, spec and storage `device=` arguments, `nn.Linear(...,
-  device=device)`), or build a whole model under `with torch.device(device):`.
-  Do not build on CPU and move afterwards with `.to(device)`, `.cuda()` or
-  `.to(tensor)`: the detour allocates twice, serializes host-to-device copies
-  into startup, and hides placement bugs until the move.
-- The same applies to state created at run time (buffers, replay storages,
-  initial recurrent states, RNG-driven noise): derive the device from the
-  data or parameters involved and allocate there.
-- Exceptions, which must be stated in a comment: buffers that have to live on
-  the host by design (pinned staging memory, shared-memory slots, checkpoint
-  loading to CPU before dispatch), and moving user-supplied objects whose
-  device the caller chose.
+- **Create tensors and modules directly on their target device** using
+  `device=` (factories, constructors, specs, storages) or
+  `with torch.device(device):`. Do not create on CPU then call `.to(device)`,
+  `.cuda()` or `.to(tensor)`: this adds allocations and startup copies and
+  hides placement bugs.
+- For runtime state (buffers, replay storages, initial recurrent states,
+  random noise), allocate on the device of the relevant data or parameters.
+- Document exceptions in a comment: required host allocations (pinned
+  staging memory, shared-memory slots, checkpoint loading on CPU before
+  dispatch), or moving user-supplied objects whose device the caller chose.
 
 ## 7. Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,23 @@ Strongly encouraged (not mandatory):
 - Do not work around this by overriding `to()` or `_apply()` to synchronize a
   device cache; that still encodes an invalid single-device assumption.
 
+### 6b. Device placement
+
+- **Create tensors and modules directly on their target device.** Pass
+  `device=` to factory functions and constructors (`torch.zeros(...,
+  device=device)`, spec and storage `device=` arguments, `nn.Linear(...,
+  device=device)`), or build a whole model under `with torch.device(device):`.
+  Do not build on CPU and move afterwards with `.to(device)`, `.cuda()` or
+  `.to(tensor)`: the detour allocates twice, serializes host-to-device copies
+  into startup, and hides placement bugs until the move.
+- The same applies to state created at run time (buffers, replay storages,
+  initial recurrent states, RNG-driven noise): derive the device from the
+  data or parameters involved and allocate there.
+- Exceptions, which must be stated in a comment: buffers that have to live on
+  the host by design (pinned staging memory, shared-memory slots, checkpoint
+  loading to CPU before dispatch), and moving user-supplied objects whose
+  device the caller chose.
+
 ## 7. Tests
 
 - Every new public class / function needs tests.


### PR DESCRIPTION
## Description

Adds section 6b to the agent contribution rules (`CLAUDE.md`, which `AGENTS.md` links to): tensors and modules are created directly on their target device through `device=` arguments or a `torch.device` context, never built on CPU and moved with `.to(device)` afterwards. The rule covers run-time state as well and lists the host-resident exceptions that must be stated in a comment.

## Motivation and Context

Several recent contributions built models on CPU and moved them to the training or serving device afterwards. That doubles allocations, puts host-to-device copies on the startup path and hides placement bugs until the move. The rule makes the expectation explicit for agent-authored code.

## Types of changes

- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the CONTRIBUTION guide (required)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature).
- [x] I have updated the documentation accordingly.

Generated with [Claude Code](https://claude.com/claude-code)