### PR TITLE
[BugFix] Vectorize TicTacToeEnv.win and honor rand_action(None)

### DIFF
--- a/test/test_custom_envs.py
+++ b/test/test_custom_envs.py
@@ -139,9 +139,33 @@ class TestTicTacToeEnv:
         board[1, 1, 0] = 0
         td["mask"] = board.flatten(-2, -1) == -1
         td["action"] = torch.tensor([2, 2])
-        done = env.step(td)["next", "done"]
-        assert done[0]
-        assert not done[1]
+        nxt = env.step(td)["next"]
+        assert nxt["done"].eq(torch.tensor([[True], [False]])).all()
+        assert nxt["player0", "reward"].eq(torch.tensor([[1.0], [0.0]])).all()
+
+    def test_tictactoe_win_batched_single_player(self):
+        # env 0 wins on the learner move; env 1 stays live so player1 replies.
+        # the live board must not be overwritten by the terminal env.
+        torch.manual_seed(0)
+        env = TicTacToeEnv(single_player=True)
+        td = env.reset(TensorDict(batch_size=[2]))
+        board = td["board"]
+        board[0, 0, 0] = 1
+        board[0, 0, 1] = 1
+        board[0, 1, 0] = 0
+        board[0, 1, 1] = 0
+        board[1, 0, 0] = 1
+        board[1, 1, 0] = 0
+        td["mask"] = board.flatten(-2, -1) == -1
+        td["action"] = torch.tensor([2, 2])
+        nxt = env.step(td)["next"]
+        assert nxt["done"].eq(torch.tensor([[True], [False]])).all()
+        assert nxt["player0", "reward"].eq(torch.tensor([[1.0], [0.0]])).all()
+        assert (nxt["board"][0, 0] == 0).all()
+        assert not torch.equal(nxt["board"][1], nxt["board"][0])
+        occupied = nxt["board"] != -1
+        assert occupied[0].sum() == 5
+        assert occupied[1].sum() == 4
 
     def test_tictactoe_rand_action(self):
         torch.manual_seed(0)

--- a/test/test_custom_envs.py
+++ b/test/test_custom_envs.py
@@ -127,6 +127,37 @@ class TestTicTacToeEnv:
         )
         assert r.shape == (5, 100)
 
+    def test_tictactoe_win_batched(self):
+        env = TicTacToeEnv()
+        td = env.reset(TensorDict(batch_size=[2]))
+        board = td["board"]
+        board[0, 0, 0] = 1
+        board[0, 0, 1] = 1
+        board[0, 1, 0] = 0
+        board[0, 1, 1] = 0
+        board[1, 0, 0] = 1
+        board[1, 1, 0] = 0
+        td["mask"] = board.flatten(-2, -1) == -1
+        td["action"] = torch.tensor([2, 2])
+        done = env.step(td)["next", "done"]
+        assert done[0]
+        assert not done[1]
+
+    def test_tictactoe_rand_action(self):
+        torch.manual_seed(0)
+        env = TicTacToeEnv()
+        td = env.rand_action()
+        assert "action" in td
+
+        td = env.reset()
+        td["action"] = torch.tensor(0)
+        td = env.step(td)["next"]
+        mask = td["mask"]
+        assert not mask.all()
+        for _ in range(32):
+            action = env.rand_action(td.clone())["action"]
+            assert mask[action]
+
 
 class TestPendulum:
     @pytest.mark.parametrize("device", [None, *get_default_devices()])

--- a/torchrl/envs/custom/tictactoeenv.py
+++ b/torchrl/envs/custom/tictactoeenv.py
@@ -239,34 +239,29 @@ class TicTacToeEnv(EnvBase):
         )
         if self.single_player:
             select = (~done & (turn == 0)).squeeze(-1)
-            if select.all():
-                state_select = state
-            elif select.any():
-                state_select = state[select]
-            else:
+            if not select.any():
                 return state
-            state_select = self._step(self.rand_action(state_select))
             if select.all():
-                return state_select
-            return torch.where(done, state, state_select)
+                return self._step(self.rand_action(state))
+            state[select] = self._step(self.rand_action(state[select]))
+            return state
         return state
 
     def _set_seed(self, seed: int | None) -> None:
         ...
 
     @staticmethod
-    def win(board: torch.Tensor, action: torch.Tensor):
-        row = action // 3  # type: ignore
-        col = action % 3  # type: ignore
-        if board[..., row, :].sum() == 3:
-            return True
-        if board[..., col].sum() == 3:
-            return True
-        if board.diagonal(0, -2, -1).sum() == 3:
-            return True
-        if board.flip(-1).diagonal(0, -2, -1).sum() == 3:
-            return True
-        return False
+    def win(board: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+        action = action.reshape(board.shape[:-2])
+        row = action // 3
+        col = action % 3
+        row_win = board.sum(-1).gather(-1, row.unsqueeze(-1)).squeeze(-1) == 3
+        col_win = board.sum(-2).gather(-1, col.unsqueeze(-1)).squeeze(-1) == 3
+        diag_win = (row == col) & (board.diagonal(0, -2, -1).sum(-1) == 3)
+        antidiag_win = ((row + col) == 2) & (
+            board.flip(-1).diagonal(0, -2, -1).sum(-1) == 3
+        )
+        return (row_win | col_win | diag_win | antidiag_win).unsqueeze(-1)
 
     @staticmethod
     def full(board: torch.Tensor) -> bool:
@@ -277,12 +272,15 @@ class TicTacToeEnv(EnvBase):
         pass
 
     def rand_action(self, tensordict: TensorDictBase | None = None):
-        mask = tensordict.get("mask")
+        if tensordict is None:
+            tensordict = TensorDict(batch_size=self.batch_size, device=self.device)
+        mask = tensordict.get("mask", None)
         action_spec = self.action_spec
         if tensordict.ndim:
             action_spec = action_spec.expand(tensordict.shape)
         else:
             action_spec = action_spec.clone()
-        action_spec.update_mask(mask)
+        if mask is not None:
+            action_spec.update_mask(mask)
         tensordict.set(self.action_key, action_spec.rand())
         return tensordict

--- a/torchrl/envs/custom/tictactoeenv.py
+++ b/torchrl/envs/custom/tictactoeenv.py
@@ -252,6 +252,7 @@ class TicTacToeEnv(EnvBase):
 
     @staticmethod
     def win(board: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+        """Whether ``action`` completes a line; ``[..., 1]`` bool."""
         action = action.reshape(board.shape[:-2])
         row = action // 3
         col = action % 3


### PR DESCRIPTION
## Description

`TicTacToeEnv.win` used Python `if tensor.sum() == 3`, which reduces over the whole batch. One env completing a line could mark every env done. `rand_action` also assumed a tensordict was passed, so `env.rand_action()` raised `AttributeError`.

`win()` now returns a per-env bool tensor. `rand_action(None)` builds a tensordict like ChessEnv (#4225) and still honors `"mask"` when present.

### Code example

A win in the first board must not mark the second board done. Sampling without an input TensorDict also works.

```python
import torch
from tensordict import TensorDict
from torchrl.envs import TicTacToeEnv

env = TicTacToeEnv()
assert "action" in env.rand_action()  # Previously raised AttributeError.
td = env.reset(TensorDict(batch_size=[2]))
board = td["board"]
board[0, 0, :2] = 1
board[0, 1, :2] = 0
board[1, 0, 0] = 1
board[1, 1, 0] = 0
td["mask"] = board.flatten(-2, -1) == -1
td["action"] = torch.tensor([2, 2])
next_td = env.step(td)["next"]
torch.testing.assert_close(next_td["done"], torch.tensor([[True], [False]]))
env.close()
```

## Motivation and Context

close #4342

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.