### PR TITLE
[Feature] Add explicit transformer state and recurrent container candidates

### DIFF
--- a/test/modules/test_transformer.py
+++ b/test/modules/test_transformer.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import copy
 import os
 import pickle
+from functools import partial
 
 import pytest
 import torch
@@ -16,13 +18,28 @@ from tensordict.nn import TensorDictModule, TensorDictSequential
 from torch import nn
 
 from torchrl.collectors import Collector
-from torchrl.envs import InitTracker, SerialEnv, TransformedEnv
+from torchrl.data import (
+    LazyMemmapStorage,
+    LazyTensorStorage,
+    SliceSampler,
+    TensorDictReplayBuffer,
+)
+from torchrl.envs import (
+    check_env_specs,
+    Compose,
+    InitTracker,
+    ParallelEnv,
+    SerialEnv,
+    step_mdp,
+    TransformedEnv,
+)
 from torchrl.modules import CausalTransformer, set_recurrent_mode, TransformerModule
 from torchrl.modules.tensordict_module.transformer import (
     positions_from_is_init,
     segment_causal_mask_from_is_init,
 )
 from torchrl.testing import get_default_devices
+from torchrl.testing._state_candidates import _make_candidate, _STATE_CLASSES
 from torchrl.testing.mocking_classes import ContinuousActionVecMockEnv
 
 
@@ -434,6 +451,176 @@ class TestTransformerModule:
         torch.testing.assert_close(
             second["embed"][:1], first_step["embed"], atol=1e-4, rtol=1e-4
         )
+
+
+def _explicit_state_env(kind, container):
+    module = _make_candidate(kind, container)
+    return TransformedEnv(
+        ContinuousActionVecMockEnv(),
+        Compose(InitTracker(), module.make_tensordict_primer()),
+    )
+
+
+@pytest.mark.parametrize("kind", ["gru", "lstm", "gtrxl"])
+@pytest.mark.parametrize("container", ["td", "tc", "ttd"])
+@pytest.mark.parametrize("env_kind", ["single", "serial", "parallel"])
+@pytest.mark.parametrize("storage_cls", [LazyTensorStorage, LazyMemmapStorage])
+def test_explicit_state_lifecycle(kind, container, env_kind, storage_cls, tmp_path):
+    torch.manual_seed(0)
+    module = _make_candidate(kind, container)
+    if env_kind == "single":
+        env = _explicit_state_env(kind, container)
+    else:
+        env_cls = SerialEnv if env_kind == "serial" else ParallelEnv
+        env = env_cls(2, partial(_explicit_state_env, kind, container))
+    policy = TensorDictSequential(
+        module,
+        TensorDictModule(nn.Linear(16, 7), in_keys=["embed"], out_keys=["action"]),
+    )
+    cls = _STATE_CLASSES[kind][container]
+    try:
+        check_env_specs(env)
+        collector = Collector(
+            env,
+            policy,
+            frames_per_batch=16,
+            total_frames=32,
+            auto_register_policy_transforms=False,
+        )
+        try:
+            iterator = iter(collector)
+            first = next(iterator)
+            snapshot = first.clone()
+            second = next(iterator).clone()
+            # This is checked on a clone because collector buffers are reusable.
+            first = snapshot
+        finally:
+            collector.shutdown()
+        for batch in (first, second):
+            assert type(batch.get(("agent", "state"))) is cls
+            assert type(batch.get(("next", "agent", "state"))) is cls
+        # Direct slices retain their real episode flags and initial memory.
+        window = second[..., 1:5].clone()
+        expected = window["embed"].clone()
+        with set_recurrent_mode(True):
+            actual = module(window)["embed"]
+        torch.testing.assert_close(actual, expected, atol=2e-5, rtol=2e-5)
+        storage_kwargs = (
+            {"scratch_dir": str(tmp_path)} if storage_cls is LazyMemmapStorage else {}
+        )
+        rb = TensorDictReplayBuffer(
+            storage=storage_cls(64, **storage_kwargs),
+            sampler=SliceSampler(slice_len=4, truncated_key=None),
+            batch_size=8,
+        )
+        rb.extend(torch.cat((first, second), -1).reshape(-1))
+        sample = rb.sample().reshape(2, 4)
+        assert type(sample.get(("agent", "state"))) is cls
+        assert sample["is_init"][:, 0].all()
+        expected = sample["embed"].clone()
+        with set_recurrent_mode(True):
+            actual = module(sample.clone())["embed"]
+        torch.testing.assert_close(actual, expected, atol=2e-5, rtol=2e-5)
+        if kind == "gtrxl":
+            assert sample.get(("agent", "state")).get("valid").dtype is torch.bool
+    finally:
+        if not env.is_closed:
+            env.close()
+
+
+@pytest.mark.parametrize("container", ["td", "tc", "ttd"])
+@pytest.mark.parametrize("batch_shape", [(2,), (2, 2)])
+@pytest.mark.parametrize("device", get_default_devices())
+def test_gtrxl_explicit_state_numerics(container, batch_shape, device):
+    # Each case deliberately changes the schema/shape of the same forward code.
+    torch._dynamo.reset()
+    torch.manual_seed(1)
+    module = _make_candidate("gtrxl", container, memory_len=3, device=device)
+    spec = module.transformer.state_spec
+    td = TensorDict(
+        {
+            "observation": torch.randn(*batch_shape, 7, device=device),
+            "is_init": torch.ones(*batch_shape, 1, dtype=torch.bool, device=device),
+            ("agent", "state"): spec.zero(batch_shape),
+        },
+        batch_shape,
+    )
+    trajectory = []
+    for step in range(7):
+        td["observation"] = torch.randn(*batch_shape, 7, device=device)
+        td["is_init"] = torch.zeros(*batch_shape, 1, dtype=torch.bool, device=device)
+        if step == 4:
+            td["is_init"][0] = True
+            state = td.get(("agent", "state"))
+            state[0] = spec.zero(batch_shape[1:])
+        before = td.get(("agent", "state")).clone()
+        module(td)
+        torch.testing.assert_close(
+            td.get(("agent", "state")).get("memory"), before.get("memory")
+        )
+        trajectory.append(td.clone())
+        td = step_mdp(td)
+    trajectory = torch.stack(trajectory, -1)
+    expected = trajectory["embed"].clone()
+    with set_recurrent_mode(True):
+        out = module(trajectory.clone())
+    torch.testing.assert_close(out["embed"], expected, atol=2e-5, rtol=2e-5)
+    # Compile the state-carrying window, including resets, as one graph.
+    compiled = torch.compile(module, backend="aot_eager", fullgraph=True)
+    with set_recurrent_mode(True):
+        result = compiled(trajectory.clone())
+    torch.testing.assert_close(result["embed"], expected, atol=2e-5, rtol=2e-5)
+    window = trajectory[..., 1:4].clone()
+    memory = window.get(("agent", "state")).get("memory").requires_grad_()
+    obs = window["observation"].requires_grad_()
+    with set_recurrent_mode(True):
+        module(window)["embed"][..., -1, :].square().sum().backward()
+    assert memory.grad is None
+    assert obs.grad[..., 0, :].abs().sum() > 0
+    assert all(
+        p.grad is not None and p.grad.isfinite().all() for p in module.parameters()
+    )
+    # Weight synchronization may clear module caches, but must retain the
+    # caller's supplied history, even though its activations are now stale.
+    with torch.no_grad():
+        module.transformer.embedding.bias.add_(0.1)
+    module.mark_weight_update()
+    retained = trajectory[..., 3].clone()
+    empty = retained.clone()
+    empty.get(("agent", "state")).get("valid").zero_()
+    assert not torch.allclose(module(retained)["embed"], module(empty)["embed"])
+
+
+@pytest.mark.parametrize("precision", ["float64", "bfloat16", "autocast"])
+def test_gtrxl_validity_and_precision(precision):
+    module = _make_candidate("gtrxl", "ttd", memory_len=3)
+    dtype = torch.float32 if precision == "autocast" else getattr(torch, precision)
+    module.to(dtype=dtype)
+    state = module.transformer.state_spec.zero([2])
+    state.valid[:, 1] = True  # Usable slots need not form a contiguous suffix.
+    state.memory.normal_()
+    td = TensorDict(
+        {
+            "observation": torch.randn(2, 7, dtype=dtype),
+            "is_init": torch.zeros(2, 1, dtype=torch.bool),
+            ("agent", "state"): state,
+        },
+        [2],
+    )
+    perturbed = td.clone()
+    memory = perturbed.get(("agent", "state")).memory
+    memory[:, :, [0, 2]] = 1000  # Invalid slots must not influence attention.
+    context = (
+        torch.autocast("cpu", dtype=torch.bfloat16)
+        if precision == "autocast"
+        else contextlib.nullcontext()
+    )
+    with context:
+        expected = module(td.clone())["embed"]
+        actual = module(perturbed)["embed"]
+    torch.testing.assert_close(actual, expected)
+    assert actual.isfinite().all()
+    assert module.transformer.state_spec.zero().memory.dtype is dtype
 
 
 if __name__ == "__main__":

--- a/torchrl/modules/models/_gtrxl.py
+++ b/torchrl/modules/models/_gtrxl.py
@@ -1,0 +1,191 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+"""Private GTrXL candidate for the recurrent-state container comparison.
+
+The public state class is deliberately undecided. This reference uses a
+sequential window implementation with gradients through the current window.
+See Parisotto et al., https://proceedings.mlr.press/v119/parisotto20a.html.
+"""
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from tensordict import TensorDict
+from torch import nn
+
+from torchrl.data import Binary, Composite, Unbounded
+
+
+class _GRUGate(nn.Module):
+    def __init__(self, width, bias, *, device=None, dtype=None):
+        super().__init__()
+        self.x_rz = nn.Linear(width, 2 * width, bias=False, device=device, dtype=dtype)
+        self.y_rzh = nn.Linear(width, 3 * width, bias=False, device=device, dtype=dtype)
+        self.x_h = nn.Linear(width, width, bias=False, device=device, dtype=dtype)
+        self.bias = nn.Parameter(torch.full((width,), bias, device=device, dtype=dtype))
+
+    def forward(self, x, y):
+        xr, xz = self.x_rz(x).chunk(2, -1)
+        yr, yz, yh = self.y_rzh(y).chunk(3, -1)
+        reset = (xr + yr).sigmoid()
+        update = (xz + yz - self.bias).sigmoid()
+        candidate = (yh + self.x_h(reset * x)).tanh()
+        return (1 - update) * x + update * candidate
+
+
+class _GTrXLBlock(nn.Module):
+    def __init__(
+        self, width, heads, memory_len, gate_bias, dropout, *, device=None, dtype=None
+    ):
+        super().__init__()
+        self.heads = heads
+        self.head_dim = width // heads
+        self.norm1 = nn.LayerNorm(width, device=device, dtype=dtype)
+        self.norm2 = nn.LayerNorm(width, device=device, dtype=dtype)
+        self.q = nn.Linear(width, width, bias=False, device=device, dtype=dtype)
+        self.kv = nn.Linear(width, 2 * width, bias=False, device=device, dtype=dtype)
+        self.relative = nn.Linear(width, width, bias=False, device=device, dtype=dtype)
+        self.content_bias = nn.Parameter(
+            torch.zeros(heads, self.head_dim, device=device, dtype=dtype)
+        )
+        self.position_bias = nn.Parameter(
+            torch.zeros(heads, self.head_dim, device=device, dtype=dtype)
+        )
+        self.out = nn.Linear(width, width, device=device, dtype=dtype)
+        self.mlp = nn.Sequential(
+            nn.Linear(width, 4 * width, device=device, dtype=dtype),
+            nn.ReLU(),
+            nn.Linear(4 * width, width, device=device, dtype=dtype),
+        )
+        self.dropout = nn.Dropout(dropout)
+        self.attention_gate = _GRUGate(width, gate_bias, device=device, dtype=dtype)
+        self.mlp_gate = _GRUGate(width, gate_bias, device=device, dtype=dtype)
+        distance = torch.arange(
+            memory_len, -1, -1, device=device, dtype=dtype or torch.float32
+        )
+        frequency = torch.exp(
+            -math.log(10000)
+            * torch.arange(0, width, 2, device=device, dtype=dtype or torch.float32)
+            / width
+        )
+        angle = distance[:, None] * frequency[None]
+        self.register_buffer("positions", torch.cat((angle.sin(), angle.cos()), -1))
+
+    def forward(self, current, memory, valid):
+        batch, width = current.shape
+        context = self.norm1(torch.cat((memory, current.unsqueeze(1)), 1))
+        q = self.q(context[:, -1]).reshape(batch, self.heads, self.head_dim)
+        k, v = self.kv(context).chunk(2, -1)
+        k = k.reshape(batch, -1, self.heads, self.head_dim)
+        v = v.reshape(batch, -1, self.heads, self.head_dim)
+        relative = self.relative(self.positions).reshape(-1, self.heads, self.head_dim)
+        scores = torch.einsum("bhd,bmhd->bhm", q + self.content_bias, k)
+        scores = scores + torch.einsum("bhd,mhd->bhm", q + self.position_bias, relative)
+        scores = scores / math.sqrt(self.head_dim)
+        valid = torch.cat((valid, torch.ones_like(valid[:, :1])), 1)
+        weights = scores.masked_fill(~valid[:, None], -torch.inf).softmax(-1)
+        attention = torch.einsum("bhm,bmhd->bhd", self.dropout(weights), v)
+        current = self.attention_gate(
+            current, self.dropout(F.relu(self.out(attention.reshape(batch, width))))
+        )
+        return self.mlp_gate(
+            current, self.dropout(F.relu(self.mlp(self.norm2(current))))
+        )
+
+
+class _GTrXL(nn.Module):
+    """Explicit layer-memory backbone; not exported until the comparison is reviewed."""
+
+    def __init__(
+        self,
+        input_size,
+        hidden_size=32,
+        num_layers=2,
+        *,
+        num_heads=4,
+        memory_len=16,
+        state_cls=TensorDict,
+        gate_bias=2.0,
+        dropout=0.0,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        if hidden_size % num_heads or hidden_size % 2:
+            raise ValueError("hidden_size must be even and divisible by num_heads")
+        if memory_len < 1 or num_layers < 1:
+            raise ValueError("memory_len and num_layers must be positive")
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.memory_len = memory_len
+        self.state_cls = state_cls
+        self.embedding = nn.Linear(input_size, hidden_size, device=device, dtype=dtype)
+        self.blocks = nn.ModuleList(
+            _GTrXLBlock(
+                hidden_size,
+                num_heads,
+                memory_len,
+                gate_bias,
+                dropout,
+                device=device,
+                dtype=dtype,
+            )
+            for _ in range(num_layers)
+        )
+
+    @property
+    def state_spec(self):
+        weight = self.embedding.weight
+        return Composite(
+            memory=Unbounded(
+                shape=(self.num_layers, self.memory_len, self.hidden_size),
+                dtype=weight.dtype,
+                device=weight.device,
+            ),
+            valid=Binary(
+                shape=(self.memory_len,), dtype=torch.bool, device=weight.device
+            ),
+            data_cls=self.state_cls,
+            device=weight.device,
+        )
+
+    def forward_state(self, features, state, is_init, *, recurrent):
+        # The wrapper flattens environment batch dimensions, keeping time last.
+        stored_memory = state.get("memory").detach()
+        stored_valid = state.get("valid")
+        memory = stored_memory[:, 0]
+        valid = stored_valid[:, 0]
+        outputs, memories, validity = [], [], []
+        for step in range(features.shape[1]):
+            init = is_init[:, step]
+            reset_memory = (
+                stored_memory[:, step] if recurrent else torch.zeros_like(memory)
+            )
+            reset_valid = (
+                stored_valid[:, step] if recurrent else torch.zeros_like(valid)
+            )
+            memory = torch.where(init[:, None, None, None], reset_memory, memory)
+            valid = torch.where(init[:, None], reset_valid, valid)
+            value = self.embedding(features[:, step])
+            layer_inputs = []
+            for layer, block in enumerate(self.blocks):
+                layer_inputs.append(value)
+                value = block(value, memory[:, layer], valid)
+            # Only layer inputs are needed by the next step's attention.
+            memory = torch.cat(
+                (memory[:, :, 1:], torch.stack(layer_inputs, 1).unsqueeze(2)), 2
+            )
+            valid = torch.cat((valid[:, 1:], torch.ones_like(valid[:, :1])), 1)
+            outputs.append(value)
+            memories.append(memory.detach())
+            validity.append(valid)
+        next_state = self.state_cls.from_dict(
+            {"memory": torch.stack(memories, 1), "valid": torch.stack(validity, 1)},
+            batch_size=features.shape[:2],
+            device=features.device,
+        )
+        return torch.stack(outputs, 1), next_state

--- a/torchrl/modules/tensordict_module/transformer.py
+++ b/torchrl/modules/tensordict_module/transformer.py
@@ -4,17 +4,21 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F
 
-from tensordict import TensorDictBase, unravel_key_list
+from tensordict import TensorDictBase, unravel_key, unravel_key_list
 from tensordict.nn import dispatch, TensorDictModuleBase as ModuleBase
 from torch import nn
 
 from torchrl._utils import is_compiling
+from torchrl.data.tensor_specs import Composite
 from torchrl.modules.tensordict_module.rnn import recurrent_mode
+
+if TYPE_CHECKING:
+    from torchrl.envs import TensorDictPrimer
 
 
 def positions_from_is_init(is_init: torch.Tensor) -> torch.Tensor:
@@ -395,7 +399,7 @@ class TransformerModule(ModuleBase):
     :class:`~torchrl.modules.set_recurrent_mode` context manager, exactly as
     for the recurrent modules.
 
-    Unlike the recurrent modules, no state travels in the tensordict. The
+    With the reference :class:`CausalTransformer`, no state travels in the tensordict. The
     key/value cache is inference state owned by the module instance: it is
     allocated by the backbone on the first cached step, indexed by batch
     position (one stream per environment of the batch), cleared wherever
@@ -406,6 +410,19 @@ class TransformerModule(ModuleBase):
     observations and features only, never a cache; the training path reads
     ``is_init`` to rebuild positions and a block-diagonal causal mask over the
     window.
+
+    An experimental explicit-state backbone can instead expose
+    ``forward_state(features, state, is_init, *, recurrent) -> (out, next_state)``
+    and a ``state_spec`` :class:`~torchrl.data.Composite`. The wrapper passes
+    flattened environment batches with shape ``[B, T]`` and preserves the
+    returned state container. Use ``in_keys=[features, state, "is_init"]`` and
+    ``out_keys=[out, ("next", state)]`` (including nested state keys), and attach
+    :meth:`make_tensordict_primer`. This path stores state in trajectories and
+    never reads or updates the module-owned cache. In recurrent mode the
+    backbone must initialize from stored state at the window start and each
+    ``is_init`` boundary, including boundaries inserted by a slice sampler.
+    The episode-alignment and ``max_seq_len`` restrictions below concern the
+    reference module-owned-cache path.
 
     Args:
         input_size (int, optional): number of input features. Unused if
@@ -440,7 +457,7 @@ class TransformerModule(ModuleBase):
         default_recurrent_mode (bool, optional): the recurrent mode when not
             overridden by the :class:`~torchrl.modules.set_recurrent_mode`
             context manager. Defaults to ``False``.
-        validate_windows (bool, optional): whether the window path checks that
+        validate_windows (bool, optional): whether the module-owned-cache window path checks that
             every row starts with ``is_init=True`` and raises otherwise. The
             check is data-dependent: under :func:`torch.compile` it costs one
             graph break, and ``fullgraph=True`` rejects it at compile time.
@@ -536,14 +553,15 @@ class TransformerModule(ModuleBase):
                     "A transformer instance cannot be passed along with size "
                     "arguments."
                 )
-            for attr in _BACKBONE_ATTRIBUTES:
+            explicit_state = callable(getattr(transformer, "forward_state", None))
+            for attr in () if explicit_state else _BACKBONE_ATTRIBUTES:
                 if not hasattr(transformer, attr):
                     raise ValueError(
                         "The transformer backbone must expose a "
                         f"{attr!r} attribute; see CausalTransformer for the "
                         "backbone contract."
                     )
-            for method in _BACKBONE_METHODS:
+            for method in () if explicit_state else _BACKBONE_METHODS:
                 if not callable(getattr(transformer, method, None)):
                     raise ValueError(
                         "The transformer backbone must implement "
@@ -581,14 +599,36 @@ class TransformerModule(ModuleBase):
             out_keys = [out_key]
         in_keys = unravel_key_list(in_keys)
         out_keys = unravel_key_list(out_keys)
-        if not isinstance(in_keys, (tuple, list)) or (
-            len(in_keys) != 1 and not (len(in_keys) == 2 and in_keys[-1] == "is_init")
+        self._explicit_state = callable(getattr(transformer, "forward_state", None))
+        if self._explicit_state:
+            if len(in_keys) == 2 and in_keys[-1] != "is_init":
+                in_keys = [*in_keys, "is_init"]
+            if len(in_keys) != 3 or in_keys[-1] != "is_init" or len(out_keys) != 2:
+                raise ValueError(
+                    "Explicit state requires in_keys=[features, state, 'is_init'] "
+                    "and out_keys=[features, ('next', state)]."
+                )
+            state_key = in_keys[1]
+            state_key = (state_key,) if isinstance(state_key, str) else state_key
+            if out_keys[1] != ("next", *state_key):
+                raise ValueError(
+                    "The state output key must be ('next', *state_input_key)."
+                )
+        if (
+            not isinstance(in_keys, (tuple, list))
+            or (
+                len(in_keys) != 1
+                and not (len(in_keys) == 2 and in_keys[-1] == "is_init")
+            )
+            and not self._explicit_state
         ):
             raise ValueError(
                 "TransformerModule expects 1 input: a value (and potentially "
                 f"an 'is_init' marker). Got in_keys {in_keys} instead."
             )
-        if not isinstance(out_keys, (tuple, list)) or len(out_keys) != 1:
+        if not self._explicit_state and (
+            not isinstance(out_keys, (tuple, list)) or len(out_keys) != 1
+        ):
             raise ValueError(
                 "TransformerModule expects 1 output: a value. Got out_keys "
                 f"{out_keys} instead."
@@ -604,6 +644,21 @@ class TransformerModule(ModuleBase):
         self._positions: torch.Tensor | None = None
         self._cache_dtype: torch.dtype | None = None
         self._weights_version: tuple[tuple[int, int], ...] | None = None
+
+    def make_tensordict_primer(self) -> TensorDictPrimer | None:
+        """Initialize explicit recurrent state using the backbone's composite spec.
+
+        Module-owned caches do not require an environment primer.
+        """
+        if not self._explicit_state:
+            return None
+        # EnvBase imports the module package before transforms are initialized.
+        from torchrl.envs import TensorDictPrimer
+
+        return TensorDictPrimer(
+            Composite({unravel_key(self.in_keys[1]): self.transformer.state_spec}),
+            expand_specs=True,
+        )
 
     @property
     def recurrent_mode(self):
@@ -639,6 +694,9 @@ class TransformerModule(ModuleBase):
         once new weights are applied, so every stream restarts instead of
         attending to keys and values computed with the previous weights. Call
         it yourself after updating the parameters by other means.
+
+        Explicit caller-owned state is preserved. Stored activations may be
+        stale relative to the new weights, as with other recurrent replay.
         """
         self.reset_cache()
 
@@ -695,12 +753,14 @@ class TransformerModule(ModuleBase):
     def forward(self, tensordict: TensorDictBase):
         """Run the transformer, honouring ``is_init`` for state resets.
 
-        With ``recurrent_mode=False``, one step is processed against the
+        For the module-owned cache, with ``recurrent_mode=False`` one step is processed against the
         module's cache, whose rows are cleared where ``is_init`` is set; this
         path is inference only and runs under :func:`torch.no_grad`. With
         ``recurrent_mode=True``, a full ``(B, T)`` window is processed under a
         block-diagonal causal mask built from ``is_init``; the cache is
         neither read nor written, and gradients flow through the window.
+        Explicit-state backbones receive the stored state in both modes;
+        only their single-step collection path runs under ``torch.no_grad``.
         """
         shape = tensordict.shape
         if self.recurrent_mode:
@@ -723,7 +783,19 @@ class TransformerModule(ModuleBase):
         is_init = tensordict_shaped["is_init"].squeeze(-1)
         value = tensordict_shaped.get(self.in_keys[0])
 
-        if self.recurrent_mode:
+        if self._explicit_state:
+            state = tensordict_shaped.get(self.in_keys[1])
+            if self.recurrent_mode:
+                out, next_state = self.transformer.forward_state(
+                    value, state, is_init, recurrent=True
+                )
+            else:
+                with torch.no_grad():
+                    out, next_state = self.transformer.forward_state(
+                        value, state, is_init, recurrent=False
+                    )
+            tensordict_shaped.set(self.out_keys[1], next_state)
+        elif self.recurrent_mode:
             if self.validate_windows and not is_init[..., 0].all():
                 raise ValueError(
                     "TransformerModule(recurrent_mode=True) expects "

--- a/torchrl/modules/utils/utils.py
+++ b/torchrl/modules/utils/utils.py
@@ -77,7 +77,9 @@ def get_primers_from_module(module, warn=True, strict=True):
         if not hasattr(submodule, "make_tensordict_primer"):
             return
         try:
-            primers.append(submodule.make_tensordict_primer())
+            primer = submodule.make_tensordict_primer()
+            if primer is not None:
+                primers.append(primer)
         except Exception as e:
             if strict:
                 raise

--- a/torchrl/testing/_state_candidates.py
+++ b/torchrl/testing/_state_candidates.py
@@ -7,6 +7,12 @@ from __future__ import annotations
 
 import torch
 from tensordict import TensorClass, TensorDict, TypedTensorDict
+from tensordict.nn import TensorDictModuleBase
+
+from torchrl.data import Composite, Unbounded
+from torchrl.envs import TensorDictPrimer
+from torchrl.modules import GRUModule, LSTMModule, TransformerModule
+from torchrl.modules.models._gtrxl import _GTrXL
 
 
 class _GRUTC(TensorClass):
@@ -15,6 +21,16 @@ class _GRUTC(TensorClass):
 
 class _GRUTTD(TypedTensorDict):
     carry: torch.Tensor
+
+
+class _LSTMTC(TensorClass):
+    hidden: torch.Tensor
+    cell: torch.Tensor
+
+
+class _LSTMTTD(TypedTensorDict):
+    hidden: torch.Tensor
+    cell: torch.Tensor
 
 
 class _GTrXLTC(TensorClass):
@@ -29,5 +45,91 @@ class _GTrXLTTD(TypedTensorDict):
 
 _STATE_CLASSES = {
     "gru": {"td": TensorDict, "tc": _GRUTC, "ttd": _GRUTTD},
+    "lstm": {"td": TensorDict, "tc": _LSTMTC, "ttd": _LSTMTTD},
     "gtrxl": {"td": TensorDict, "tc": _GTrXLTC, "ttd": _GTrXLTTD},
 }
+
+
+class _StateRNN(TensorDictModuleBase):
+    def __init__(
+        self, kind, state_cls, input_size, hidden_size, num_layers, device, state_key
+    ):
+        super().__init__()
+        self.state_cls = state_cls
+        self.state_key = state_key
+        fields = ("carry",) if kind == "gru" else ("hidden", "cell")
+        in_keys = ["observation", *((*state_key, field) for field in fields)]
+        out_keys = ["embed", *(("next", *state_key, field) for field in fields)]
+        rnn_cls = GRUModule if kind == "gru" else LSTMModule
+        self.rnn = rnn_cls(
+            input_size,
+            hidden_size,
+            num_layers=num_layers,
+            in_keys=in_keys,
+            out_keys=out_keys,
+            device=device,
+        )
+        self.in_keys = self.rnn.in_keys
+        self.out_keys = ["embed", ("next", *state_key)]
+        self.state_spec = Composite(
+            {
+                field: Unbounded((num_layers, hidden_size), device=device)
+                for field in fields
+            },
+            data_cls=state_cls,
+            device=device,
+        )
+
+    def make_tensordict_primer(self):
+        return TensorDictPrimer(
+            Composite({self.state_key: self.state_spec}), expand_specs=True
+        )
+
+    def forward(self, td):
+        td = self.rnn(td)
+        key = ("next", *self.state_key)
+        value = td.get(key)
+        if type(value) is not self.state_cls:
+            td.set(key, self.state_cls.from_tensordict(value))
+        return td
+
+
+def _make_candidate(
+    kind="gtrxl",
+    container="td",
+    *,
+    input_size=7,
+    hidden_size=16,
+    num_layers=2,
+    memory_len=8,
+    device="cpu",
+    state_key=("agent", "state"),
+):
+    if container == "flat":
+        rnn_cls = GRUModule if kind == "gru" else LSTMModule
+        return rnn_cls(
+            input_size,
+            hidden_size,
+            num_layers=num_layers,
+            in_key="observation",
+            out_key="embed",
+            device=device,
+        )
+    state_cls = _STATE_CLASSES[kind][container]
+    if kind == "gtrxl":
+        return TransformerModule(
+            transformer=_GTrXL(
+                input_size,
+                hidden_size,
+                num_layers,
+                num_heads=2,
+                memory_len=memory_len,
+                state_cls=state_cls,
+                device=device,
+            ),
+            in_keys=["observation", state_key, "is_init"],
+            out_keys=["embed", ("next", *state_key)],
+        )
+    return _StateRNN(
+        kind, state_cls, input_size, hidden_size, num_layers, device, state_key
+    )


### PR DESCRIPTION
## Description

Add an experimental explicit-state path to `TransformerModule` using its existing `in_keys`/`out_keys` and recurrent-mode conventions. Root state is the carry before the observation; the module writes the resulting carry under `("next", state_key)`, and its primer initializes the state from `Composite(data_cls=...)`.

The draft includes private GRU/LSTM adapters and a private GTrXL reference to compare plain TensorDict, TensorClass and TypedTensorDict with identical payloads. GTrXL uses relative attention, reordered layer normalization, GRU gates, rolling layer-input memory and a boolean validity mask. Its training-window execution is sequential; an optimized parallel window implementation and public state classes remain follow-up work.

## Motivation and Context

Collectors need to retain recurrent state so sampled intermediate sequences can start from their stored carry. In recurrent mode this path loads stored state at the first timestep and at `is_init` boundaries inserted by SliceSampler. Direct slices whose first `is_init` remains false are supported too. Initial memory is detached while gradients flow through the current window.

The merged #4193 module-owned cache path retains its validation, autocast and weight-update behavior. Explicit caller-owned memory remains available after weight updates; its activations may be stale relative to the learner's weights, as with other recurrent replay. Existing GRU/LSTM defaults are unchanged.

Related discussion: #2325. Architecture reference: [Parisotto et al., 2020](https://proceedings.mlr.press/v119/parisotto20a.html).

## Stack and decision gate

Draft stack: #4324 (compatibility) → **#4325 (this PR)** → #4326 (comparison benchmarks). This PR targets the #4324 branch. Merge the compatibility PR first and retarget this draft to `main` afterward. The stack includes the merged [TensorDict #1766](https://github.com/pytorch/tensordict/pull/1766) and still depends on [TensorDict #1789](https://github.com/pytorch/tensordict/pull/1789).

This remains a container-comparison draft. No public state-container choice is made here. Public GTrXL exports, final documentation and the PPO example are deferred until that decision; compact replay is explored in the following benchmark draft rather than introduced as a production storage API.

The Linux dependency pin and CUDA-test isolation cleanup are inherited from #4324; both child branches have been restacked onto that fix. The pin includes the compiled typed-state wrapping fix and is temporary until TensorDict #1789 merges.

## Validation

`python -m pytest test/modules/test_transformer.py -q`: **89 passed** against current TorchRL main plus this stack and the TensorDict dependency branches, on CPU with PyTorch 2.11.0.

This includes 54 lifecycle combinations across GRU/LSTM/GTrXL, the three containers, single/serial/parallel environments and tensor/memmap replay. Numerical regressions cover intermediate slices, sampler boundaries, partial resets, fixed memory horizons, snapshot values, multidimensional batches, detached initial memory, finite gradients, precision variants and caller-owned state after weight synchronization. Explicit-state windows run through fullgraph AOT eager; existing cache tests also exercise Inductor. Formatting, flake8 and whitespace checks pass.

## Types of changes

- [x] New feature
- [x] Documentation

## Checklist

- [x] I have read the contribution guide.
- [x] I have updated the tests accordingly.
- [x] I have documented the experimental backbone and primer contract.
- [ ] Final public API documentation and tutorial (after the container decision).

