### PR TITLE
[Versioning] Require TensorDict 0.14.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "numpy",
     "packaging",
     "cloudpickle",
-    "tensordict>=0.14.1,<0.15.0",
+    "tensordict>=0.14.2,<0.15.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

- raise the minimum supported TensorDict version to 0.14.2
- ensure TorchRL installations include the dependency fixes required by the current codebase

## Validation

- `git diff --check`
- metadata-only change; existing packaging and CI jobs validate dependency resolution