### PR TITLE
[CI] Install psutil in Windows unit tests

### DIFF
--- a/.github/unittest/windows_optdepts/scripts/unittest.sh
+++ b/.github/unittest/windows_optdepts/scripts/unittest.sh
@@ -35,7 +35,7 @@ echo $(python --version)
 echo $(conda info -e)
 
 echo "=== Installing test dependencies ==="
-python -m pip install hypothesis future cloudpickle pytest pytest-cov pytest-mock pytest-instafail pytest-rerunfailures expecttest pyyaml scipy coverage
+python -m pip install hypothesis future cloudpickle psutil pytest pytest-cov pytest-mock pytest-instafail pytest-rerunfailures expecttest pyyaml scipy coverage
 
 # =================================== Install =================================================
 


### PR DESCRIPTION
## Summary

- install `psutil` in the Windows unit-test environment
- unblock collection of `test/test_inference_server.py`

## Context

The same collection failure occurred on two consecutive `release/0.14.0` runs: [34378795236](https://github.com/pytorch/rl/actions/runs/34378795236) and [34457989393](https://github.com/pytorch/rl/actions/runs/34457989393). The test module imports `psutil`, but the Windows setup script did not install it.

## Testing

- `bash -n .github/unittest/windows_optdepts/scripts/unittest.sh`
- `git diff --check`

No additional test is warranted: this is a CI environment dependency correction, and successful Windows test collection directly verifies it.