### PR TITLE
[BugFix] TensorDictPrimer fills non-float specs as float32

### DIFF
--- a/test/transforms/test_compose_and_env.py
+++ b/test/transforms/test_compose_and_env.py
@@ -1440,6 +1440,28 @@ class TestTensorDictPrimer(TransformBase):
         assert "mykey" in env.reset().keys()
         assert ("next", "mykey") in env.rollout(3).keys(True)
 
+    def test_spec_dtype_respected(self):
+        """The float default fill must not promote int/bool specs to float32."""
+        env = TransformedEnv(
+            ContinuousActionVecMockEnv(),
+            TensorDictPrimer(
+                intkey=Unbounded([1], dtype=torch.long),
+                boolkey=Unbounded([1], dtype=torch.bool),
+            ),
+        )
+        check_env_specs(env)
+        reset = env.reset()
+        assert reset["intkey"].dtype is torch.long
+        assert reset["boolkey"].dtype is torch.bool
+        rollout = env.rollout(3)
+        assert rollout[("next", "intkey")].dtype is torch.long
+        assert rollout[("next", "boolkey")].dtype is torch.bool
+
+        t = TensorDictPrimer(intkey=Unbounded([1], dtype=torch.long))
+        td = TensorDict({"a": torch.zeros(())}, [])
+        t(td)
+        assert td["intkey"].dtype is torch.long
+
     def test_nested_key_env(self):
         env = MultiKeyCountingEnv()
         env_obs_spec_prior_primer = env.observation_spec.clone()

--- a/torchrl/envs/transforms/_env.py
+++ b/torchrl/envs/transforms/_env.py
@@ -538,6 +538,7 @@ class TensorDictPrimer(Transform):
                         spec.shape,
                         value,
                         device=spec.device,
+                        dtype=spec.dtype,
                     )
 
             tensordict.set(key, value)
@@ -643,8 +644,11 @@ class TensorDictPrimer(Transform):
                             spec.shape,
                             value,
                             device=spec.device,
+                            dtype=spec.dtype,
                         )
-                        prev_val = tensordict.get(key, 0.0)
+                        prev_val = tensordict.get(key, default=None)
+                        if prev_val is None:
+                            prev_val = torch.zeros_like(value)
                         value = torch.where(
                             expand_as_right(_reset, value), value, prev_val
                         )


### PR DESCRIPTION
## Description

`TensorDictPrimer` fills missing entries with `torch.full(spec.shape, 0.0, device=...)` without passing `spec.dtype`, and merges partial resets with `torch.where` against a Python-float default, so integer and boolean primer entries are silently promoted to float32 at reset and at `_step`. The two sites now pass `dtype=spec.dtype` and default the previous value to `torch.zeros_like(value)`.

Split out of #4193, where a `torch.long` position counter primed for the transformer module exposed it; the fix is independent of that module.

## Motivation and Context

A primer declared with an integer or boolean spec must produce tensors of that dtype, otherwise downstream indexing and equality checks fail or silently change meaning.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

- [x] I have read the CONTRIBUTION guide (required)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (required for a bug fix or a new feature).
- [x] I have updated the documentation accordingly.

## Tests

- `test/transforms/test_compose_and_env.py::TestTensorDictPrimer::test_spec_dtype_respected`: integer and boolean primer entries keep their spec dtype through `reset` and `step`.