### PR TITLE
[BugFix] Preserve typed state through specs and environment buffers

### DIFF
--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -238,7 +238,9 @@ export pybind11_DIR
 
 # install tensordict
 if [[ "$RELEASE" == 0 ]]; then
-  uv_pip_install --no-build-isolation --no-deps git+https://github.com/pytorch/tensordict.git
+  # Draft dependency: TensorDict #1766 plus #1789 (typed nested key traversal).
+  # Remove this pin once both prerequisites have merged into TensorDict main.
+  uv_pip_install --no-build-isolation --no-deps git+https://github.com/pytorch/tensordict.git@786fab0440d0476c1b6f9f5d558c3791614d5723
 else
   uv_pip_install --no-deps tensordict
 fi

--- a/.github/unittest/linux/scripts/run_all.sh
+++ b/.github/unittest/linux/scripts/run_all.sh
@@ -238,9 +238,9 @@ export pybind11_DIR
 
 # install tensordict
 if [[ "$RELEASE" == 0 ]]; then
-  # Draft dependency: TensorDict #1766 plus #1789 (typed nested key traversal).
-  # Remove this pin once both prerequisites have merged into TensorDict main.
-  uv_pip_install --no-build-isolation --no-deps git+https://github.com/pytorch/tensordict.git@786fab0440d0476c1b6f9f5d558c3791614d5723
+  # Draft dependency: TensorDict #1789 (typed key traversal and compilation).
+  # Remove this pin once the prerequisite has merged into TensorDict main.
+  uv_pip_install --no-build-isolation --no-deps git+https://github.com/pytorch/tensordict.git@2d252bfae380f150a6136930d7d7a5833d68ecf1
 else
   uv_pip_install --no-deps tensordict
 fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,7 +83,7 @@ jobs:
   lint-done:
     name: lint-done
     needs: [python-source-and-configs, c-source]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Check lint results

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -431,7 +431,7 @@ jobs:
       - tests-optdeps
       - tests-stable-gpu
       - tests-stable-gpu-distributed
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/test/envs/test_step_mdp.py
+++ b/test/envs/test_step_mdp.py
@@ -26,6 +26,7 @@ from torchrl.envs.utils import (
     step_mdp,
 )
 from torchrl.testing import get_default_devices, HALFCHEETAH_VERSIONED
+from torchrl.testing._state_candidates import _STATE_CLASSES
 from torchrl.testing.mocking_classes import (
     ContinuousActionVecMockEnv,
     CountingBatchedEnv,
@@ -40,6 +41,27 @@ _has_gymnasium = importlib.util.find_spec("gymnasium") is not None
 
 @pytest.mark.filterwarnings("error")
 class TestStepMdp:
+    @pytest.mark.parametrize("container", ["td", "tc", "ttd"])
+    @pytest.mark.parametrize("optimized", [False, True])
+    def test_typed_state_replaces_plain_destination(self, container, optimized):
+        cls = _STATE_CLASSES["gru"][container]
+        state = cls.from_dict({"carry": torch.ones(2, 3)}, batch_size=[2])
+        data = TensorDict(
+            {"state": {"carry": torch.zeros(2, 3)}, "next": {"state": state}}, [2]
+        )
+        if optimized:
+            result = _StepMDP._grab_and_place(
+                {"state": {"carry": None}},
+                data["next"],
+                data.exclude("next").clone(),
+                True,
+            )
+        else:
+            result = step_mdp(data)
+        assert type(result.get("state")) is cls
+        torch.testing.assert_close(result.get(("state", "carry")), state.get("carry"))
+        assert data.get(("state", "carry")).eq(0).all()
+
     @pytest.mark.parametrize("keep_other", [True, False])
     @pytest.mark.parametrize("exclude_reward", [True, False])
     @pytest.mark.parametrize("exclude_done", [True, False])

--- a/test/test_inference_server.py
+++ b/test/test_inference_server.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import concurrent.futures
 import contextlib
 import functools as ft
+import gc
 import importlib.util
 import logging
 import multiprocessing as mp
@@ -547,6 +548,9 @@ class TestInferenceServerCore:
     @pytest.mark.parametrize("metadata", [False, True])
     @set_capture_non_tensor_stack(True)
     def test_static_batch_pads_slices_and_owns_results(self, metadata):
+        # Collect previous servers' reference cycles before capturing: their
+        # CUDA graph destructors must not run during this case's capture.
+        gc.collect()
         policy = TensorDictModule(
             _BatchSizeModule(), in_keys=["observation"], out_keys=["action"]
         )

--- a/test/test_specs.py
+++ b/test/test_specs.py
@@ -42,11 +42,44 @@ from torchrl.data.tensor_specs import (
 from torchrl.data.utils import check_no_exclusive_keys, consolidate_spec
 
 from torchrl.testing import get_available_devices, get_default_devices, set_global_var
+from torchrl.testing._state_candidates import _STATE_CLASSES
 
 pytestmark = [
     pytest.mark.filterwarnings("error"),
     pytest.mark.filterwarnings("ignore: memoized encoding is an experimental feature"),
 ]
+
+
+@pytest.mark.parametrize("container", ["td", "tc", "ttd"])
+@pytest.mark.parametrize("memo", [False, True])
+@pytest.mark.parametrize("source_kind", ["dict", "container"])
+def test_composite_typed_state_encode(container, memo, source_kind):
+    cls = _STATE_CLASSES["gtrxl"][container]
+    spec = Composite(
+        memory=Unbounded((2, 3, 4, 8)),
+        valid=Binary(shape=(2, 4), dtype=torch.bool),
+        shape=(2,),
+        data_cls=cls,
+    )
+    spec.memoize_encode(memo)
+    for _ in range(2):
+        original = spec.zero()
+        source = original if source_kind == "container" else original.to_dict()
+        encoded = spec.encode(source)
+        assert type(encoded) is cls
+        assert encoded.batch_size == original.batch_size
+        assert encoded.get("valid").dtype is torch.bool
+        torch.testing.assert_close(encoded.get("memory"), original.get("memory"))
+        spec.type_check(encoded)
+        assert spec.is_in(encoded)
+    expanded = spec.clone().expand(3, 2)
+    assert expanded.data_cls is cls
+    assert type(expanded.rand()) is cls
+    outer_spec = Composite(state=spec, shape=spec.shape)
+    invalid = outer_spec.zero()
+    invalid.get("state").set("memory", invalid.get(("state", "memory")).long())
+    with pytest.raises(TypeError):
+        outer_spec.type_check(invalid)
 
 
 class TestRanges:

--- a/test/transforms/test_compose_and_env.py
+++ b/test/transforms/test_compose_and_env.py
@@ -85,6 +85,7 @@ from torchrl.testing import (  # noqa
     rand_reset,
     retry,
 )
+from torchrl.testing._state_candidates import _STATE_CLASSES
 from torchrl.testing.mocking_classes import (
     ContinuousActionVecMockEnv,
     CountingEnv,
@@ -1451,6 +1452,41 @@ class TestBatchSizeTransform(TransformBase):
 
 
 class TestTensorDictPrimer(TransformBase):
+    @pytest.mark.parametrize("container", ["td", "tc", "ttd"])
+    def test_typed_state_partial_reset(self, container):
+        cls = _STATE_CLASSES["gtrxl"][container]
+        state_spec = Composite(
+            memory=Unbounded((2, 3, 8)),
+            valid=Unbounded((3,), dtype=torch.bool),
+            data_cls=cls,
+        )
+        primer = TensorDictPrimer(
+            Composite(
+                {
+                    ("agent", "state"): state_spec,
+                    "counter": Unbounded((1,), dtype=torch.long),
+                }
+            ),
+            expand_specs=True,
+        )
+        env = TransformedEnv(SerialEnv(2, ContinuousActionVecMockEnv), primer)
+        try:
+            td = env.reset()
+            state = td.get(("agent", "state"))
+            state.get("memory").fill_(3)
+            state.get("valid").fill_(True)
+            td.set("_reset", torch.tensor([[True], [False]]))
+            result = env.reset(td)
+            state = result.get(("agent", "state"))
+            assert type(state) is cls
+            assert state.get("memory")[0].eq(0).all()
+            assert state.get("memory")[1].eq(3).all()
+            assert not state.get("valid")[0].any()
+            assert state.get("valid")[1].all()
+            assert result["counter"].dtype is torch.long
+        finally:
+            env.close()
+
     def test_single_trans_env_check(self):
         env = TransformedEnv(
             ContinuousActionVecMockEnv(),

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -5063,7 +5063,7 @@ class Composite(TensorSpec):
             to ``None``.
         shape (torch.Size): the leading shape of all the leaves. Equivalent
             to the batch-size of the corresponding tensordicts.
-        data_cls (type, optional): the tensordict subclass (TensorDict, TensorClass, tensorclass...) that should be
+        data_cls (type, optional): the tensor container class (TensorDict, TypedTensorDict, TensorClass, tensorclass...) that should be
             enforced in the env. Defaults to ``None``.
         step_mdp_static (bool, optional): whether the spec is static under step_mdp. Defaults to ``False``.
             Defining a `Composite` as a step_mdp_static spec will make it so that the entire related TensorDict/TensorClass
@@ -5631,10 +5631,10 @@ class Composite(TensorSpec):
     def _encode_eager(
         self, vals: dict[str, Any], *, ignore_device: bool = False
     ) -> dict[str, torch.Tensor]:
-        if isinstance(vals, TensorDict):
+        if isinstance(vals, TensorDictBase):
             out = vals.empty()  # create and empty tensordict similar to vals
         elif self.data_cls is not None:
-            out = {}
+            out = TensorDict({}, batch_size=getattr(vals, "batch_size", self.shape))
         else:
             out = TensorDict._new_unsafe({}, self.shape)
         for key, item in vals.items():
@@ -5653,7 +5653,7 @@ class Composite(TensorSpec):
                     f"Encoding key {key} raised a RuntimeError. Scroll up to know more."
                 ) from err
         if self.data_cls is not None:
-            return self.data_cls.from_dict(out)
+            return self.data_cls.from_dict(out, batch_size=out.batch_size)
         return out
 
     def _encode_memo(
@@ -5673,7 +5673,7 @@ class Composite(TensorSpec):
         elif self.data_cls is not None:
 
             def empty(vals):
-                out = {}
+                out = TensorDict({}, batch_size=getattr(vals, "batch_size", self.shape))
                 return vals, out
 
         else:
@@ -5705,7 +5705,11 @@ class Composite(TensorSpec):
 
         funcs.append(populate)
         if self.data_cls is not None:
-            funcs.append(self.data_cls.from_dict)
+
+            def cast(out):
+                return self.data_cls.from_dict(out, batch_size=out.batch_size)
+
+            funcs.append(cast)
         if len(funcs) == 0:
             self._encode_memo_dict[ignore_device] = lambda x: x
         elif len(funcs) == 1:
@@ -5738,7 +5742,14 @@ class Composite(TensorSpec):
             if self[_key] is not None and (
                 selected_keys is None or _key in selected_keys
             ):
-                self._specs[_key].type_check(value[_key], _key)
+                item = value.get(_key, NO_DEFAULT)
+                if item is NO_DEFAULT:
+                    raise KeyError(_key)
+                spec = self._specs[_key]
+                if isinstance(spec, Composite):
+                    spec.type_check(item)
+                else:
+                    spec.type_check(item, _key)
 
     def is_in(self, val: dict | TensorDictBase) -> bool:
         # TODO: make warnings for these

--- a/torchrl/envs/transforms/_env.py
+++ b/torchrl/envs/transforms/_env.py
@@ -370,6 +370,13 @@ class TensorDictPrimer(Transform):
                 extra_kwargs = {}
             primers = Composite(kwargs, device=device, shape=shape, **extra_kwargs)
         self.primers = primers
+        # Leaf-wise initialization otherwise creates plain TensorDict parents.
+        # Restore children before parents, without copying their tensor storage.
+        self._data_classes = tuple(
+            (key, spec.data_cls)
+            for key, spec in reversed(list(primers.items(True)))
+            if isinstance(spec, Composite) and spec.data_cls is not None
+        )
         self.expand_specs = expand_specs
         self.call_before_env_reset = call_before_env_reset
 
@@ -511,6 +518,8 @@ class TensorDictPrimer(Transform):
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         if self.single_default_value and callable(self.default_value):
             tensordict.update(self.default_value())
+            if self._data_classes:
+                self._restore_data_classes(tensordict)
             for key, spec in self.primers.items(True, True):
                 if not self._validated:
                     self._validate_value_tensor(tensordict.get(key), spec)
@@ -542,9 +551,17 @@ class TensorDictPrimer(Transform):
                     )
 
             tensordict.set(key, value)
+        if self._data_classes:
+            self._restore_data_classes(tensordict)
         if not self._validated:
             self._validated = True
         return tensordict
+
+    def _restore_data_classes(self, tensordict):
+        for key, data_cls in self._data_classes:
+            value = tensordict.get(key, None)
+            if value is not None and type(value) is not data_cls:
+                tensordict.set(key, data_cls.from_tensordict(value))
 
     def _step(
         self, tensordict: TensorDictBase, next_tensordict: TensorDictBase
@@ -555,6 +572,8 @@ class TensorDictPrimer(Transform):
             if key not in next_tensordict.keys(True, is_leaf=_is_leaf_nontensor):
                 prev_val = tensordict.get(key)
                 next_tensordict.set(key, prev_val)
+        if self._data_classes:
+            self._restore_data_classes(next_tensordict)
         return next_tensordict
 
     def _reset(
@@ -622,6 +641,8 @@ class TensorDictPrimer(Transform):
                 for key, spec in self.primers.items(True, True):
                     if not self._validated:
                         self._validate_value_tensor(tensordict_reset.get(key), spec)
+                if self._data_classes:
+                    self._restore_data_classes(tensordict_reset)
                 self._validated = True
                 return tensordict_reset
 
@@ -654,6 +675,8 @@ class TensorDictPrimer(Transform):
                         )
                 tensordict_reset.set(key, value)
             self._validated = True
+        if self._data_classes:
+            self._restore_data_classes(tensordict_reset)
         return tensordict_reset
 
     def __repr__(self) -> str:

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -218,6 +218,8 @@ class _StepMDP:
                 val_out = data_out._get_str(key, None)
                 if val_out is None or val_out.batch_size != val.batch_size:
                     val_out = val.empty(batch_size=val.batch_size)
+                elif type(val_out) is not type(val):
+                    val_out = type(val).from_dict(val_out, batch_size=val.batch_size)
                 if isinstance(val, LazyStackedTensorDict):
 
                     val = LazyStackedTensorDict.lazy_stack(
@@ -554,6 +556,8 @@ def _set(source, dest, key, total_key, excluded):
                 new_val = dest.get(key, None)
                 if new_val is None:
                     new_val = val.empty()
+                elif type(new_val) is not type(val):
+                    new_val = type(val).from_dict(new_val, batch_size=val.batch_size)
                 non_empty_local = False
                 for subkey in val.keys():
                     non_empty_local = (

--- a/torchrl/testing/_state_candidates.py
+++ b/torchrl/testing/_state_candidates.py
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Shared, private fixtures for the recurrent-state comparison and benchmarks."""
+from __future__ import annotations
+
+import torch
+from tensordict import TensorClass, TensorDict, TypedTensorDict
+
+
+class _GTrXLTC(TensorClass):
+    memory: torch.Tensor
+    valid: torch.Tensor
+
+
+class _GTrXLTTD(TypedTensorDict):
+    memory: torch.Tensor
+    valid: torch.Tensor
+
+
+_STATE_CLASSES = {
+    "gtrxl": {"td": TensorDict, "tc": _GTrXLTC, "ttd": _GTrXLTTD},
+}

--- a/torchrl/testing/_state_candidates.py
+++ b/torchrl/testing/_state_candidates.py
@@ -9,6 +9,14 @@ import torch
 from tensordict import TensorClass, TensorDict, TypedTensorDict
 
 
+class _GRUTC(TensorClass):
+    carry: torch.Tensor
+
+
+class _GRUTTD(TypedTensorDict):
+    carry: torch.Tensor
+
+
 class _GTrXLTC(TensorClass):
     memory: torch.Tensor
     valid: torch.Tensor
@@ -20,5 +28,6 @@ class _GTrXLTTD(TypedTensorDict):
 
 
 _STATE_CLASSES = {
+    "gru": {"td": TensorDict, "tc": _GRUTC, "ttd": _GRUTTD},
     "gtrxl": {"td": TensorDict, "tc": _GTrXLTC, "ttd": _GTrXLTTD},
 }


### PR DESCRIPTION
## Description

Preserve `Composite(data_cls=...)` containers across spec encoding, environment initialization, partial resets and `step_mdp` copies into existing buffers. Encoding now retains batch metadata, nested dtype checks work with tensorclass access, and leaf-wise writes restore the declared nested class.

Container restoration paths are prepared when the primer is constructed. This adds no new spec subclass, global registry or per-step tensor-spec validation.

## Motivation and Context

Structured recurrent state needs to retain its class and batch dimensions while moving through environment data. Previously a primer or a copy into a plain destination could turn a typed state into a plain TensorDict, and `Composite.type_check()` failed on tensorclass string indexing.

Related discussion: #2325.

## Stack and dependencies

Draft stack: **#4324 (this PR)** → #4325 (explicit transformer state) → #4326 (comparison benchmarks). Each child targets its parent branch so the diffs are independently reviewable. Existing GRU/LSTM defaults remain unchanged, and this PR makes no public state-container selection.

The typed candidate tests use the merged [TensorDict #1766](https://github.com/pytorch/tensordict/pull/1766) and still depend on [TensorDict #1789](https://github.com/pytorch/tensordict/pull/1789) for nested-key traversal and compiled state wrapping. The Linux integration suite temporarily pins TensorDict to `2d252bfae380f150a6136930d7d7a5833d68ecf1`, the exact #1789 head. Remove the pin after #1789 merges; release installation remains unchanged.

Coverage upload and the lint summary still run after failures, but skip cancelled workflows so superseded stack runs cannot report missing artifacts or false lint failures.

## Validation

```sh
python -m pytest test/test_specs.py test/envs/test_step_mdp.py::TestStepMdp \
  test/transforms/test_compose_and_env.py::TestTensorDictPrimer -q
```

**3,100 passed, 16 skipped** on CPU with PyTorch 2.11.0 and the TensorDict dependency branches. Skips cover CUDA-only cases and existing primer cases without an inverse or meaningful random variant. Formatting, flake8 and whitespace checks pass.

The compatibility branch includes its own GRU fixtures so it can be tested independently of the transformer PR. The existing static-batch GPU test collects previous servers' reference cycles before capture to isolate CUDA graph lifetimes; that cleanup passed the previous nightly and stable GPU CI runs.

The compact parametrized regressions cover eager/memoized encoding, nested dtype failures, class preservation in both step_mdp implementations, partial resets and boolean/integer metadata.

## Types of changes

- [x] Bug fix

## Checklist

- [x] I have read the contribution guide.
- [x] I have updated the tests accordingly.
- [x] I have updated the relevant spec documentation.

