### PR TITLE
[Performance] Send at least 64 transitions per worker message by default

### DIFF
--- a/docs/source/reference/collectors_single.rst
+++ b/docs/source/reference/collectors_single.rst
@@ -222,15 +222,18 @@ environment cleanup hooks run. Environment factories in this mode must not start
 multiprocessing children.
 
 With process workers, ``transition_chunk_size="auto"`` (the default) makes each
-worker accumulate ``frames_per_batch // num_envs`` consecutive transitions and
-send them as one dense message, so every batch holds one contiguous run per
-environment, the layout of the synchronous collectors, and a transition waits at
-most one batch. The driver then receives one message per chunk, concatenates
-whole chunks into each batch and performs a single routed replay write per
-batch, so its cost per transition is amortized over the chunk. Pass ``1`` to
-send every transition as soon as it completes, or a larger value to amortize
-further; up to ``transition_chunk_size - 1`` transitions per environment remain
-in the worker while collection is paused or stopped. Chunked batches are dense
+worker accumulate at least 64 consecutive transitions, or
+``frames_per_batch // num_envs`` when that is larger and never more than
+``frames_per_batch``, and send them as one dense message. The driver then
+receives one message per chunk, concatenates whole chunks into each batch and
+performs a single routed replay write per batch, so its cost per transition is
+amortized over the chunk; that work competes with training, and on a
+64-environment pixel workload 16-transition messages collected 17% slower than
+64-transition ones. A transition reaches the driver once its chunk is complete,
+about 64 environment steps later. Pass ``1`` to send every transition as soon as
+it completes, or another value to trade delivery latency against driver work; up
+to ``transition_chunk_size - 1`` transitions per environment remain in the worker
+while collection is paused or stopped. Chunked batches are dense
 :class:`~tensordict.TensorDict` instances whose ``env_index`` is a tensor.
 
 Scaling ``Collector`` across local processes

--- a/sota-implementations/dreamer_v3/README.md
+++ b/sota-implementations/dreamer_v3/README.md
@@ -73,8 +73,8 @@ With the asynchronous collector,
 dedicated process that the environment workers reach directly whenever
 `collector.async_env_backend=multiprocessing` and `collector.envs_per_worker=1`,
 and from a thread of the training process otherwise; `thread` and `process`
-force one of the two. `collector.transition_chunk_size=auto` sends one
-contiguous run per environment and batch from each worker process. In both
+force one of the two. `collector.transition_chunk_size=auto` sends at
+least 64 consecutive transitions per worker-process message. In both
 backends collection post-processing, episode reporting, device normalization,
 and replay writes happen through the collector's standard replay integration.
 

--- a/sota-implementations/dreamer_v3/config.yaml
+++ b/sota-implementations/dreamer_v3/config.yaml
@@ -28,7 +28,8 @@ collector:
   # two.
   inference_backend: auto  # one of: auto, thread, process
   # Consecutive transitions per environment-worker message with the process
-  # backend; auto sends one contiguous run per environment and batch.
+  # backend; auto sends at least 64 (fewer messages keep the driver off the
+  # learner's way) and never more than a batch.
   transition_chunk_size: auto
   policy_device: null
   inference_max_batch_size: null  # null uses num_envs

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -4224,7 +4224,8 @@ class TestAsyncBatchedCollector:
         try:
             assert collector._uses_process_env_workers
             assert collector.server_backend == "process"
-            assert collector._transition_chunk_size == 12 // num_envs
+            # At least 64 per message, capped at one batch.
+            assert collector._transition_chunk_size == 12
             frames = 0
             for batch in collector:
                 frames += batch.numel()
@@ -4360,7 +4361,7 @@ class TestAsyncBatchedCollector:
         try:
             assert collector.server_backend == "process"
             assert collector._env_backend == "multiprocessing"
-            assert collector._transition_chunk_size == 2
+            assert collector._transition_chunk_size == 4
             assert sum(batch.numel() for batch in collector) == 8
         finally:
             collector.shutdown()

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -4349,6 +4349,33 @@ class TestAsyncBatchedCollector:
         finally:
             collector.shutdown()
 
+    @pytest.mark.parametrize(
+        "num_envs, frames_per_batch, expected",
+        [
+            # frames_per_batch // num_envs is 32: the floor of 64 applies.
+            (8, 256, 64),
+            # One run per environment and batch is longer than the floor.
+            (2, 256, 128),
+            # A batch shorter than the floor caps the message at one batch.
+            (2, 12, 12),
+        ],
+    )
+    def test_auto_transition_chunk_size_floor_and_cap(
+        self, num_envs, frames_per_batch, expected
+    ):
+        collector = AsyncBatchedCollector(
+            create_env_fn=[_counting_env_factory] * num_envs,
+            policy_factory=_make_counting_policy,
+            transport="auto",
+            frames_per_batch=frames_per_batch,
+            env_backend="multiprocessing",
+        )
+        try:
+            assert collector._uses_process_env_workers
+            assert collector._transition_chunk_size == expected
+        finally:
+            collector.shutdown()
+
     def test_process_slot_transport_implies_process_server_and_workers(self):
         """An explicit ProcessSlotTransport needs no server or env backend settings."""
         collector = AsyncBatchedCollector(

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -760,6 +760,87 @@ class AsyncBatchedCollector(BaseCollector):
         ...     print(batch.shape)
         ...     break
         >>> collector.shutdown()
+
+        The fast configuration for many process-backed environments serves the
+        policy from a dedicated inference process that the environment workers
+        reach directly, while the driver only receives dense chunks of
+        transitions. The policy is rebuilt inside that process from a picklable,
+        module-level factory and created directly on its device; the learner's
+        weights pushed before the first iteration are applied when the server
+        starts, before any request is served:
+
+        >>> import functools
+        >>> import torch
+        >>> from torchrl.modules.inference_server import (
+        ...     InferenceDeviceConfig,
+        ...     InferenceServerConfig,
+        ... )
+        >>> def make_policy(device):
+        ...     with torch.device(device):
+        ...         module = nn.Linear(4, 2)
+        ...     return TensorDictModule(
+        ...         module, in_keys=["observation"], out_keys=["action"]
+        ...     )
+        >>> num_envs = 64
+        >>> collector = AsyncBatchedCollector(
+        ...     create_env_fn=[lambda: GymEnv("CartPole-v1")] * num_envs,
+        ...     policy_factory=functools.partial(make_policy, "cuda:0"),
+        ...     frames_per_batch=1024,
+        ...     # One environment per worker process; the shared-memory exchange
+        ...     # is not involved once the workers reach the server directly.
+        ...     env_backend="multiprocessing",
+        ...     # Derive the request and response slot layouts from one
+        ...     # environment and one policy pass, then serve from a process.
+        ...     transport="auto",
+        ...     # Dense 64-step messages keep the driver off the per-transition
+        ...     # path; "auto" gives at least 64 as well.
+        ...     transition_chunk_size=64,
+        ...     server_config=InferenceServerConfig(
+        ...         max_batch_size=num_envs, min_batch_size=1, timeout=0.001
+        ...     ),
+        ...     device_config=InferenceDeviceConfig(
+        ...         policy_device="cuda:0", output_device="cpu", storing_device="cpu"
+        ...     ),
+        ... )
+        >>> collector.server_backend
+        'process'
+        >>> learner_policy = make_policy("cuda:0")  # the copy being trained
+        >>> collector.update_policy_weights_(learner_policy)
+        >>> for batch in collector:
+        ...     print(batch.shape)  # dense: whole 64-step chunks, env_index is a tensor
+        ...     break
+        torch.Size([1024])
+        >>> collector.shutdown()
+
+        The slot layouts can also be built by hand, for instance when the
+        served keys differ from what one policy pass returns. A
+        :class:`~torchrl.modules.inference_server.ProcessSlotTransport` implies
+        the process inference server and multiprocessing workers:
+
+        >>> from torchrl.modules.inference_server import ProcessSlotTransport
+        >>> env = GymEnv("CartPole-v1")
+        >>> request_spec = env.fake_tensordict().select("observation")
+        >>> response_spec = make_policy("cpu")(request_spec.clone()).select("action")
+        >>> response_spec["policy_version"] = torch.zeros((), dtype=torch.long)
+        >>> env.close()
+        >>> collector = AsyncBatchedCollector(
+        ...     create_env_fn=[lambda: GymEnv("CartPole-v1")] * num_envs,
+        ...     policy_factory=functools.partial(make_policy, "cuda:0"),
+        ...     frames_per_batch=1024,
+        ...     transport=ProcessSlotTransport(
+        ...         request_spec, response_spec, num_slots=num_envs
+        ...     ),
+        ...     transition_chunk_size=64,
+        ...     device_config=InferenceDeviceConfig(
+        ...         policy_device="cuda:0", output_device="cpu", storing_device="cpu"
+        ...     ),
+        ... )
+        >>> collector.shutdown()
+
+        Pass ``replay_buffer=`` to let a background thread write each batch to
+        replay with one routed ``extend``; the DreamerV3 example under
+        ``sota-implementations/dreamer_v3`` uses this path with a
+        :class:`~torchrl.data.ReplayBufferEnsemble` routed by ``env_index``.
     """
 
     def __init__(

--- a/torchrl/collectors/_async_batched.py
+++ b/torchrl/collectors/_async_batched.py
@@ -57,6 +57,9 @@ from torchrl.weight_update.weight_sync_schemes import WeightStrategy
 _ENV_IDX_KEY = "env_index"
 
 _POLICY_BACKENDS = ("threading", "multiprocessing", "ray", "monarch")
+# Consecutive transitions per worker message that transition_chunk_size="auto"
+# uses at least; see AsyncBatchedCollector.
+_AUTO_TRANSITION_CHUNK = 64
 _ENV_BACKENDS = ("threading", "multiprocessing")
 _PauseRequest = tuple[threading.Barrier, threading.Event]
 
@@ -655,10 +658,14 @@ class AsyncBatchedCollector(BaseCollector):
             transitions each environment worker process accumulates before
             sending them to the driver as one dense message. Requires a
             :class:`~torchrl.modules.inference_server.ProcessSlotTransport`.
-            ``"auto"`` (default) uses ``frames_per_batch // len(create_env_fn)``
-            with process workers, so each batch holds one contiguous run per
-            environment like the synchronous collectors and a transition waits
-            at most one batch; it resolves to ``1`` otherwise.
+            ``"auto"`` (default) uses at least 64 consecutive transitions per
+            message with process workers, ``frames_per_batch //
+            len(create_env_fn)`` when that is larger, and never more than
+            ``frames_per_batch``: the driver's work per message competes with
+            training, and smaller messages measurably slow collection down. A
+            transition reaches the driver once its message is complete, about
+            64 environment steps later; pass ``1`` for step-level delivery.
+            It resolves to ``1`` without process workers.
             ``1`` sends every transition as soon as it completes.
             Larger values take the driver off the per-transition path: it
             receives one message per chunk, concatenates whole chunks into
@@ -1074,10 +1081,15 @@ class AsyncBatchedCollector(BaseCollector):
 
         # ---- resolve the chunk size -------------------------------------------
         if transition_chunk_size == "auto":
-            # One contiguous run per environment and batch, the layout of the
-            # synchronous collectors, so a transition waits at most one batch.
+            # The driver's work per message competes with training: with 64
+            # environments and 1024-frame batches, frames_per_batch // num_envs
+            # (16) collected 17% slower than 64 transitions per message. Never
+            # more than one batch per message.
             transition_chunk_size = (
-                max(1, frames_per_batch // self._num_envs)
+                min(
+                    max(frames_per_batch // self._num_envs, _AUTO_TRANSITION_CHUNK),
+                    max(frames_per_batch, 1),
+                )
                 if uses_process_env_workers
                 else 1
             )


### PR DESCRIPTION
## Description

`transition_chunk_size="auto"` now resolves to at least 64 consecutive transitions per environment-worker message with process slots, `frames_per_batch // num_envs` when that is larger, and never more than `frames_per_batch`. It resolved to `frames_per_batch // num_envs` before, chosen so that each batch held one contiguous run per environment and a transition waited at most one batch.

The driver's work per message (unpickling, concatenation, the routed replay write) competes with training for the interpreter, so the message count matters more than that layout. Two otherwise identical runs of the DreamerV3 example on the 64-environment pixel task (1,024-frame batches, process slots, compiled learner, train ratio 16), started within a minute of each other on identical hardware:

| `transition_chunk_size` | Steps/s (last window, 38 min in) | Learner updates/s |
| --- | ---: | ---: |
| `auto` = 16 (previous rule) | 1,012 | 1.98 |
| 64 | 1,227 | 2.40 |

The 64-transition run matches the throughput measured for the performance stack before it merged (1,252 steps/s, 2.45 updates/s). The gap was the same at the 30-minute status.

What changes for users:
- Delivery latency: a transition reaches the driver about 64 environment steps after it was produced instead of one batch's worth. With a replay buffer, which is how this path is used, that is irrelevant; consumers that iterate over batches and need step-level freshness pass `transition_chunk_size=1`.
- Batch composition: a batch may now contain runs from a subset of the environments rather than one run per environment. Replay routing is per environment stream, so replay users see no difference.
- Small batches are unaffected: the message never exceeds `frames_per_batch`.

Docstring, the collector documentation, the DreamerV3 README and config comment state the new rule and the trade-off. The two tests that asserted the resolved value are updated (they exercise the cap), and `test_auto_transition_chunk_size_floor_and_cap` checks the floor (8 environments x 256 frames: previous rule 32, resolved 64), a per-environment run above the floor (2 x 256: 128) and the cap (2 x 12: 12).

The class docstring gains a second example showing the tuned configuration end to end: a picklable, device-aware policy factory, `transport="auto"` with multiprocessing workers, `transition_chunk_size=64`, explicit server and device configurations, the resolved `server_backend`, a weight push before the first iteration, and the same layouts built by hand with `ProcessSlotTransport`.

## Motivation and Context

Follow-up to #4313. The default should be the fast configuration; the benchmark above shows the previous rule left about 17% of collection throughput unused on the workload the process-slot path was built for.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [x] Performance (default value change of an unreleased option)

## Checklist

- [x] I have read the CONTRIBUTION guide (required)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (required for a bug fix or a new feature).
- [x] I have updated the documentation accordingly.

Generated with [Claude Code](https://claude.com/claude-code)
