### PR TITLE
[BugFix] Clamp negative MultiCategorical projections

### DIFF
--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -321,6 +321,23 @@ class TestRanges:
             projection[..., 0] = -1
         assert not ts.is_in(projection)
 
+    @pytest.mark.parametrize(
+        "dtype", [torch.float32, torch.int64, torch.uint8, torch.bool]
+    )
+    @pytest.mark.parametrize(
+        "nvec, value, expected",
+        [
+            (3, -2, 0),
+            ([3, 2, 4], [[-1, 1, 6], [2, -3, -4]], [[0, 1, 3], [2, 0, 0]]),
+            ([[2, 4], [3, 2]], [[-1, 8], [5, -2]], [[0, 3], [2, 0]]),
+        ],
+    )
+    def test_multi_discrete_project_out_of_bounds(self, dtype, nvec, value, expected):
+        spec = MultiCategorical(nvec, dtype=dtype)
+        projected = spec.project(torch.tensor(value))
+        torch.testing.assert_close(projected, torch.tensor(expected, dtype=dtype))
+        assert spec.is_in(projected)
+
     @pytest.mark.parametrize("n", [1, 4, 7, 99])
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("shape", [None, [], [1], [1, 2]])

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -4843,7 +4843,7 @@ class MultiCategorical(Categorical):
             val = val.unsqueeze(0)
         if not self.dtype.is_floating_point:
             val = torch.round(val)
-        val = val.type(self.dtype)
+        val = val.clamp_min(0).type(self.dtype)
         val[val >= self.nvec] = (self.nvec.expand_as(val)[val >= self.nvec] - 1).type(
             self.dtype
         )


### PR DESCRIPTION
## Description

Clamp negative values to zero in `MultiCategorical.project()` before converting to the output dtype. For example, projecting `[-1, 4]` with cardinalities `[3, 2]` now produces `[0, 1]`, which belongs to the spec, instead of `[-1, 1]`.

## Motivation and Context

The missing lower bound violates the documented projection contract and allows invalid negative actions through `SafeModule(safe=True)`. Applying the clamp before the dtype conversion also preserves boolean outputs and prevents unsigned wraparound.

Closes #4316.

- [x] I have raised an issue to propose this change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the contribution guide.
- [x] I have updated the tests accordingly.

## Validation

- `python -m pytest test/test_specs.py -k multi_discrete -q --tb=short` — 83 passed.
- The regression checks exact projected values and domain membership for scalar inputs, batched samples, heterogeneous cardinalities, and signed, floating, unsigned, and boolean output dtypes.
- Manually checked direct projection and a `SafeModule` using a nested action key.
- All applicable pre-commit hooks passed for the two changed files; the pinned formatter hooks ran under Python 3.11 for wheel compatibility.
