### PR TITLE
[CI] Fix DreamerV3 process benchmark exchange

### DIFF
--- a/benchmarks/test_dreamer_v3_benchmark.py
+++ b/benchmarks/test_dreamer_v3_benchmark.py
@@ -60,6 +60,8 @@ def _benchmark_config(
     cfg = OmegaConf.load(BENCHMARK_DIR / "dreamer_v3.yaml")
     if has_backend:
         cfg.collector.inference_backend = inference_backend
+    if inference_backend == "process":
+        cfg.collector.env_exchange = "auto"
     cfg.optimization.device = device
     cfg.optimization.train_ratio = train_ratio
     cfg.logger.metrics_jsonl = str(metrics)


### PR DESCRIPTION
## Summary

- keep shared-memory environment exchange for the thread-inference benchmark series
- use `env_exchange=auto` when the process-inference series selects `ProcessSlotTransport`, which owns the environment-worker exchange

Fixes the repeated process-series failures in the continuous benchmark.

## Validation

- `git diff --check`
- the existing process-backend DreamerV3 benchmark cases provide regression coverage