### PR TITLE
[BugFix] ParallelEnv without buffers keeps the state of workers it does not reset

### DIFF
--- a/test/envs/test_auto_reset.py
+++ b/test/envs/test_auto_reset.py
@@ -657,8 +657,12 @@ class TestNonTensorEnv:
             time.sleep(0.1)
             gc.collect()
 
-    @pytest.mark.parametrize("use_buffers", [False, True])
-    def test_parallel_partial_reset(self, use_buffers, maybe_fork_ParallelEnv):
+    @pytest.mark.parametrize(
+        "use_buffers,consolidate", [(False, False), (False, True), (True, True)]
+    )
+    def test_parallel_partial_reset(
+        self, use_buffers, consolidate, maybe_fork_ParallelEnv
+    ):
         """Regression: a *partial* reset (subset of workers) with NonTensor data.
 
         ``out`` carries no NonTensor leaf (NonTensor is not shared-memory
@@ -666,7 +670,9 @@ class TestNonTensorEnv:
         ``IndexError: list index out of range``. The reset workers must get the
         fresh value while the untouched worker keeps its current value.
         """
-        env = maybe_fork_ParallelEnv(3, EnvWithMetadata, use_buffers=use_buffers)
+        env = maybe_fork_ParallelEnv(
+            3, EnvWithMetadata, use_buffers=use_buffers, consolidate=consolidate
+        )
         try:
             env.set_seed(0)
             td = env.reset()
@@ -679,16 +685,14 @@ class TestNonTensorEnv:
             reset.set("_reset", torch.tensor([True, False, True]).reshape(3, 1))
             out = env.reset(reset)
             assert out.get("non_tensor").tolist() == [0, 4, 0]
-            if use_buffers:
-                # maybe_reset can call reset with only the reset mask;
-                # NonTensor values for workers that are not reset must come
-                # from the shared-buffer cache.
-                reset = TensorDict(
-                    {"_reset": torch.tensor([False, True, False]).reshape(3, 1)},
-                    batch_size=[3],
-                )
-                out = env.reset(reset)
-                assert out.get("non_tensor").tolist() == [0, 0, 0]
+            # maybe_reset can call reset with only the reset mask;
+            # untouched workers must retain their most recent reset output.
+            reset = TensorDict(
+                {"_reset": torch.tensor([False, True, False]).reshape(3, 1)},
+                batch_size=[3],
+            )
+            out = env.reset(reset)
+            assert out.get("non_tensor").tolist() == [0, 0, 0]
         finally:
             env.close(raise_if_closed=False)
             del env

--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -39,7 +39,7 @@ from torchrl.envs import (
 from torchrl.envs.batched_envs import _stackable
 from torchrl.envs.libs.dm_control import _has_dmc, DMControlEnv
 from torchrl.envs.libs.gym import GymEnv
-from torchrl.envs.transforms import Compose, StepCounter
+from torchrl.envs.transforms import Compose, StepCounter, Transform
 from torchrl.modules import ActorCriticOperator, MLP, SafeModule, ValueOperator
 from torchrl.testing import (
     CARTPOLE_VERSIONED,
@@ -243,6 +243,35 @@ class TestParallel:
         try:
             assert isinstance(env, SerialEnv)
             env.reset()
+        finally:
+            env.close(raise_if_closed=False)
+
+    def test_no_buffers_partial_reset_keeps_current_state(self, maybe_fork_ParallelEnv):
+        # Without buffers, workers that are not reset used to come back as
+        # empty slots when the caller passed only the reset signal (the
+        # collector's maybe_reset), which broke transforms reading the
+        # observation on reset and left a ragged lazy stack.
+        class ReadsObservationOnReset(Transform):
+            def _reset(self, tensordict, tensordict_reset):
+                assert tensordict_reset["observation"].shape[0] == 2
+                return tensordict_reset
+
+        env = TransformedEnv(
+            maybe_fork_ParallelEnv(2, CountingEnv, use_buffers=False),
+            ReadsObservationOnReset(),
+        )
+        try:
+            td = env.reset()
+            td = env.step(env.rand_action(td))
+            td = env.step(env.rand_action(td))
+            kept = td["next", "observation"][1].clone()
+            td["next", "done"][0] = True
+            td["next", "terminated"][0] = True
+            out = env.maybe_reset(env.step_mdp(td))
+            assert not isinstance(out, LazyStackedTensorDict)
+            assert (out["observation"][0] == 0).all()
+            assert (out["observation"][1] == kept).all()
+            assert not out["done"].any()
         finally:
             env.close(raise_if_closed=False)
 

--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import functools as ft
 import gc
 import os
 import time
@@ -262,8 +263,8 @@ class TestParallel:
         )
         try:
             td = env.reset()
-            td = env.step(env.rand_action(td))
-            td = env.step(env.rand_action(td))
+            td = env.step(td.update(self._ones_action(env)))
+            td = env.step(td.update(self._ones_action(env)))
             kept = td["next", "observation"][1].clone()
             td["next", "done"][0] = True
             td["next", "terminated"][0] = True
@@ -272,6 +273,35 @@ class TestParallel:
             assert (out["observation"][0] == 0).all()
             assert (out["observation"][1] == kept).all()
             assert not out["done"].any()
+        finally:
+            env.close(raise_if_closed=False)
+
+    @pytest.mark.parametrize("step", [False, True])
+    def test_no_buffers_partial_reset_cache_is_independent(
+        self, step, maybe_fork_ParallelEnv
+    ):
+        # Different observation shapes force a lazy stack that aliases its rows.
+        env = maybe_fork_ParallelEnv(
+            2,
+            [
+                CountingEnv,
+                ft.partial(
+                    TransformedEnv,
+                    CountingEnv(),
+                    CatFrames(N=2, dim=-1, in_keys=["observation"]),
+                ),
+            ],
+            use_buffers=False,
+        )
+        try:
+            td = env.reset()
+            if step:
+                td = env.step(td.update(self._ones_action(env)))["next"]
+            kept = td[1]["observation"].clone()
+            td[1]["observation"].fill_(99)
+            reset = TensorDict({"_reset": torch.tensor([[True], [False]])}, [2])
+            out = env._reset(reset)
+            torch.testing.assert_close(out[1]["observation"], kept)
         finally:
             env.close(raise_if_closed=False)
 
@@ -430,6 +460,26 @@ class TestParallel:
                     torch.testing.assert_close(
                         self._batched_count(indexed_env), expected[selected]
                     )
+                    if parallel and not use_buffers:
+                        # Mask-only resets must read the same worker state
+                        # through both an indexed view and its parent.
+                        for target, observation in (
+                            (indexed_env, expected[selected]),
+                            (env, expected),
+                        ):
+                            reset = TensorDict(
+                                {
+                                    "_reset": torch.zeros_like(
+                                        observation, dtype=torch.bool
+                                    )
+                                },
+                                target.batch_size,
+                            )
+                            # Inspect the data delivered to reset transforms,
+                            # before EnvBase merges it with the caller's input.
+                            torch.testing.assert_close(
+                                target._reset(reset)["observation"], observation
+                            )
                 finally:
                     indexed_env.close(raise_if_closed=False)
 

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -2755,7 +2755,8 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             channel = self.parent_channels[i]
             td = channel.recv()
             out_tds.append(td)
-            self._last_worker_outputs[i] = td
+            # Lazy stacks can expose the received tensors directly to callers.
+            self._last_worker_outputs[self._worker_indices[i]] = td.clone()
 
         out = LazyStackedTensorDict.maybe_dense_stack(out_tds)
         if self.device is not None and out.device != self.device:
@@ -2967,7 +2968,9 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 tensordict = tensordict.to("cpu")
             if self.consolidate:
                 try:
-                    tensordict = tensordict.consolidate(
+                    # Consolidation locks non-tensor leaves too. Keep those
+                    # locks off the caller's data, which reset updates in place.
+                    tensordict = tensordict.clone().consolidate(
                         # share_memory=False: avoid resource_sharer which causes
                         # progressive slowdown with fork on Linux
                         share_memory=False,
@@ -2987,7 +2990,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 localtd = local_data
                 if localtd is not None:
                     localtd = localtd.exclude(*self.reset_keys)
-                last = self._last_worker_outputs[i]
+                last = self._last_worker_outputs[self._worker_indices[i]]
                 if last is not None:
                     # Describe the worker's current state, not only the data the
                     # caller passed (maybe_reset passes the reset signal alone).
@@ -3009,7 +3012,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 continue
             td = channel.recv()
             out_tds[i] = td
-            self._last_worker_outputs[i] = td
+            self._last_worker_outputs[self._worker_indices[i]] = td.clone()
         result = LazyStackedTensorDict.maybe_dense_stack(out_tds)
         device = self.device
         if device is not None and result.device != device:

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -550,6 +550,10 @@ class BatchedEnvBase(EnvBase):
         self.num_threads = num_threads
         self._cache_in_keys = None
         self._use_buffers = use_buffers
+        # Without shared buffers the parent holds no copy of the workers'
+        # state; the last output each worker sent stands in for it when a
+        # partial reset leaves some workers untouched.
+        self._last_worker_outputs: list[TensorDictBase | None] = [None] * num_workers
         self._metadata_from_workers = metadata_from_workers
         self.consolidate = consolidate
         self.daemon = daemon
@@ -2751,6 +2755,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             channel = self.parent_channels[i]
             td = channel.recv()
             out_tds.append(td)
+            self._last_worker_outputs[i] = td
 
         out = LazyStackedTensorDict.maybe_dense_stack(out_tds)
         if self.device is not None and out.device != self.device:
@@ -2982,6 +2987,16 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 localtd = local_data
                 if localtd is not None:
                     localtd = localtd.exclude(*self.reset_keys)
+                last = self._last_worker_outputs[i]
+                if last is not None:
+                    # Describe the worker's current state, not only the data the
+                    # caller passed (maybe_reset passes the reset signal alone).
+                    current = last.select(
+                        *self.observation_keys, *self.done_keys, strict=False
+                    ).clone()
+                    if localtd is not None:
+                        current.update(localtd)
+                    localtd = current
                 out_tds[i] = localtd
                 continue
             needs_resetting_int.append(i)
@@ -2994,6 +3009,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                 continue
             td = channel.recv()
             out_tds[i] = td
+            self._last_worker_outputs[i] = td
         result = LazyStackedTensorDict.maybe_dense_stack(out_tds)
         device = self.device
         if device is not None and result.device != device:


### PR DESCRIPTION
When `ParallelEnv(use_buffers=False)` receives a partial reset containing only the reset mask, workers that are not reset previously returned incomplete observations. Reset transforms could fail on empty rows, and the result could become a ragged lazy stack. This also affects `metadata_from_workers=True`, which disables shared buffers.

Cache each worker's latest step or reset output and use it to fill untouched workers' observations and done flags, while preserving caller-supplied values. Keep independent snapshots so edits to heterogeneous lazy-stack outputs cannot corrupt the cache, and address the cache by the original worker indices so indexed views share the correct state with their parent.

Clone reset inputs before consolidation to avoid locking the caller's non-tensor metadata. This fixes the partial-reset regression that failed the Python 3.10, 3.13, and 3.14 multiprocessing CI jobs.

Validation:

- 49 selected reset, metadata, indexing, dynamic-environment, and non-tensor tests passed locally on Python 3.12, PyTorch 2.11.0, and TensorDict 0.14.2.
- Regression checks fail against the original PR implementation for non-tensor consolidation, indexed views, and caller mutation after both reset and step.
- The original observation-reset regression now uses deterministic actions.
- Repository formatting and flake8 checks passed for all three changed files.
