### PR TITLE
[BugFix] Stop caching Tokenizer parent.device

### DIFF
--- a/docs/source/reference/envs_transforms.rst
+++ b/docs/source/reference/envs_transforms.rst
@@ -29,6 +29,11 @@ By default, the transformed environment will inherit the device of the
 It is now apparent that this can bring a significant speedup depending on the kind of
 operations that is to be computed.
 
+:attr:`Tokenizer.out_device` describes the destination of token tensors and
+attention masks. It follows the current parent environment device; ``None``
+leaves outputs on the tokenizer's chosen device. ``Tokenizer.device`` is a
+deprecated alias and will be removed in TorchRL v0.17.
+
 A great advantage of environment wrappers is that one can consult the environment up to that wrapper.
 The same can be achieved with TorchRL transformed environments: the ``parent`` attribute will
 return a new :class:`TransformedEnv` with all the transforms up to the transform of interest.

--- a/docs/source/reference/llms_transforms.rst
+++ b/docs/source/reference/llms_transforms.rst
@@ -7,6 +7,11 @@ LLM Transforms
 
 Transforms for LLM environments, including tools and utilities.
 
+:attr:`Tokenizer.out_device` describes the destination of token tensors and
+attention masks. It follows the current parent environment device; ``None``
+leaves outputs on the tokenizer's chosen device. ``Tokenizer.device`` is a
+deprecated alias and will be removed in TorchRL v0.17.
+
 .. autosummary::
     :toctree: generated/
     :template: rl_template.rst

--- a/test/llm/test_llm_transforms.py
+++ b/test/llm/test_llm_transforms.py
@@ -25,7 +25,7 @@ from torchrl.envs.llm.transforms import (
     ToolRegistry,
     XMLBlockParser,
 )
-from torchrl.envs.transforms import TransformedEnv
+from torchrl.envs.transforms import Tokenizer as EnvTokenizer, TransformedEnv
 from torchrl.testing.mocking_classes import CountingEnv
 
 _has_transformers = importlib.util.find_spec("transformers") is not None
@@ -725,7 +725,9 @@ class TestIncrementalTokenizer:
 
 
 class TestTokenizer:
-    def test_device_follows_env_to(self):
+    @pytest.mark.parametrize("tokenizer_cls", [Tokenizer, EnvTokenizer])
+    @pytest.mark.filterwarnings("error::DeprecationWarning")
+    def test_device_follows_env_to(self, tokenizer_cls):
         # Cached parent.device goes stale after env.to (issue #4345).
         class DummyTokenizer:
             def __call__(self, value, return_tensors="pt", **kwargs):
@@ -735,17 +737,32 @@ class TestTokenizer:
                     "attention_mask": torch.ones(batch, 2, dtype=torch.long),
                 }
 
-        t = Tokenizer(
-            in_keys=["text"],
-            out_keys=["input_ids"],
+        t = tokenizer_cls(
+            in_keys=[("text", "prompt")],
+            out_keys=[("tokens", "prompt")],
             tokenizer=DummyTokenizer(),
         )
-        env = TransformedEnv(CountingEnv(), t)
-        td = TensorDict({"text": "hello"})
-        t(td.clone())
-        env.to("meta")
+        td = TensorDict({("text", "prompt"): "hello"})
+        assert t.out_device is None
         out = t(td.clone())
-        assert out["input_ids"].device == torch.device("meta")
+        assert out["tokens", "prompt"].device == torch.device("cpu")
+        with pytest.warns(DeprecationWarning, match=r"v0\.17.*out_device"):
+            assert t.device is None
+
+        env = TransformedEnv(CountingEnv(), t)
+        try:
+            for device in (None, "cpu", "meta"):
+                if device is not None:
+                    env.to(device)
+                expected = torch.device(device) if device is not None else None
+                assert t.out_device == expected
+                out = t(td.clone())
+                for key in ("prompt", "attention_mask"):
+                    assert out["tokens", key].device == torch.device(device or "cpu")
+                with pytest.warns(DeprecationWarning, match=r"v0\.17.*out_device"):
+                    assert t.device == t.out_device
+        finally:
+            env.close()
 
 
 class TestPolicyVersion:

--- a/test/llm/test_llm_transforms.py
+++ b/test/llm/test_llm_transforms.py
@@ -10,6 +10,7 @@ import importlib.util
 import json
 
 import pytest
+import torch
 from tensordict import set_list_to_stack, TensorDict
 
 from torchrl.data.llm import History
@@ -19,11 +20,13 @@ from torchrl.envs.llm.transforms import (
     IncrementalTokenizer,
     JSONCallParser,
     PolicyVersion,
+    Tokenizer,
     ToolCall,
     ToolRegistry,
     XMLBlockParser,
 )
 from torchrl.envs.transforms import TransformedEnv
+from torchrl.testing.mocking_classes import CountingEnv
 
 _has_transformers = importlib.util.find_spec("transformers") is not None
 
@@ -719,6 +722,30 @@ class TestIncrementalTokenizer:
         assert ("tokens", "prompt") in result.keys(True, True)
         tokens = result.get(("tokens", "prompt"), as_list=True)
         assert tokens[0].numel() > 0
+
+
+class TestTokenizer:
+    def test_device_follows_env_to(self):
+        # Cached parent.device goes stale after env.to (issue #4345).
+        class DummyTokenizer:
+            def __call__(self, value, return_tensors="pt", **kwargs):
+                batch = 1 if isinstance(value, str) else len(value)
+                return {
+                    "input_ids": torch.ones(batch, 2, dtype=torch.long),
+                    "attention_mask": torch.ones(batch, 2, dtype=torch.long),
+                }
+
+        t = Tokenizer(
+            in_keys=["text"],
+            out_keys=["input_ids"],
+            tokenizer=DummyTokenizer(),
+        )
+        env = TransformedEnv(CountingEnv(), t)
+        td = TensorDict({"text": "hello"})
+        t(td.clone())
+        env.to("meta")
+        out = t(td.clone())
+        assert out["input_ids"].device == torch.device("meta")
 
 
 class TestPolicyVersion:

--- a/test/transforms/test_key_transforms.py
+++ b/test/transforms/test_key_transforms.py
@@ -1645,3 +1645,27 @@ class TestTokenizer(TransformBase):
         )[0]
         torch.testing.assert_close(td_out["tokens"], expected)
         assert "attention_mask" not in td_out.keys()
+
+
+class TestTokenizerDevice:
+    def test_device_follows_env_to(self):
+        # Cached parent.device goes stale after env.to (issue #4345).
+        class DummyTokenizer:
+            def __call__(self, value, return_tensors="pt", **kwargs):
+                batch = 1 if isinstance(value, str) else len(value)
+                return {
+                    "input_ids": torch.ones(batch, 2, dtype=torch.long),
+                    "attention_mask": torch.ones(batch, 2, dtype=torch.long),
+                }
+
+        t = Tokenizer(
+            in_keys=["text"],
+            out_keys=["input_ids"],
+            tokenizer=DummyTokenizer(),
+        )
+        env = TransformedEnv(CountingEnv(), t)
+        td = TensorDict({"text": "hello"})
+        t(td.clone())
+        env.to("meta")
+        out = t(td.clone())
+        assert out["input_ids"].device == torch.device("meta")

--- a/test/transforms/test_key_transforms.py
+++ b/test/transforms/test_key_transforms.py
@@ -1645,27 +1645,3 @@ class TestTokenizer(TransformBase):
         )[0]
         torch.testing.assert_close(td_out["tokens"], expected)
         assert "attention_mask" not in td_out.keys()
-
-
-class TestTokenizerDevice:
-    def test_device_follows_env_to(self):
-        # Cached parent.device goes stale after env.to (issue #4345).
-        class DummyTokenizer:
-            def __call__(self, value, return_tensors="pt", **kwargs):
-                batch = 1 if isinstance(value, str) else len(value)
-                return {
-                    "input_ids": torch.ones(batch, 2, dtype=torch.long),
-                    "attention_mask": torch.ones(batch, 2, dtype=torch.long),
-                }
-
-        t = Tokenizer(
-            in_keys=["text"],
-            out_keys=["input_ids"],
-            tokenizer=DummyTokenizer(),
-        )
-        env = TransformedEnv(CountingEnv(), t)
-        td = TensorDict({"text": "hello"})
-        t(td.clone())
-        env.to("meta")
-        out = t(td.clone())
-        assert out["input_ids"].device == torch.device("meta")

--- a/torchrl/envs/llm/transforms/tokenizer.py
+++ b/torchrl/envs/llm/transforms/tokenizer.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from typing import Any, TYPE_CHECKING
 
@@ -95,11 +96,27 @@ class Tokenizer(UnaryTransform):
         self._missing_tolerance = missing_tolerance
 
     @property
-    def device(self) -> torch.device | None:
+    def out_device(self) -> torch.device | None:
+        """Destination for token tensors and attention masks, read from the parent.
+
+        If there is no parent or its device is ``None``, tokenization outputs
+        retain the device chosen by the tokenizer.
+        """
         parent = self.parent
         if parent is None:
             return None
         return parent.device
+
+    @property
+    def device(self) -> torch.device | None:
+        """Deprecated alias for :attr:`out_device`, removed in TorchRL v0.17."""
+        warnings.warn(
+            "Tokenizer.device is deprecated and will be removed in TorchRL v0.17. "
+            "Use out_device instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.out_device
 
     def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
         # Specialized for attention mask
@@ -164,7 +181,7 @@ class Tokenizer(UnaryTransform):
         return super()._reset(tensordict, tensordict_reset)
 
     def call_tokenizer_fn(self, value: str | list[str]):
-        device = self.device
+        device = self.out_device
         kwargs = {"add_special_tokens": self.add_special_tokens}
         if self.max_length is not None:
             kwargs["padding"] = "max_length"

--- a/torchrl/envs/llm/transforms/tokenizer.py
+++ b/torchrl/envs/llm/transforms/tokenizer.py
@@ -95,15 +95,11 @@ class Tokenizer(UnaryTransform):
         self._missing_tolerance = missing_tolerance
 
     @property
-    def device(self):
-        if "_device" in self.__dict__:
-            return self._device
+    def device(self) -> torch.device | None:
         parent = self.parent
         if parent is None:
             return None
-        device = parent.device
-        self._device = device
-        return device
+        return parent.device
 
     def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
         # Specialized for attention mask

--- a/torchrl/envs/transforms/_tensor.py
+++ b/torchrl/envs/transforms/_tensor.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import hashlib
+import warnings
 from collections.abc import Callable, Sequence
 from copy import copy
 from typing import Any, TYPE_CHECKING
@@ -758,11 +759,27 @@ class Tokenizer(UnaryTransform):
         self._missing_tolerance = missing_tolerance
 
     @property
-    def device(self) -> torch.device | None:
+    def out_device(self) -> torch.device | None:
+        """Destination for token tensors and attention masks, read from the parent.
+
+        If there is no parent or its device is ``None``, tokenization outputs
+        retain the device chosen by the tokenizer.
+        """
         parent = self.parent
         if parent is None:
             return None
         return parent.device
+
+    @property
+    def device(self) -> torch.device | None:
+        """Deprecated alias for :attr:`out_device`, removed in TorchRL v0.17."""
+        warnings.warn(
+            "Tokenizer.device is deprecated and will be removed in TorchRL v0.17. "
+            "Use out_device instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.out_device
 
     def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
         # Specialized for attention mask
@@ -827,7 +844,7 @@ class Tokenizer(UnaryTransform):
         return super()._reset(tensordict, tensordict_reset)
 
     def call_tokenizer_fn(self, value: str | list[str]):
-        device = self.device
+        device = self.out_device
         kwargs = {"add_special_tokens": self.add_special_tokens}
         if self.max_length is not None:
             kwargs["padding"] = "max_length"

--- a/torchrl/envs/transforms/_tensor.py
+++ b/torchrl/envs/transforms/_tensor.py
@@ -759,14 +759,10 @@ class Tokenizer(UnaryTransform):
 
     @property
     def device(self) -> torch.device | None:
-        if "_device" in self.__dict__:
-            return self._device
         parent = self.parent
         if parent is None:
             return None
-        device = parent.device
-        self._device = device
-        return device
+        return parent.device
 
     def _call(self, next_tensordict: TensorDictBase) -> TensorDictBase:
         # Specialized for attention mask


### PR DESCRIPTION
## Description

Both LLM `Tokenizer` and `torchrl.envs.transforms.Tokenizer` cached `parent.device` on first access. `env.to(...)` does not move that Python attribute, so later tokenize calls stayed on the stale device.

`out_device` now reads `parent.device` on each call and describes where token tensors and attention masks are written. After `env.to("meta")`, both outputs are on `meta`. When `out_device` is `None`, outputs keep the device chosen by the tokenizer.

Both Tokenizer implementations retain `device` as a deprecated alias, with removal scheduled for TorchRL v0.17. Reading the alias emits a `DeprecationWarning`; normal tokenization uses `out_device` and does not warn.

### Code example

Use `out_device` to inspect tokenization output placement. Tokenization follows an environment device move even after the first call. The small tokenizer stub avoids a model download; the same API is available on `torchrl.envs.transforms.Tokenizer`.

```python
import torch
from tensordict import TensorDict
from torchrl.envs import TransformedEnv
from torchrl.envs.llm.transforms import Tokenizer
from torchrl.testing.mocking_classes import CountingEnv

class FixedTokenizer:
    def __call__(self, value, **kwargs):
        return {
            "input_ids": torch.tensor([[1, 2]]),
            "attention_mask": torch.tensor([[1, 1]]),
        }

transform = Tokenizer(
    in_keys=["text"], out_keys=["input_ids"], tokenizer=FixedTokenizer(),
)
env = TransformedEnv(CountingEnv(), transform)
assert transform(TensorDict(text="hello"))["input_ids"].device.type == "cpu"
env.to("meta")
assert transform.out_device == torch.device("meta")
assert transform(TensorDict(text="hello"))["input_ids"].device.type == "meta"
# The second result used to stay on CPU because parent.device was cached.
env.close()
```

## Motivation and Context

close #4345

Same class of bug as #4224.

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.