### PR TITLE
[Feature] Shared buffers for ParallelEnv workers that report their own metadata

### DIFF
--- a/benchmarks/benchmark_parallel_env_startup.py
+++ b/benchmarks/benchmark_parallel_env_startup.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""Benchmark ``ParallelEnv`` startup metadata strategies.
+"""Benchmark ``ParallelEnv`` startup metadata strategies and rollout throughput.
 
 The benchmark records constructor calls in separate marker files so parent-side
 temporary environments and long-lived worker environments can be counted
@@ -13,6 +13,7 @@ independently. For example::
 
 Use ``--mode`` to run one strategy, and ``--start-method forkserver`` to compare
 the no-shadow-environment path with the default ``spawn`` worker startup.
+Compare ``--use-buffers`` and ``--no-use-buffers`` for batched control steps/s.
 """
 
 from __future__ import annotations
@@ -62,6 +63,8 @@ def _run_mode(
     delay: float,
     start_method: Literal["spawn", "forkserver", "fork"],
     marker_dir: Path,
+    use_buffers: bool | None,
+    steps: int,
 ) -> dict[str, float | int | str]:
     parent_pid = os.getpid()
     common_factory = partial(
@@ -88,7 +91,7 @@ def _run_mode(
             create_env_fn,
             create_env_kwargs=create_env_kwargs,
             metadata_from_workers=mode == "workers",
-            use_buffers=False,
+            use_buffers=use_buffers,
             mp_start_method=start_method,
         )
     construct_seconds = construct_timer.elapsed()
@@ -99,6 +102,9 @@ def _run_mode(
         with timeit(f"{mode}/first_step") as step_timer:
             env.rand_step(tensordict)
         first_step_seconds = step_timer.elapsed()
+        with timeit(f"{mode}/rollout") as rollout_timer:
+            env.rollout(steps, break_when_any_done=False)
+        steps_per_second = steps / rollout_timer.elapsed()
     finally:
         env.close(raise_if_closed=False)
 
@@ -109,6 +115,8 @@ def _run_mode(
         "mode": mode,
         "start_method": start_method,
         "num_workers": num_workers,
+        "use_buffers": env._use_buffers,
+        "steps_per_second": steps_per_second,
         "parent_constructions": parent_constructions,
         "worker_constructions": worker_constructions,
         "closed_constructions": closed_constructions,
@@ -132,6 +140,8 @@ def main() -> None:
         choices=("spawn", "forkserver", "fork"),
         default="spawn",
     )
+    parser.add_argument("--use-buffers", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--steps", type=int, default=1000)
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
 
@@ -145,6 +155,8 @@ def main() -> None:
                 delay=args.delay,
                 start_method=args.start_method,
                 marker_dir=Path(marker_dir),
+                use_buffers=args.use_buffers,
+                steps=args.steps,
             )
         results.append(result)
         torchrl_logger.info("ParallelEnv startup benchmark: %s", result)

--- a/docs/source/reference/envs_vectorized.rst
+++ b/docs/source/reference/envs_vectorized.rst
@@ -68,8 +68,9 @@ needed.
   In this opt-in mode, the real worker environments report their metadata before
   normal initialization. The workers start eagerly, their tensor schemas are
   validated for compatibility, and no temporary environment is created in the
-  parent. This mode currently requires pipe-based communication with
-  ``use_buffers=False``. All workers must expose the same tensor schema: specs
+  parent. The shared buffers are allocated once the workers have reported
+  their specs and handed to them, so ``use_buffers`` keeps its usual meaning
+  and default. All workers must expose the same tensor schema: specs
   and example tensors may only differ in non-tensor payload values (such as
   language instructions). Environments with genuinely heterogeneous specs
   should keep the default metadata path. At shutdown, workers started in this
@@ -93,7 +94,6 @@ needed.
           make_env,
           create_env_kwargs=[{"g": 9.0 + worker_idx} for worker_idx in range(4)],
           metadata_from_workers=True,
-          use_buffers=False,
       )
 
 .. note::

--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -1718,6 +1718,43 @@ def test_heterogeneous_non_tensor_workers(cls, maybe_fork_ParallelEnv):
         env.close(raise_if_closed=False)
 
 
+@pytest.mark.parametrize("use_buffers", [None, True, False])
+def test_parallel_env_metadata_from_workers_buffers(use_buffers):
+    # Workers that report their own metadata get the shared buffers once the
+    # parent has allocated them from that metadata, and behave like the
+    # default path with the same use_buffers setting.
+    env = ParallelEnv(
+        2,
+        ContinuousActionVecMockEnv,
+        metadata_from_workers=True,
+        use_buffers=use_buffers,
+    )
+    ref = ParallelEnv(2, ContinuousActionVecMockEnv, use_buffers=use_buffers)
+    try:
+        assert env._metadata_from_workers
+        assert env._use_buffers is (use_buffers is not False)
+        rollouts = []
+        for batched in (env, ref):
+            batched.set_seed(0)
+            torch.manual_seed(0)
+            rollouts.append(batched.rollout(5, break_when_any_done=False))
+        assert rollouts[0].shape == rollouts[1].shape == (2, 5)
+        if use_buffers is not False:
+            # The shared-memory workers reseed torch on set_seed, so the
+            # rollouts match the default path exactly.
+            assert_allclose_td(rollouts[0], rollouts[1])
+        # a partial reset goes through the same buffers
+        reset = rollouts[0][:, -1].select(*env.reset_keys, strict=False).clone()
+        reset["_reset"] = torch.tensor([True, False])
+        out = env.reset(reset)
+        assert out.shape == (2,)
+        torch.manual_seed(0)
+        assert env.rollout(3, break_when_any_done=False).shape == (2, 3)
+    finally:
+        env.close(raise_if_closed=False)
+        ref.close(raise_if_closed=False)
+
+
 def test_stackable():
     # Tests the _stackable util
     stack = [TensorDict({"a": 0}, []), TensorDict({"b": 1}, [])]

--- a/test/envs/test_parallel.py
+++ b/test/envs/test_parallel.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import functools as ft
 import gc
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -144,7 +145,8 @@ class TestParallel:
                 4, make_env, create_env_kwargs=[{"seed": 0}, {"seed": 1}]
             )
 
-    def test_metadata_from_workers_uses_live_envs(self, tmp_path):
+    @pytest.mark.parametrize("use_buffers", [None, True, False])
+    def test_metadata_from_workers_uses_live_envs(self, tmp_path, use_buffers):
         env = ParallelEnv(
             2,
             _WorkerMetadataToyEnv,
@@ -152,12 +154,12 @@ class TestParallel:
                 {"worker_idx": i, "marker_dir": str(tmp_path)} for i in range(2)
             ],
             metadata_from_workers=True,
-            use_buffers=False,
+            use_buffers=use_buffers,
             mp_start_method="spawn",
         )
         try:
             assert not env.is_closed
-            assert env._use_buffers is False
+            assert env._use_buffers is (use_buffers is not False)
             constructed = list(tmp_path.glob("constructed-*"))
             assert len(constructed) == 2
             assert all(f"-{os.getpid()}" not in path.name for path in constructed)
@@ -167,15 +169,6 @@ class TestParallel:
         finally:
             env.close(raise_if_closed=False)
         assert len(list(tmp_path.glob("closed-*"))) == 2
-
-    def test_metadata_from_workers_rejects_buffers(self):
-        with pytest.raises(RuntimeError, match="requires use_buffers=False"):
-            ParallelEnv(
-                2,
-                CountingEnv,
-                metadata_from_workers=True,
-                use_buffers=True,
-            )
 
     def test_metadata_from_workers_rejects_incompatible_schemas(self, tmp_path):
         with pytest.raises(RuntimeError, match="metadata are incompatible"):
@@ -1718,41 +1711,34 @@ def test_heterogeneous_non_tensor_workers(cls, maybe_fork_ParallelEnv):
         env.close(raise_if_closed=False)
 
 
+@pytest.mark.parametrize("metadata_from_workers", [False, True])
 @pytest.mark.parametrize("use_buffers", [None, True, False])
-def test_parallel_env_metadata_from_workers_buffers(use_buffers):
-    # Workers that report their own metadata get the shared buffers once the
-    # parent has allocated them from that metadata, and behave like the
-    # default path with the same use_buffers setting.
+def test_parallel_env_metadata_from_workers_buffers(metadata_from_workers, use_buffers):
+    class SlowCountingEnv(CountingEnv):
+        def _step(self, tensordict):
+            # Expose premature completion after loading worker state.
+            time.sleep(0.1)
+            return super()._step(tensordict)
+
     env = ParallelEnv(
         2,
-        ContinuousActionVecMockEnv,
-        metadata_from_workers=True,
+        SlowCountingEnv,
+        metadata_from_workers=metadata_from_workers,
         use_buffers=use_buffers,
     )
-    ref = ParallelEnv(2, ContinuousActionVecMockEnv, use_buffers=use_buffers)
     try:
-        assert env._metadata_from_workers
         assert env._use_buffers is (use_buffers is not False)
-        rollouts = []
-        for batched in (env, ref):
-            batched.set_seed(0)
-            torch.manual_seed(0)
-            rollouts.append(batched.rollout(5, break_when_any_done=False))
-        assert rollouts[0].shape == rollouts[1].shape == (2, 5)
-        if use_buffers is not False:
-            # The shared-memory workers reseed torch on set_seed, so the
-            # rollouts match the default path exactly.
-            assert_allclose_td(rollouts[0], rollouts[1])
-        # a partial reset goes through the same buffers
-        reset = rollouts[0][:, -1].select(*env.reset_keys, strict=False).clone()
-        reset["_reset"] = torch.tensor([True, False])
-        out = env.reset(reset)
-        assert out.shape == (2,)
-        torch.manual_seed(0)
-        assert env.rollout(3, break_when_any_done=False).shape == (2, 3)
+        for _ in range(2):  # The second reset restarts the closed workers.
+            td = env.reset()
+            env.load_state_dict(env.state_dict())
+            td["action"] = env.action_spec.one()
+            td = env.step(td)["next"]
+            assert td["observation"].tolist() == [[1], [1]]
+            td["_reset"] = torch.tensor([[True], [False]])
+            assert env.reset(td)["observation"].tolist() == [[0], [1]]
+            env.close()
     finally:
         env.close(raise_if_closed=False)
-        ref.close(raise_if_closed=False)
 
 
 def test_stackable():
@@ -1771,3 +1757,7 @@ def test_stackable():
     assert not _stackable(*stack)
     stack = [TensorDict({"a": "a string"}, []), TensorDict({"a": "another string"}, [])]
     assert _stackable(*stack)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, *sys.argv[1:]]))

--- a/test/libs/test_brax.py
+++ b/test/libs/test_brax.py
@@ -232,7 +232,7 @@ class TestBrax:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
             assert env._metadata_from_workers
-            assert env._use_buffers is False
+            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
             assert not env.is_closed
             env.reset()
             assert env.batch_size == torch.Size([3])

--- a/test/libs/test_dm_control.py
+++ b/test/libs/test_dm_control.py
@@ -123,7 +123,7 @@ class TestDMControl:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
             assert env._metadata_from_workers
-            assert env._use_buffers is False
+            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
             assert not env.is_closed
             env.reset()
             assert env.batch_size == torch.Size([3])

--- a/test/libs/test_genesis.py
+++ b/test/libs/test_genesis.py
@@ -172,7 +172,7 @@ class TestGenesis:
         try:
             assert isinstance(env, ParallelEnv)
             assert env._metadata_from_workers
-            assert env._use_buffers is False
+            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
             assert not env.is_closed
             assert env.reset().batch_size == torch.Size([2])
         finally:

--- a/test/libs/test_gym.py
+++ b/test/libs/test_gym.py
@@ -1808,7 +1808,7 @@ class TestGym:
                 nworkers = getattr(env, "num_envs", None)
             assert nworkers == 3
             assert env._metadata_from_workers
-            assert env._use_buffers is False
+            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
             assert not any(
                 isinstance(factory, EnvCreator) for factory in env.create_env_fn
             )

--- a/test/libs/test_habitat.py
+++ b/test/libs/test_habitat.py
@@ -57,7 +57,7 @@ class TestHabitat:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
             assert env._metadata_from_workers
-            assert env._use_buffers is False
+            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
             assert not env.is_closed
             env.reset()
             assert env.batch_size == torch.Size([3])

--- a/test/libs/test_habitat.py
+++ b/test/libs/test_habitat.py
@@ -57,7 +57,7 @@ class TestHabitat:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
             assert env._metadata_from_workers
-            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
+            assert env._use_buffers
             assert not env.is_closed
             env.reset()
             assert env.batch_size == torch.Size([3])

--- a/test/libs/test_libero.py
+++ b/test/libs/test_libero.py
@@ -293,7 +293,7 @@ class TestLibero:
         try:
             assert env.num_workers == 2
             assert env._metadata_from_workers
-            assert env._use_buffers is False
+            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
             assert env.batch_size == torch.Size([2])
             assert env.full_observation_spec["observation", "image"].shape == (
                 2,

--- a/test/libs/test_libero.py
+++ b/test/libs/test_libero.py
@@ -293,7 +293,7 @@ class TestLibero:
         try:
             assert env.num_workers == 2
             assert env._metadata_from_workers
-            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
+            assert env._use_buffers
             assert env.batch_size == torch.Size([2])
             assert env.full_observation_spec["observation", "image"].shape == (
                 2,

--- a/test/libs/test_mjlab.py
+++ b/test/libs/test_mjlab.py
@@ -135,7 +135,7 @@ def test_num_workers_uses_worker_metadata():
     try:
         assert isinstance(env, ParallelEnv)
         assert env._metadata_from_workers
-        assert env._use_buffers is False
+        assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
         assert not env.is_closed
         assert env.reset().batch_size == torch.Size([2, 1])
     finally:

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -2063,8 +2063,8 @@ class TestMujoco:
             assert isinstance(env_b, ParallelEnv)
             assert env_a._metadata_from_workers
             assert env_b._metadata_from_workers
-            assert env_a._use_buffers is False
-            assert env_b._use_buffers is False
+            assert env_a._use_buffers
+            assert env_b._use_buffers
             assert env_a.batch_size == env_b.batch_size
         finally:
             env_a.close()
@@ -2088,7 +2088,7 @@ class TestMujoco:
         env = HopperEnv(backend="mujoco", num_envs=2, seed=0)
         assert isinstance(env, ParallelEnv)
         assert env._metadata_from_workers
-        assert env._use_buffers is False
+        assert env._use_buffers
         td = env.rollout(3)
         assert torch.isfinite(td.get(("next", "reward"))).all()
         env.close()

--- a/test/libs/test_mujoco_playground.py
+++ b/test/libs/test_mujoco_playground.py
@@ -195,7 +195,7 @@ class TestMujocoPlayground:
             assert isinstance(env, ParallelEnv)
             assert env.num_workers == 3
             assert env._metadata_from_workers
-            assert env._use_buffers is False
+            assert env._use_buffers == (not env.meta_data.has_dynamic_specs)
             assert not env.is_closed
             env.reset()
         finally:

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -2106,21 +2106,6 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             func = _run_worker_pipe_shared_mem
         else:
             func = _run_worker_pipe_direct
-        # We look for cuda tensors through the leaves
-        # because the shared tensordict could be partially on cuda
-        # and some leaves may be inaccessible through get (e.g., LazyStacked)
-        has_cuda = [False]
-
-        def look_for_cuda(tensor, has_cuda=has_cuda):
-            has_cuda[0] = has_cuda[0] or tensor.is_cuda
-
-        if self._use_buffers and not self._metadata_from_workers:
-            self.shared_tensordict_parent.apply(look_for_cuda, filter_empty=True)
-        has_cuda = has_cuda[0]
-        if has_cuda:
-            self.event = torch.cuda.Event()
-        else:
-            self.event = None
         self._events = [ctx.Event() for _ in range(_num_workers)]
 
         # Shared-memory done flags: workers write 1 when done, parent spin-polls.
@@ -2196,6 +2181,18 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                     # use msg as sync point
                     parent_pipe.recv()
 
+            # We look for cuda tensors through the leaves
+            # because the shared tensordict could be partially on cuda
+            # and some leaves may be inaccessible through get (e.g., LazyStacked)
+            has_cuda = [False]
+
+            def look_for_cuda(tensor, has_cuda=has_cuda):
+                has_cuda[0] = has_cuda[0] or tensor.is_cuda
+
+            if self._use_buffers:
+                self.shared_tensordict_parent.apply(look_for_cuda, filter_empty=True)
+            self.event = torch.cuda.Event() if has_cuda[0] else None
+
             for channel in self.parent_channels:
                 channel.send(("init", None))
         except Exception:
@@ -2208,13 +2205,6 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
 
     def _send_worker_buffers(self) -> None:
         """Hand the freshly allocated shared buffers to workers started for their metadata."""
-        has_cuda = [False]
-
-        def look_for_cuda(tensor, has_cuda=has_cuda):
-            has_cuda[0] = has_cuda[0] or tensor.is_cuda
-
-        self.shared_tensordict_parent.apply(look_for_cuda, filter_empty=True)
-        self.event = torch.cuda.Event() if has_cuda[0] else None
         for idx, channel in enumerate(self.parent_channels):
             channel.send(
                 (
@@ -3398,58 +3388,12 @@ def _run_worker_pipe_shared_mem(
     worker_idx: int | None = None,
     shm_done_flags=None,
 ) -> None:
+    pid = os.getpid()
     # Handle warning filtering (moved from _ProcessNoWarn)
     if filter_warnings:
         warnings.filterwarnings("ignore")
     if num_threads is not None:
         torch.set_num_threads(num_threads)
-    parent_pipe.close()
-    if not isinstance(env_fun, EnvBase):
-        env = env_fun(**env_fun_kwargs)
-    else:
-        if env_fun_kwargs:
-            raise RuntimeError(
-                "env_fun_kwargs must be empty if an environment is passed to a process."
-            )
-        env = env_fun
-    del env_fun
-    env.set_spec_lock_()
-
-    _shared_mem_worker_loop(
-        child_pipe,
-        env,
-        mp_event=mp_event,
-        shared_tensordict=shared_tensordict,
-        _selected_input_keys=_selected_input_keys,
-        _selected_reset_keys=_selected_reset_keys,
-        _selected_step_keys=_selected_step_keys,
-        _non_tensor_keys=_non_tensor_keys,
-        non_blocking=non_blocking,
-        has_lazy_inputs=has_lazy_inputs,
-        verbose=verbose,
-        worker_idx=worker_idx,
-        shm_done_flags=shm_done_flags,
-    )
-
-
-def _shared_mem_worker_loop(
-    child_pipe: connection.Connection,
-    env: EnvBase,
-    *,
-    mp_event: mp.Event = None,
-    shared_tensordict: TensorDictBase = None,
-    _selected_input_keys=None,
-    _selected_reset_keys=None,
-    _selected_step_keys=None,
-    _non_tensor_keys=None,
-    non_blocking: bool = False,
-    has_lazy_inputs: bool = False,
-    verbose: bool = False,
-    worker_idx: int | None = None,
-    shm_done_flags=None,
-) -> None:
-    """Serve ``env`` through the shared ``shared_tensordict`` until the parent closes it."""
-    pid = os.getpid()
     device = shared_tensordict.device
     if device is None or device.type != "cuda":
         # Check if some tensors are shared on cuda
@@ -3466,6 +3410,18 @@ def _shared_mem_worker_loop(
         event = torch.cuda.Event()
     else:
         event = None
+    parent_pipe.close()
+    if not isinstance(env_fun, EnvBase):
+        env = env_fun(**env_fun_kwargs)
+    else:
+        if env_fun_kwargs:
+            raise RuntimeError(
+                "env_fun_kwargs must be empty if an environment is passed to a process."
+            )
+        env = env_fun
+    del env_fun
+    env.set_spec_lock_()
+
     i = -1
     import torchrl
 
@@ -3699,9 +3655,7 @@ def _shared_mem_worker_loop(
 
         elif cmd == "load_state_dict":
             env.load_state_dict(data)
-            _signal_done()
-            # Also set mp_event so the parent's load_state_dict (which waits
-            # on events) can detect completion.
+            # The parent consumes only this event, not the shared completion flag.
             mp_event.set()
 
         elif cmd == "state_dict":
@@ -3862,9 +3816,11 @@ def _run_worker_pipe_direct(
             # worker reported: serve the env through them from now on.
             if initialized:
                 raise RuntimeError("worker already initialized")
-            _shared_mem_worker_loop(
+            _run_worker_pipe_shared_mem(
+                parent_pipe,
                 child_pipe,
                 env,
+                {},
                 mp_event=mp_event,
                 non_blocking=non_blocking,
                 has_lazy_inputs=has_lazy_inputs,

--- a/torchrl/envs/batched_envs.py
+++ b/torchrl/envs/batched_envs.py
@@ -128,7 +128,10 @@ def _check_start(fun):
                     "parent environment has been closed."
                 )
         elif self.is_closed:
-            self._create_td()
+            if not getattr(self, "_metadata_from_workers", False):
+                # With worker metadata the buffers are allocated by
+                # _start_workers, once the workers have reported their specs.
+                self._create_td()
             self._start_workers()
         else:
             if isinstance(self, ParallelEnv):
@@ -389,8 +392,9 @@ class BatchedEnvBase(EnvBase):
         metadata_from_workers (bool, optional): if ``True``, each worker constructs
             its environment and sends its metadata to the parent during startup. This
             avoids constructing temporary environments in the parent process. The mode
-            is only supported by :class:`~torchrl.envs.ParallelEnv`, starts its workers
-            eagerly, and currently requires ``use_buffers=False``. All workers must
+            is only supported by :class:`~torchrl.envs.ParallelEnv` and starts its
+            workers eagerly; the shared buffers (``use_buffers``) are allocated once
+            the workers have reported their specs and handed to them. All workers must
             report the same tensor schema: specs and example tensors may only differ
             in non-tensor payload values (such as language instructions). In this
             mode workers are also closed one at a time at shutdown to bound teardown
@@ -559,17 +563,10 @@ class BatchedEnvBase(EnvBase):
         self.daemon = daemon
         self.shutdown_timeout = float(shutdown_timeout)
 
-        if metadata_from_workers:
-            if not isinstance(self, ParallelEnv):
-                raise TypeError(
-                    "metadata_from_workers=True is only supported by ParallelEnv."
-                )
-            if use_buffers:
-                raise RuntimeError(
-                    "metadata_from_workers=True currently requires use_buffers=False "
-                    "because shared buffers must be allocated before workers start."
-                )
-            self._use_buffers = False
+        if metadata_from_workers and not isinstance(self, ParallelEnv):
+            raise TypeError(
+                "metadata_from_workers=True is only supported by ParallelEnv."
+            )
 
         self._single_task = callable(create_env_fn) or (len(set(create_env_fn)) == 1)
         if callable(create_env_fn):
@@ -1515,7 +1512,8 @@ class BatchedEnvBase(EnvBase):
     def start(self) -> None:
         if not self.is_closed:
             raise RuntimeError("trying to start a environment that is not closed.")
-        self._create_td()
+        if not self._metadata_from_workers:
+            self._create_td()
         self._start_workers()
 
     def to(self, device: DEVICE_TYPING):
@@ -2102,7 +2100,9 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
 
         self.parent_channels = []
         self._workers = []
-        if self._use_buffers:
+        # Workers that report their own metadata start on the pipe protocol
+        # and switch to the shared buffers once the parent has allocated them.
+        if self._use_buffers and not self._metadata_from_workers:
             func = _run_worker_pipe_shared_mem
         else:
             func = _run_worker_pipe_direct
@@ -2114,7 +2114,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
         def look_for_cuda(tensor, has_cuda=has_cuda):
             has_cuda[0] = has_cuda[0] or tensor.is_cuda
 
-        if self._use_buffers:
+        if self._use_buffers and not self._metadata_from_workers:
             self.shared_tensordict_parent.apply(look_for_cuda, filter_empty=True)
         has_cuda = has_cuda[0]
         if has_cuda:
@@ -2128,7 +2128,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
         self._shm_done_flags = mp.RawArray("b", _num_workers)
 
         kwargs = [{"mp_event": self._events[i]} for i in range(_num_workers)]
-        if self._use_buffers:
+        if self._use_buffers or self._metadata_from_workers:
             for i in range(_num_workers):
                 kwargs[i].update(
                     {
@@ -2158,7 +2158,7 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
                         "filter_warnings": self._filter_warnings_subprocess(),
                     }
                 )
-                if self._use_buffers:
+                if self._use_buffers and not self._metadata_from_workers:
                     kwargs[idx].update(
                         {
                             "shared_tensordict": self.shared_tensordicts[idx],
@@ -2186,6 +2186,11 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
             if self._metadata_from_workers:
                 metadata = self._receive_worker_metadata()
                 self._set_worker_metadata(metadata)
+                # The specs are known now: allocate the shared buffers and
+                # hand them to the workers, which then leave the pipe protocol.
+                self._create_td()
+                if self._use_buffers:
+                    self._send_worker_buffers()
             else:
                 for parent_pipe in self.parent_channels:
                     # use msg as sync point
@@ -2200,6 +2205,40 @@ class ParallelEnv(BatchedEnvBase, metaclass=_PEnvMeta):
 
         self.is_closed = False
         self.set_spec_lock_()
+
+    def _send_worker_buffers(self) -> None:
+        """Hand the freshly allocated shared buffers to workers started for their metadata."""
+        has_cuda = [False]
+
+        def look_for_cuda(tensor, has_cuda=has_cuda):
+            has_cuda[0] = has_cuda[0] or tensor.is_cuda
+
+        self.shared_tensordict_parent.apply(look_for_cuda, filter_empty=True)
+        self.event = torch.cuda.Event() if has_cuda[0] else None
+        for idx, channel in enumerate(self.parent_channels):
+            channel.send(
+                (
+                    "buffers",
+                    {
+                        "shared_tensordict": self.shared_tensordicts[idx],
+                        "_selected_input_keys": self._selected_input_keys,
+                        "_selected_reset_keys": self._selected_reset_keys,
+                        "_selected_step_keys": self._selected_step_keys,
+                        "_non_tensor_keys": self._non_tensor_keys,
+                    },
+                )
+            )
+        for worker_idx, channel in enumerate(self.parent_channels):
+            if not channel.poll(self.BATCHED_PIPE_TIMEOUT):
+                raise TimeoutError(
+                    f"ParallelEnv worker {worker_idx} did not acknowledge the shared buffers."
+                )
+            message = channel.recv()
+            if message != "started":
+                raise RuntimeError(
+                    f"ParallelEnv worker {worker_idx} sent {message!r} instead of "
+                    "acknowledging the shared buffers."
+                )
 
     def _receive_worker_metadata(self) -> list[EnvMetaData]:
         metadata = [None] * self.num_workers
@@ -3359,12 +3398,58 @@ def _run_worker_pipe_shared_mem(
     worker_idx: int | None = None,
     shm_done_flags=None,
 ) -> None:
-    pid = os.getpid()
     # Handle warning filtering (moved from _ProcessNoWarn)
     if filter_warnings:
         warnings.filterwarnings("ignore")
     if num_threads is not None:
         torch.set_num_threads(num_threads)
+    parent_pipe.close()
+    if not isinstance(env_fun, EnvBase):
+        env = env_fun(**env_fun_kwargs)
+    else:
+        if env_fun_kwargs:
+            raise RuntimeError(
+                "env_fun_kwargs must be empty if an environment is passed to a process."
+            )
+        env = env_fun
+    del env_fun
+    env.set_spec_lock_()
+
+    _shared_mem_worker_loop(
+        child_pipe,
+        env,
+        mp_event=mp_event,
+        shared_tensordict=shared_tensordict,
+        _selected_input_keys=_selected_input_keys,
+        _selected_reset_keys=_selected_reset_keys,
+        _selected_step_keys=_selected_step_keys,
+        _non_tensor_keys=_non_tensor_keys,
+        non_blocking=non_blocking,
+        has_lazy_inputs=has_lazy_inputs,
+        verbose=verbose,
+        worker_idx=worker_idx,
+        shm_done_flags=shm_done_flags,
+    )
+
+
+def _shared_mem_worker_loop(
+    child_pipe: connection.Connection,
+    env: EnvBase,
+    *,
+    mp_event: mp.Event = None,
+    shared_tensordict: TensorDictBase = None,
+    _selected_input_keys=None,
+    _selected_reset_keys=None,
+    _selected_step_keys=None,
+    _non_tensor_keys=None,
+    non_blocking: bool = False,
+    has_lazy_inputs: bool = False,
+    verbose: bool = False,
+    worker_idx: int | None = None,
+    shm_done_flags=None,
+) -> None:
+    """Serve ``env`` through the shared ``shared_tensordict`` until the parent closes it."""
+    pid = os.getpid()
     device = shared_tensordict.device
     if device is None or device.type != "cuda":
         # Check if some tensors are shared on cuda
@@ -3381,18 +3466,6 @@ def _run_worker_pipe_shared_mem(
         event = torch.cuda.Event()
     else:
         event = None
-    parent_pipe.close()
-    if not isinstance(env_fun, EnvBase):
-        env = env_fun(**env_fun_kwargs)
-    else:
-        if env_fun_kwargs:
-            raise RuntimeError(
-                "env_fun_kwargs must be empty if an environment is passed to a process."
-            )
-        env = env_fun
-    del env_fun
-    env.set_spec_lock_()
-
     i = -1
     import torchrl
 
@@ -3686,6 +3759,8 @@ def _run_worker_pipe_direct(
     consolidate: bool = True,
     filter_warnings: bool = False,
     metadata_from_worker: bool = False,
+    worker_idx: int | None = None,
+    shm_done_flags=None,
 ) -> None:
     # Handle warning filtering (moved from _ProcessNoWarn)
     if filter_warnings:
@@ -3781,6 +3856,24 @@ def _run_worker_pipe_direct(
             # np.random.seed(data)
             new_seed = env.set_seed(data[0], static_seed=data[1])
             child_pipe.send(("seeded", new_seed))
+
+        elif cmd == "buffers":
+            # The parent allocated the shared buffers from the metadata this
+            # worker reported: serve the env through them from now on.
+            if initialized:
+                raise RuntimeError("worker already initialized")
+            _shared_mem_worker_loop(
+                child_pipe,
+                env,
+                mp_event=mp_event,
+                non_blocking=non_blocking,
+                has_lazy_inputs=has_lazy_inputs,
+                verbose=verbose,
+                worker_idx=worker_idx,
+                shm_done_flags=shm_done_flags,
+                **data,
+            )
+            return
 
         elif cmd == "init":
             if verbose:


### PR DESCRIPTION
`ParallelEnv(metadata_from_workers=True)` can now use shared buffers while avoiding temporary environments in the parent. Workers report their specs, the parent allocates and sends their buffers, and each worker hands its live environment to the existing shared-memory worker. Buffer selection retains the usual defaults, including the dynamic-spec and MPS fallbacks and explicit `use_buffers=False`.

This also fixes stale completion flags after `load_state_dict()`: state loading signals only the event consumed by the parent, so the next step waits for its own result. The startup paths share CUDA-event setup, and no additional serving-loop wrapper is needed. The reset, step, and automatic-reset serving code is unchanged.

Validation:
- 20 focused parallel-environment tests and 2 MuJoCo integration tests passed. The state-load regression fails in all four buffered cases on the original PR and passes with this patch.
- Additional CPU checks passed for explicit/implicit restart, indexed views, individual/memory-mapped buffers, dynamic specs, and per-worker text observations. CUDA was not tested locally.
- Extended `benchmarks/benchmark_parallel_env_startup.py` with `--use-buffers` / `--no-use-buffers` and rollout throughput. For 4 workers and 2,000 batched steps across three local CPU runs, the original and simplified implementations had medians of 3,282 and 3,241 steps/s, respectively (1.3% apart, within run-to-run variation).
- Formatting, lint, docstring checks, and `git diff --check` passed.
