### PR TITLE
[CI] Update SGLang CUDA bindings constraint

### DIFF
--- a/.github/unittest/llm/scripts_sglang/install.sh
+++ b/.github/unittest/llm/scripts_sglang/install.sh
@@ -115,7 +115,7 @@ uv pip install --reinstall --index-url https://pypi.org/simple "torchvision===0.
 # Keep secondary dependencies inside the ranges required by the latest SGLang
 # dependency set so uv pip check catches real breakage instead of resolver drift.
 printf "* Constraining secondary dependencies for SGLang\n"
-uv pip install "cuda-bindings~=13.3.1" "pillow>=9.2,<12" "numpy>=1.25,<2.4" "fsspec[http]<=2026.2.0"
+uv pip install "cuda-bindings~=13.4.1" "pillow>=9.2,<12" "numpy>=1.25,<2.4" "fsspec[http]<=2026.2.0"
 
 # Install MCP dependencies for tool execution tests
 printf "* Installing MCP dependencies (uvx, Deno)\n"


### PR DESCRIPTION
## Summary

- update the SGLang test environment to install the CUDA bindings range required by `cuda-python`
- remove the CUDA bindings incompatibility reported by `uv pip check` after upstream dependency drift

## Context

The same incompatibility appears on both [main](https://github.com/pytorch/rl/actions/runs/34457819014) and the [release branch](https://github.com/pytorch/rl/actions/runs/34457989445): `cuda-python` requires `cuda-bindings~=13.4.1`, while the CI script pins `~=13.3.1`. The main run also reports an independent TensorDict source-version metadata mismatch; that mismatch is absent on the release branch, which correctly installs the stable TensorDict package.

## Testing

- `bash -n .github/unittest/llm/scripts_sglang/install.sh`
- `git diff --check`

No additional test is warranted: this only repairs the CI dependency constraint, and the SGLang workflow’s existing `uv pip check` directly verifies it.