### PR TITLE
[BugFix] Only forward the applicable SACLossConfig fields to each SAC variant

### DIFF
--- a/test/test_configs.py
+++ b/test/test_configs.py
@@ -10,6 +10,7 @@ import dataclasses
 import enum
 import importlib.util
 import inspect
+import math
 import os
 import pkgutil
 import subprocess
@@ -2015,6 +2016,72 @@ class TestLossConfigs:
         assert loss.delay_actor
         assert "target_actor_network_params" in dict(loss.named_children())
         assert loss.max_importance_ratio == 100.0
+
+    @pytest.mark.parametrize("discrete", [False, True])
+    def test_sac_loss_config(self, discrete):
+        # SACLoss and DiscreteSACLoss accept different kwargs, so each variant
+        # must only receive the config fields that apply to it
+        from hydra.utils import instantiate
+        from torchrl.modules import ProbabilisticActor
+        from torchrl.modules.distributions import OneHotCategorical
+        from torchrl.objectives.sac import DiscreteSACLoss, SACLoss
+        from torchrl.trainers.algorithms.configs.modules import (
+            MLPConfig,
+            TanhNormalModelConfig,
+            TensorDictModuleConfig,
+        )
+        from torchrl.trainers.algorithms.configs.objectives import SACLossConfig
+
+        num_actions = 4
+        if discrete:
+            actor_network = ProbabilisticActor(
+                TensorDictModule(
+                    torch.nn.Linear(10, num_actions),
+                    in_keys=["observation"],
+                    out_keys=["logits"],
+                ),
+                in_keys=["logits"],
+                distribution_class=OneHotCategorical,
+            )
+            qvalue_network = TensorDictModuleConfig(
+                module=MLPConfig(
+                    in_features=10, out_features=num_actions, depth=2, num_cells=32
+                ),
+                in_keys=["observation"],
+                out_keys=["action_value"],
+            )
+        else:
+            actor_network = TanhNormalModelConfig(
+                network=MLPConfig(
+                    in_features=10, out_features=4, depth=2, num_cells=32
+                ),
+                in_keys=["observation"],
+                out_keys=["action"],
+            )
+            qvalue_network = TensorDictModuleConfig(
+                module=MLPConfig(in_features=12, out_features=1, depth=2, num_cells=32),
+                in_keys=["observation", "action"],
+                out_keys=["state_action_value"],
+            )
+        cfg = SACLossConfig(
+            actor_network=actor_network,
+            qvalue_network=qvalue_network,
+            discrete=discrete,
+            action_space="one-hot",
+            num_actions=num_actions,
+            target_entropy_weight=0.5,
+            num_qvalue_nets=3,
+        )
+
+        loss = instantiate(cfg)
+        assert loss.num_qvalue_nets == 3
+        if discrete:
+            assert type(loss) is DiscreteSACLoss
+            # target_entropy="auto" is derived from num_actions and target_entropy_weight
+            expected_entropy = 0.5 * math.log(num_actions)
+            assert loss.target_entropy.item() == pytest.approx(expected_entropy)
+        else:
+            assert type(loss) is SACLoss
 
     @pytest.mark.skipif(not _has_gymnasium, reason="Gymnasium is not installed")
     def test_dqn_loss_config(self):

--- a/torchrl/trainers/algorithms/configs/objectives.py
+++ b/torchrl/trainers/algorithms/configs/objectives.py
@@ -48,7 +48,9 @@ class SACLossConfig(LossConfig):
 
     Every kwarg accepted by ``SACLoss.__init__`` is exposed as a field here. The
     ``discrete``/``action_space``/``num_actions``/``target_entropy_weight`` fields
-    apply only when the discrete variant is selected.
+    apply only when the discrete variant is selected, and the
+    ``value_network``/``action_spec``/``delay_actor``/``delay_value`` fields only
+    when it is not.
     """
 
     actor_network: Any = None
@@ -101,8 +103,14 @@ def _make_sac_loss(*args, **kwargs) -> SACLoss:
         kwargs["value_network"] = value_network()
 
     if discrete_loss_type:
+        # DiscreteSACLoss has no value network, action spec or delayed actor/value.
+        for key in ("value_network", "action_spec", "delay_actor", "delay_value"):
+            kwargs.pop(key, None)
         loss = DiscreteSACLoss(*args, **kwargs)
     else:
+        # SACLoss has no `action_space`, `num_actions` or `target_entropy_weight` kwarg.
+        for key in ("action_space", "num_actions", "target_entropy_weight"):
+            kwargs.pop(key, None)
         loss = SACLoss(*args, **kwargs)
     if gamma is not None:
         loss.make_value_estimator(gamma=gamma)


### PR DESCRIPTION
## Description

`_make_sac_loss` now drops the config fields the selected SAC variant does not accept, the same way `_make_iql_loss` does for IQL:

* `SACLoss`: `action_space`, `num_actions`, `target_entropy_weight`
* `DiscreteSACLoss`: `value_network`, `action_spec`, `delay_actor`, `delay_value`

The `SACLossConfig` docstring already said which fields only apply to the discrete variant; it now also names the ones that only apply to the continuous variant.

## Motivation and Context

Closes #4337.

`SACLossConfig` could not be instantiated for either variant, so the `sac` loss group failed with `SACLoss.__init__() got an unexpected keyword argument 'action_space'`, including in `sota-implementations/sac_trainer`.

Testing:

* `TestLossConfigs::test_sac_loss_config[False]` and `[True]` build both variants from the config, check that `num_qvalue_nets` reaches the loss and, for the discrete one, that `target_entropy` comes out as `0.5 * log(num_actions)` from `num_actions` and `target_entropy_weight`. Both fail on `main` with the errors from the issue and pass with this change.
* `pytest test/test_configs.py`: 258 passed, 67 skipped, 60 xfailed on this branch, against 256 passed on `main`. The same 3 prioritized sampler tests fail on both because my local build has no C++ extension (`SumSegmentTreeFp32 is not available`).
* `instantiate(cfg.loss)` on the composed `sota-implementations/sac_trainer/config/config.yaml` now returns a `SACLoss`.
* Pinned `ufmt`, `flake8`, `pydocstyle` and `codespell` on the changed files.

#4100 also edits `_make_sac_loss` (value transforms), in a different part of the function.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
