### PR TITLE
[BugFix] Build IncrementalTokenizer tokens.full from NestedKey

### DIFF
--- a/test/llm/test_llm_transforms.py
+++ b/test/llm/test_llm_transforms.py
@@ -724,60 +724,47 @@ class TestIncrementalTokenizer:
         tokens = result.get(("tokens", "prompt"), as_list=True)
         assert tokens[0].numel() > 0
 
-    def test_step_nested_tokens_full_key(self):
-        """Nested tokens_key looks up (*prefix, 'full'), not (first, 'full')."""
+    @pytest.mark.parametrize(
+        "tokens_key, expected_full_key, decoy_key",
+        [
+            pytest.param(
+                ("obs", "tok", "prompt"),
+                ("obs", "tok", "full"),
+                ("obs", "full"),
+                id="nested",
+            ),
+            pytest.param(
+                "tokens",
+                ("tokens", "full"),
+                "tokens_full",
+                id="string",
+            ),
+            pytest.param(
+                ("tokens",),
+                ("tokens", "full"),
+                "full",
+                id="one_tuple",
+            ),
+        ],
+    )
+    def test_step_tokens_full_key(self, tokens_key, expected_full_key, decoy_key):
+        """Reuse tokens.full under the last NestedKey component; decoys fail the old lookups."""
         tokens_full = torch.tensor([1, 2, 3])
         decoy = torch.tensor([9, 9, 9])
         transform = IncrementalTokenizer(
             self.DummyTokenizer(),
-            tokens_key=("obs", "tok", "prompt"),
+            tokens_key=tokens_key,
         )
         td = TensorDict(
             {
-                ("obs", "tok", "full"): tokens_full,
-                # Old bug used (tokens_key[0], "full")
-                ("obs", "full"): decoy,
+                expected_full_key: tokens_full,
+                decoy_key: decoy,
             },
             batch_size=(),
         )
         next_td = TensorDict(batch_size=())
         out = transform._step(td, next_td)
-        assert torch.equal(out[("obs", "tok", "prompt")], tokens_full)
-
-    def test_step_string_tokens_full_key(self):
-        """String tokens_key looks up ('tokens', 'full'), not 'tokens_full'."""
-        tokens_full = torch.tensor([4, 5, 6])
-        decoy = torch.tensor([9, 9, 9])
-        transform = IncrementalTokenizer(self.DummyTokenizer(), tokens_key="tokens")
-        td = TensorDict(
-            {
-                ("tokens", "full"): tokens_full,
-                "tokens_full": decoy,
-            },
-            batch_size=(),
-        )
-        next_td = TensorDict(batch_size=())
-        out = transform._step(td, next_td)
-        assert torch.equal(out["tokens"], tokens_full)
-
-    def test_step_one_tuple_tokens_full_key(self):
-        """A 1-tuple tokens_key looks up ('tokens', 'full'), not ('full',)."""
-        tokens_full = torch.tensor([7, 8, 9])
-        decoy = torch.tensor([9, 9, 9])
-        transform = IncrementalTokenizer(
-            self.DummyTokenizer(), tokens_key=("tokens",)
-        )
-        td = TensorDict(
-            {
-                ("tokens", "full"): tokens_full,
-                # Old bug used (*tokens_key[:-1], "full") -> ("full",)
-                "full": decoy,
-            },
-            batch_size=(),
-        )
-        next_td = TensorDict(batch_size=())
-        out = transform._step(td, next_td)
-        assert torch.equal(out["tokens"], tokens_full)
+        assert torch.equal(out[tokens_key], tokens_full)
 
 
 class TestPolicyVersion:

--- a/test/llm/test_llm_transforms.py
+++ b/test/llm/test_llm_transforms.py
@@ -760,6 +760,25 @@ class TestIncrementalTokenizer:
         out = transform._step(td, next_td)
         assert torch.equal(out["tokens"], tokens_full)
 
+    def test_step_one_tuple_tokens_full_key(self):
+        """A 1-tuple tokens_key looks up ('tokens', 'full'), not ('full',)."""
+        tokens_full = torch.tensor([7, 8, 9])
+        decoy = torch.tensor([9, 9, 9])
+        transform = IncrementalTokenizer(
+            self.DummyTokenizer(), tokens_key=("tokens",)
+        )
+        td = TensorDict(
+            {
+                ("tokens", "full"): tokens_full,
+                # Old bug used (*tokens_key[:-1], "full") -> ("full",)
+                "full": decoy,
+            },
+            batch_size=(),
+        )
+        next_td = TensorDict(batch_size=())
+        out = transform._step(td, next_td)
+        assert torch.equal(out["tokens"], tokens_full)
+
 
 class TestPolicyVersion:
     def test_int_version_dtype_and_device(self):

--- a/test/llm/test_llm_transforms.py
+++ b/test/llm/test_llm_transforms.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 
 import pytest
+import torch
 from tensordict import set_list_to_stack, TensorDict
 
 from torchrl.data.llm import History
@@ -462,6 +463,9 @@ class TestToolCall:
 class TestIncrementalTokenizer:
     """Tests for the IncrementalTokenizer transform."""
 
+    class DummyTokenizer:
+        vocab_size = 32
+
     def test_reset_tokenizes_history(self, tokenizer):
         """Test that reset produces correct tokens from history."""
         system_prompt = "You are a helpful assistant."
@@ -719,6 +723,42 @@ class TestIncrementalTokenizer:
         assert ("tokens", "prompt") in result.keys(True, True)
         tokens = result.get(("tokens", "prompt"), as_list=True)
         assert tokens[0].numel() > 0
+
+    def test_step_nested_tokens_full_key(self):
+        """Nested tokens_key looks up (*prefix, 'full'), not (first, 'full')."""
+        tokens_full = torch.tensor([1, 2, 3])
+        decoy = torch.tensor([9, 9, 9])
+        transform = IncrementalTokenizer(
+            self.DummyTokenizer(),
+            tokens_key=("obs", "tok", "prompt"),
+        )
+        td = TensorDict(
+            {
+                ("obs", "tok", "full"): tokens_full,
+                # Old bug used (tokens_key[0], "full")
+                ("obs", "full"): decoy,
+            },
+            batch_size=(),
+        )
+        next_td = TensorDict(batch_size=())
+        out = transform._step(td, next_td)
+        assert torch.equal(out[("obs", "tok", "prompt")], tokens_full)
+
+    def test_step_string_tokens_full_key(self):
+        """String tokens_key looks up ('tokens', 'full'), not 'tokens_full'."""
+        tokens_full = torch.tensor([4, 5, 6])
+        decoy = torch.tensor([9, 9, 9])
+        transform = IncrementalTokenizer(self.DummyTokenizer(), tokens_key="tokens")
+        td = TensorDict(
+            {
+                ("tokens", "full"): tokens_full,
+                "tokens_full": decoy,
+            },
+            batch_size=(),
+        )
+        next_td = TensorDict(batch_size=())
+        out = transform._step(td, next_td)
+        assert torch.equal(out["tokens"], tokens_full)
 
 
 class TestPolicyVersion:

--- a/torchrl/envs/llm/transforms/tokenizer.py
+++ b/torchrl/envs/llm/transforms/tokenizer.py
@@ -491,11 +491,14 @@ class IncrementalTokenizer(Transform):
         """
         # Try to reuse tokens.full from the action tensordict
         # Since next.history.prompt = history.full, tokens.full is already the correct tokenization
-        tokens_full_key = (
-            (self.tokens_key[0], "full")
-            if isinstance(self.tokens_key, tuple)
-            else "tokens_full"
-        )
+        # Replace the last NestedKey component with "full":
+        #   "tokens" -> ("tokens", "full")
+        #   ("obs", "tok", "prompt") -> ("obs", "tok", "full")
+        tokens_key = self.tokens_key
+        if isinstance(tokens_key, str):
+            tokens_full_key = (tokens_key, "full")
+        else:
+            tokens_full_key = (*tokens_key[:-1], "full")
         existing_tokens_full = tensordict.get(tokens_full_key, None)
 
         if existing_tokens_full is not None:

--- a/torchrl/envs/llm/transforms/tokenizer.py
+++ b/torchrl/envs/llm/transforms/tokenizer.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from typing import Any, TYPE_CHECKING
 
 import torch
-from tensordict import NonTensorData, NonTensorStack, TensorDictBase
+from tensordict import NonTensorData, NonTensorStack, TensorDictBase, unravel_key
 from tensordict.nn import dispatch
 from tensordict.utils import _zip_strict, NestedKey
 from torch import Tensor
@@ -493,8 +493,9 @@ class IncrementalTokenizer(Transform):
         # Since next.history.prompt = history.full, tokens.full is already the correct tokenization
         # Replace the last NestedKey component with "full":
         #   "tokens" -> ("tokens", "full")
+        #   ("tokens",) -> ("tokens", "full")
         #   ("obs", "tok", "prompt") -> ("obs", "tok", "full")
-        tokens_key = self.tokens_key
+        tokens_key = unravel_key(self.tokens_key)
         if isinstance(tokens_key, str):
             tokens_full_key = (tokens_key, "full")
         else:


### PR DESCRIPTION
## Description

On `_step`, `IncrementalTokenizer` reused `tokens.full` with `(tokens_key[0], "full")` or `"tokens_full"`. A NestedKey such as `("obs", "tok", "prompt")` looked up `("obs", "full")`. A string `"tokens"` looked up `"tokens_full"` instead of `("tokens", "full")`.

The lookup now replaces the last NestedKey component with `"full"`.

### Code example

Minimal step-hook regression: reuse the full token sequence from the same nested namespace. This path does not invoke the tokenizer.

```python
from types import SimpleNamespace
import torch
from tensordict import TensorDict
from torchrl.envs.llm.transforms import IncrementalTokenizer

transform = IncrementalTokenizer(
    SimpleNamespace(vocab_size=32), tokens_key=("obs", "tok", "prompt"),
)
td = TensorDict({
    ("obs", "tok", "full"): torch.tensor([1, 2, 3]),
    ("obs", "full"): torch.tensor([9, 9, 9]),  # Old lookup selected this decoy.
}, batch_size=[])
next_td = transform._step(td, TensorDict(batch_size=[]))
torch.testing.assert_close(next_td["obs", "tok", "prompt"], torch.tensor([1, 2, 3]))
```

## Motivation and Context

close #4344

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.