### PR TITLE
[Doc] Document the GRPOLoss masking strategy contract and add deterministic tests

### DIFF
--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -1539,7 +1539,7 @@ def _grpo_masking_history_td(model, tokenizer):
         generate=False,
         return_log_probs=True,
         pad_output=True,
-        tokenizer_kwargs={"chat_template_name": "qwen"},
+        chat_template_name="qwen",
     )
     td = td.update(wrapper(td))
     log_probs = td.get(("log_probs", "full"), as_padded_tensor=True)
@@ -1551,10 +1551,12 @@ def _grpo_masking_history_td(model, tokenizer):
 class TestGRPOLossMaskingContract:
     """Deterministic CPU checks of the masking strategy contract.
 
-    Every supported combination of wrapper input mode and masking strategy must
-    run through GRPOLoss.forward with a finite loss, and ``rlhf`` with ``tokens``
-    input must fail with the assistant mask error. Response tokens are fabricated
-    so no generation engine is required (issue 4227).
+    Each supported combination of wrapper input mode and masking strategy must
+    select the tokens the contract promises, run through GRPOLoss.forward with
+    a finite loss, and keep the unreduced loss in the (B, T, 1) token layout.
+    Response tokens are fabricated so no generation engine is required
+    (issue 4227). The vLLM integration path of the skipped upstream test is not
+    covered by these cases.
     """
 
     @pytest.mark.parametrize(
@@ -1564,52 +1566,83 @@ class TestGRPOLossMaskingContract:
         model, tokenizer = tiny_qwen_and_tokenizer
         wrapper, td = _grpo_masking_history_td(model, tokenizer)
 
-        masks = td.get(("masks", "all_assistant_mask"), as_padded_tensor=True)
-        assert masks is not None
-        assert (
-            masks.shape
-            == td.get(("masks", "all_attention_mask"), as_padded_tensor=True).shape
-        )
-        assert masks.shape[0] == 2
-        assert masks.dtype == torch.bool
-        assert masks.any()
+        assistant_mask = td.get(("masks", "all_assistant_mask"), as_padded_tensor=True)
+        attention_mask = td.get(("masks", "all_attention_mask"), as_padded_tensor=True)
+        assert assistant_mask is not None
+        assert assistant_mask.shape == attention_mask.shape
+        assert assistant_mask.shape[0] == 2
+        assert assistant_mask.dtype == torch.bool
+        assert assistant_mask.any()
 
-        loss_fn = GRPOLoss(actor_network=wrapper, masking_strategy=strategy)
-        result = loss_fn(td)
+        # prompt tokens are absent in history mode, so sft and rlhf must select
+        # the assistant tokens and generic must select the attended tokens
+        if strategy == "generic":
+            dist = wrapper._get_generic_dist(td.clone())
+            expected = attention_mask
+        else:
+            get_dist = (
+                wrapper._get_sft_dist if strategy == "sft" else wrapper._get_rlhf_dist
+            )
+            dist = get_dist(td.clone())
+            expected = assistant_mask
+        torch.testing.assert_close(dist.mask.bool(), expected.bool())
+
+        result = GRPOLoss(actor_network=wrapper, masking_strategy=strategy)(td.clone())
         assert torch.isfinite(result.loss_objective)
         assert result.loss_objective.shape == ()
 
-    def test_tokens_input_rlhf_raises(self, tiny_qwen_and_tokenizer):
+        # the unreduced loss keeps the (B, T, 1) log weight layout
+        unreduced = GRPOLoss(
+            actor_network=wrapper, masking_strategy=strategy, aggregation="none"
+        )(td.clone())
+        assert unreduced.loss_objective.shape == (
+            2,
+            attention_mask.shape[-1],
+            1,
+        )
+
+    def test_tokens_input_rlhf(self, tiny_qwen_and_tokenizer):
         model, tokenizer = tiny_qwen_and_tokenizer
         wrapper, td = _grpo_masking_tokens_td(model, tokenizer)
 
+        # without an assistant mask the rlhf strategy cannot run
         loss_fn = GRPOLoss(actor_network=wrapper, masking_strategy="rlhf")
         with pytest.raises(ValueError, match="Assistant mask not found"):
-            loss_fn(td)
+            loss_fn(td.clone())
+
+        # a caller supplied assistant mask is used exactly as given
+        attention_mask = td.get(("masks", "all_attention_mask"), as_padded_tensor=True)
+        supplied = attention_mask.bool().clone()
+        supplied[..., :-6] = False
+        assert supplied.any()
+        td["masks", "all_assistant_mask"] = supplied
+        dist = wrapper._get_rlhf_dist(td.clone())
+        torch.testing.assert_close(dist.mask.bool(), supplied.bool())
+        result = loss_fn(td.clone())
+        assert torch.isfinite(result.loss_objective)
+        assert result.loss_objective.shape == ()
 
     def test_tokens_input_sft_and_generic(self, tiny_qwen_and_tokenizer):
         model, tokenizer = tiny_qwen_and_tokenizer
         wrapper, td = _grpo_masking_tokens_td(model, tokenizer)
 
-        sft = GRPOLoss(actor_network=wrapper, masking_strategy="sft")(td)
-        generic = GRPOLoss(actor_network=wrapper, masking_strategy="generic")(td)
+        attention_mask = td.get(("masks", "all_attention_mask"), as_padded_tensor=True)
+        prompt_width = td.get(("tokens", "prompt"), as_padded_tensor=True).shape[-1]
+
+        sft_dist = wrapper._get_sft_dist(td.clone())
+        expected_sft = attention_mask.clone()
+        expected_sft[..., :prompt_width] = False
+        torch.testing.assert_close(sft_dist.mask.bool(), expected_sft.bool())
+
+        generic_dist = wrapper._get_generic_dist(td.clone())
+        torch.testing.assert_close(generic_dist.mask.bool(), attention_mask.bool())
+
+        sft = GRPOLoss(actor_network=wrapper, masking_strategy="sft")(td.clone())
+        generic = GRPOLoss(actor_network=wrapper, masking_strategy="generic")(
+            td.clone()
+        )
         assert torch.isfinite(sft.loss_objective)
         assert torch.isfinite(generic.loss_objective)
-        # sft excludes the prompt positions, generic includes them, so with the
-        # same data and advantage the two losses must differ
-        assert sft.loss_objective.item() != generic.loss_objective.item()
-
-    def test_history_input_sft_falls_back_to_assistant_mask(
-        self, tiny_qwen_and_tokenizer
-    ):
-        model, tokenizer = tiny_qwen_and_tokenizer
-        wrapper, td = _grpo_masking_history_td(model, tokenizer)
-
-        sft = GRPOLoss(actor_network=wrapper, masking_strategy="sft")(td)
-        rlhf = GRPOLoss(actor_network=wrapper, masking_strategy="rlhf")(td)
-        # without ("tokens", "prompt") the sft strategy uses the assistant mask,
-        # so it must agree exactly with rlhf on the same data
-        torch.testing.assert_close(sft.loss_objective, rlhf.loss_objective)
 
 
 @pytest.mark.slow

--- a/test/llm/test_llm_objectives.py
+++ b/test/llm/test_llm_objectives.py
@@ -1444,6 +1444,174 @@ class TestDistillation:
         assert torch.isfinite(loss_vals.loss_distill)
 
 
+@pytest.fixture(scope="class")
+def tiny_qwen_and_tokenizer():
+    """Tiny causal LM and matching tokenizer, cached and CPU friendly."""
+    if not _has_transformers:
+        pytest.skip("transformers lib required")
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    model = AutoModelForCausalLM.from_pretrained(
+        "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5"
+    ).eval()
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B")
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return model, tokenizer
+
+
+def _grpo_masking_tokens_td(model, tokenizer):
+    """Tokens input for batch 2 with fabricated response tokens (no generation)."""
+    vocab = model.config.vocab_size
+    response_len = 6
+    enc = tokenizer(
+        ["Are you happy? Say yes or no.", "What is 2+2?"],
+        return_tensors="pt",
+        padding=True,
+        padding_side="left",
+    )
+    prompt_ids, prompt_mask = enc["input_ids"], enc["attention_mask"]
+    batch = prompt_ids.shape[0]
+    gen = torch.Generator().manual_seed(0)
+    response_ids = torch.randint(1, vocab, (batch, response_len), generator=gen)
+    full_ids = torch.cat([prompt_ids, response_ids], dim=1)
+    attention_mask = torch.cat(
+        [prompt_mask, torch.ones(batch, response_len, dtype=prompt_mask.dtype)], dim=1
+    )
+    wrapper = TransformersWrapper(
+        model,
+        tokenizer=tokenizer,
+        input_mode="tokens",
+        generate=False,
+        return_log_probs=True,
+        pad_output=True,
+    )
+    td = TensorDict(
+        {
+            "tokens": Tokens(prompt=prompt_ids, full=full_ids),
+            "masks": Masks(all_attention_mask=attention_mask, all_assistant_mask=None),
+        },
+        batch_size=(batch,),
+    )
+    td = td.update(wrapper(td))
+    td["masks", "all_attention_mask"] = attention_mask
+    td["tokens", "full"] = full_ids
+    td["tokens", "prompt"] = prompt_ids
+    log_probs = td.get(("log_probs", "full"), as_padded_tensor=True)
+    td["log_probs", "full"] = log_probs.detach()
+    # Fixed per trajectory advantage, shape (batch, 1, 1)
+    td["advantage"] = torch.tensor([0.5, -0.5]).reshape(batch, 1, 1)
+    return wrapper, td
+
+
+def _grpo_masking_history_td(model, tokenizer):
+    """History input for batch 2 with fabricated assistant responses."""
+    chats = [
+        [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Are you happy? Say yes or no."},
+        ],
+        [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is 2+2?"},
+        ],
+    ]
+    responses = [
+        [{"role": "assistant", "content": "Yes."}],
+        [{"role": "assistant", "content": "4."}],
+    ]
+    rows = []
+    for chat, response in zip(chats, responses):
+        prompt = History.from_chats([chat]).squeeze(0)
+        resp = History.from_chats([response]).squeeze(0)
+        full = prompt.extend(resp, inplace=False, dim=-1)
+        rows.append(
+            TensorDict(
+                {"history": ChatHistory(prompt=prompt, response=resp, full=full)},
+                batch_size=(),
+            )
+        )
+    td = lazy_stack(rows)
+    wrapper = TransformersWrapper(
+        model,
+        tokenizer=tokenizer,
+        input_mode="history",
+        generate=False,
+        return_log_probs=True,
+        pad_output=True,
+        tokenizer_kwargs={"chat_template_name": "qwen"},
+    )
+    td = td.update(wrapper(td))
+    log_probs = td.get(("log_probs", "full"), as_padded_tensor=True)
+    td["log_probs", "full"] = log_probs.detach()
+    td["advantage"] = torch.tensor([0.5, -0.5]).reshape(2, 1, 1)
+    return wrapper, td
+
+
+class TestGRPOLossMaskingContract:
+    """Deterministic CPU checks of the masking strategy contract.
+
+    Every supported combination of wrapper input mode and masking strategy must
+    run through GRPOLoss.forward with a finite loss, and ``rlhf`` with ``tokens``
+    input must fail with the assistant mask error. Response tokens are fabricated
+    so no generation engine is required (issue 4227).
+    """
+
+    @pytest.mark.parametrize(
+        "strategy", ["sft", "rlhf", "generic"], ids=lambda s: f"strategy={s}"
+    )
+    def test_history_input_batch_2(self, tiny_qwen_and_tokenizer, strategy):
+        model, tokenizer = tiny_qwen_and_tokenizer
+        wrapper, td = _grpo_masking_history_td(model, tokenizer)
+
+        masks = td.get(("masks", "all_assistant_mask"), as_padded_tensor=True)
+        assert masks is not None
+        assert (
+            masks.shape
+            == td.get(("masks", "all_attention_mask"), as_padded_tensor=True).shape
+        )
+        assert masks.shape[0] == 2
+        assert masks.dtype == torch.bool
+        assert masks.any()
+
+        loss_fn = GRPOLoss(actor_network=wrapper, masking_strategy=strategy)
+        result = loss_fn(td)
+        assert torch.isfinite(result.loss_objective)
+        assert result.loss_objective.shape == ()
+
+    def test_tokens_input_rlhf_raises(self, tiny_qwen_and_tokenizer):
+        model, tokenizer = tiny_qwen_and_tokenizer
+        wrapper, td = _grpo_masking_tokens_td(model, tokenizer)
+
+        loss_fn = GRPOLoss(actor_network=wrapper, masking_strategy="rlhf")
+        with pytest.raises(ValueError, match="Assistant mask not found"):
+            loss_fn(td)
+
+    def test_tokens_input_sft_and_generic(self, tiny_qwen_and_tokenizer):
+        model, tokenizer = tiny_qwen_and_tokenizer
+        wrapper, td = _grpo_masking_tokens_td(model, tokenizer)
+
+        sft = GRPOLoss(actor_network=wrapper, masking_strategy="sft")(td)
+        generic = GRPOLoss(actor_network=wrapper, masking_strategy="generic")(td)
+        assert torch.isfinite(sft.loss_objective)
+        assert torch.isfinite(generic.loss_objective)
+        # sft excludes the prompt positions, generic includes them, so with the
+        # same data and advantage the two losses must differ
+        assert sft.loss_objective.item() != generic.loss_objective.item()
+
+    def test_history_input_sft_falls_back_to_assistant_mask(
+        self, tiny_qwen_and_tokenizer
+    ):
+        model, tokenizer = tiny_qwen_and_tokenizer
+        wrapper, td = _grpo_masking_history_td(model, tokenizer)
+
+        sft = GRPOLoss(actor_network=wrapper, masking_strategy="sft")(td)
+        rlhf = GRPOLoss(actor_network=wrapper, masking_strategy="rlhf")(td)
+        # without ("tokens", "prompt") the sft strategy uses the assistant mask,
+        # so it must agree exactly with rlhf on the same data
+        torch.testing.assert_close(sft.loss_objective, rlhf.loss_objective)
+
+
 @pytest.mark.slow
 @pytest.mark.integration
 class TestGRPOLossIntegration:

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -388,6 +388,23 @@ class GRPOLoss(LossModule):
 
         The masking strategy must match the strategy used for advantage computation to avoid shape mismatches.
 
+    .. note::
+        The mask actually selected depends on both the masking strategy and the input mode of the
+        actor network. For a transformers based actor the following holds:
+
+        * ``tokens`` input: ``"sft"`` masks the prompt positions using ``("tokens", "prompt")``,
+          ``"generic"`` masks padding positions using the attention mask, and ``"rlhf"`` requires
+          an assistant mask which is only computed in history mode, so ``"rlhf"`` with ``tokens``
+          input raises a ``ValueError``.
+        * ``history`` input: the assistant mask is computed from the chat template. ``"rlhf"`` uses
+          it directly, and ``"sft"`` falls back to it whenever ``("tokens", "prompt")`` is not
+          available, which makes ``"sft"`` and ``"rlhf"`` select the same tokens in this mode.
+        * ``"generic"`` always uses the attention mask regardless of the input mode.
+
+        In every supported combination the masks are boolean tensors of shape ``(batch, T)`` over
+        the full padded sequence and the distribution log probability has the same shape, so a per
+        trajectory advantage of shape ``(batch, 1, 1)`` broadcasts against them.
+
     Keyword Args:
         clip_epsilon (float | tuple[float, float], optional): clipping threshold(s) for the clipped surrogate.
             - float x: symmetric clipping [1 - x, 1 + x] (default: 0.2)

--- a/torchrl/objectives/llm/grpo.py
+++ b/torchrl/objectives/llm/grpo.py
@@ -393,17 +393,21 @@ class GRPOLoss(LossModule):
         actor network. For a transformers based actor the following holds:
 
         * ``tokens`` input: ``"sft"`` masks the prompt positions using ``("tokens", "prompt")``,
-          ``"generic"`` masks padding positions using the attention mask, and ``"rlhf"`` requires
-          an assistant mask which is only computed in history mode, so ``"rlhf"`` with ``tokens``
-          input raises a ``ValueError``.
+          ``"generic"`` masks padding positions using the attention mask, and ``"rlhf"`` uses a
+          caller supplied ``("masks", "all_assistant_mask")`` when the tensordict carries one and
+          raises a ``ValueError`` only when it does not.
         * ``history`` input: the assistant mask is computed from the chat template. ``"rlhf"`` uses
           it directly, and ``"sft"`` falls back to it whenever ``("tokens", "prompt")`` is not
           available, which makes ``"sft"`` and ``"rlhf"`` select the same tokens in this mode.
         * ``"generic"`` always uses the attention mask regardless of the input mode.
 
-        In every supported combination the masks are boolean tensors of shape ``(batch, T)`` over
-        the full padded sequence and the distribution log probability has the same shape, so a per
-        trajectory advantage of shape ``(batch, 1, 1)`` broadcasts against them.
+        In every supported combination the masks are ``(B, T)`` tensors over the
+        full padded sequence, interpreted as booleans, and the distribution log
+        probabilities have the same shape. The loss
+        module turns the log probabilities into a log weight of shape ``(B, T, 1)``, and it is the
+        log weight the advantage broadcasts against: a per trajectory advantage of shape
+        ``(B, 1, 1)`` or a per token advantage of shape ``(B, T, 1)``. ``forward`` requires the
+        advantage to have the same rank as the log weight.
 
     Keyword Args:
         clip_epsilon (float | tuple[float, float], optional): clipping threshold(s) for the clipped surrogate.


### PR DESCRIPTION
## Description

Documents the masking strategy contract of `GRPOLoss` in its docstring and adds a deterministic CPU test class that pins it down.

Context: issue #4227 reports a suspected shape mismatch between masking strategies. I reproduced the full matrix on CPU with `trl-internal-testing/tiny-Qwen2ForCausalLM-2.5` and the `Qwen/Qwen2.5-0.5B` tokenizer, fabricating the response tokens so that no generation engine is required. Where a supported combination runs, masks are boolean tensors of shape `(batch, T)` over the full padded sequence, the distribution log probability has the same shape, and a per trajectory advantage of shape `(batch, 1, 1)` broadcasts cleanly. I could not reproduce a shape bug in the loss reduction itself.

What the docstring note now states, and what the tests assert:

* `tokens` input: `sft` masks prompt positions using `("tokens", "prompt")`, `generic` masks padding using the attention mask, and `rlhf` uses a caller supplied `("masks", "all_assistant_mask")` when the tensordict carries one and raises a `ValueError` only when it does not. The tests compare the distribution mask against those expected tensors, so a drift in any selection fails in CI.
* `history` input: the assistant mask is computed from the chat template. `rlhf` uses it directly and `sft` falls back to it whenever `("tokens", "prompt")` is unavailable, which makes `sft` and `rlhf` select the same tokens in this mode.
* a batch 2 history input with heterogeneous prompts and fabricated assistant responses runs through `GRPOLoss.forward` with a finite loss for all three strategies, and the unreduced loss keeps the `(B, T, 1)` token layout the advantage broadcasts against.

No behavior is changed: the docstring documents current behavior, and the two open contract questions from my comment on #4227 (whether `sft` in history mode should warn about the fallback, and what error `rlhf` with `tokens` input should suggest) remain for the maintainers to decide.

## Correction to my earlier comment on #4227

In that comment I claimed the transformers wrapper history path fails at batch sizes greater than one. That was wrong, and the probe script I referenced was the cause: it built the `History` incorrectly, stacking prompt and response as separate conversation slots instead of concatenated messages, which produced a malformed `(batch, 2, T)` token tensor. With a correctly built `History` (per row `History.from_chats`, extended along the message dimension with `dim=-1`, then lazy stacked) the wrapper handles batch 2 with heterogeneous prompts fine, including the assistant masks, for all three strategies. The wrapper batch path is therefore not implicated in the skipped integration test as I suggested.

## Test results

```
pytest test/llm/test_llm_objectives.py -k "TestGRPOLossMaskingContract or TestLosses"
13 passed in 42.73s
```

## Motivation and Context

Fixes the documentation side of #4227 and pins the contract with deterministic CPU tests. The skipped vLLM integration test is left untouched: its path involves actual generated output, which the fabricated response cases here do not exercise, so validating that integration remains a follow-up before its skip could be lifted.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).

