### PR TITLE
[BugFix] Count dropped dialog turns in LLMCollector last-step mode

### DIFF
--- a/test/llm/test_llm_collectors.py
+++ b/test/llm/test_llm_collectors.py
@@ -524,8 +524,11 @@ class _DummyAssistantPolicy(TensorDictModuleBase):
     def forward(self, tensordict):
         prompt = tensordict.get(("history", "prompt"))
         response = History(content="ok", role="assistant")
-        for _ in prompt.batch_size[:-1]:
+        env_batch = prompt.batch_size[:-1]
+        for _ in env_batch:
             response = response.unsqueeze(0)
+        if env_batch:
+            response = response.expand(*env_batch)
         response = response.unsqueeze(-1)
         tensordict.set(("history", "full"), prompt.extend(response, dim=-1))
         return tensordict
@@ -553,6 +556,41 @@ class TestLLMCollectorLastStepFrames:
             AsyncEnvPool([env_maker], backend="threading", stack="lazy")
             if use_async
             else env_maker()
+        )
+        collector = LLMCollector(
+            env=env,
+            policy=_DummyAssistantPolicy(),
+            dialog_turns_per_batch=1,
+            total_dialog_turns=max_turns,
+            yield_only_last_steps=True,
+        )
+
+        batches = list(collector)
+
+        assert len(batches) == 1
+        last_step = batches[0]
+        assert last_step.numel() == 1
+        assert last_step["next", "done"].any()
+        assert int(last_step["next", "step_count"].max()) == max_turns
+        assert collector._frames == max_turns
+
+    def test_async_multi_env_does_not_overshoot_last_step_budget(self):
+        # In-progress (not-yet-done) queues must count toward the remaining
+        # budget so a second env cannot complete another 3-turn dialog.
+        max_turns = 3
+        num_envs = 2
+
+        def env_maker():
+            env = ChatEnv.from_dataloader(
+                dataloader=DummyStrDataLoader(1),
+                input_mode="history",
+                batch_size=1,
+                group_repeats=True,
+            )
+            return env.append_transform(StepCounter(max_steps=max_turns))
+
+        env = AsyncEnvPool(
+            [env_maker] * num_envs, backend="threading", stack="lazy"
         )
         collector = LLMCollector(
             env=env,

--- a/test/llm/test_llm_collectors.py
+++ b/test/llm/test_llm_collectors.py
@@ -13,10 +13,12 @@ import time
 import pytest
 import torch
 from tensordict import set_list_to_stack
+from tensordict.nn import TensorDictModuleBase
 from torchrl import logger as torchrl_logger
 from torchrl.collectors.llm import LLMCollector
 from torchrl.collectors.llm.weight_update.vllm import vLLMUpdater
 from torchrl.data import LazyStackStorage, ReplayBuffer
+from torchrl.data.llm.history import History
 from torchrl.envs import AsyncEnvPool, StepCounter
 from torchrl.envs.llm.chat import ChatEnv
 from torchrl.modules.llm import TransformersWrapper, vLLMWrapper
@@ -511,6 +513,63 @@ class TestAsyncEnvPoolSpecs:
         assert td_next.shape == torch.Size([4])
 
         env.close()
+
+
+class _DummyAssistantPolicy(TensorDictModuleBase):
+    """Appends a fixed assistant turn so ChatEnv can step without an LLM."""
+
+    in_keys = [("history", "prompt")]
+    out_keys = [("history", "full")]
+
+    def forward(self, tensordict):
+        prompt = tensordict.get(("history", "prompt"))
+        response = History(content="ok", role="assistant")
+        for _ in prompt.batch_size[:-1]:
+            response = response.unsqueeze(0)
+        response = response.unsqueeze(-1)
+        tensordict.set(("history", "full"), prompt.extend(response, dim=-1))
+        return tensordict
+
+
+class TestLLMCollectorLastStepFrames:
+    """CPU-only frame accounting for yield_only_last_steps."""
+
+    @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
+    def test_yield_only_last_steps_counts_env_turns(self, use_async):
+        # A 3-turn dialog with total_dialog_turns=3 must complete one
+        # trajectory (one last-step row), not three last-steps.
+        max_turns = 3
+
+        def env_maker():
+            env = ChatEnv.from_dataloader(
+                dataloader=DummyStrDataLoader(1),
+                input_mode="history",
+                batch_size=1,
+                group_repeats=True,
+            )
+            return env.append_transform(StepCounter(max_steps=max_turns))
+
+        env = (
+            AsyncEnvPool([env_maker], backend="threading", stack="lazy")
+            if use_async
+            else env_maker()
+        )
+        collector = LLMCollector(
+            env=env,
+            policy=_DummyAssistantPolicy(),
+            dialog_turns_per_batch=1,
+            total_dialog_turns=max_turns,
+            yield_only_last_steps=True,
+        )
+
+        batches = list(collector)
+
+        assert len(batches) == 1
+        last_step = batches[0]
+        assert last_step.numel() == 1
+        assert last_step["next", "done"].any()
+        assert int(last_step["next", "step_count"].max()) == max_turns
+        assert collector._frames == max_turns
 
 
 class TestUpdate:

--- a/torchrl/collectors/llm/base.py
+++ b/torchrl/collectors/llm/base.py
@@ -234,6 +234,7 @@ class LLMCollector(Collector):
                 )
             self._yield_queues = [deque() for _ in range(self.env.batch_size[0])]
             self._trajectory_queue = deque()
+            self._async_outstanding = 0
         self.async_envs = bool(async_envs) | isinstance(self.env, AsyncEnvPool)
         if self.async_envs and not isinstance(self.env, AsyncEnvPool):
             # This basically means that `async_envs` is automatically set and passing is it useless as of today,
@@ -320,7 +321,9 @@ class LLMCollector(Collector):
         if not self.yield_only_last_steps:
             result = lazy_stack(queue, -1)
         else:
-            dropped = len(queue) - 1
+            # deque has no slice; subtract the last row so batched env
+            # slots (numel != 1) are counted as the turns they actually ran.
+            dropped = sum(td.numel() for td in queue) - queue[-1].numel()
             if dropped:
                 self._frames += dropped
             # lazy-stack (not unsqueeze) so string fields stay nested in lists
@@ -328,6 +331,38 @@ class LLMCollector(Collector):
         self._trajectory_queue.append(result)
         queue.clear()
         return result
+
+    def _in_flight_dialog_turns(self) -> int:
+        """Turns collected but not yet charged by :meth:`iterator`."""
+        pending = sum(td.numel() for td in self._trajectory_queue)
+        in_progress = sum(
+            td.numel() for queue in self._yield_queues for td in queue
+        )
+        return pending + in_progress
+
+    def _async_send(self, next_output: TensorDictBase) -> None:
+        env_input = self.policy(next_output)
+        self.env.async_step_and_maybe_reset_send(env_input)
+        self._async_outstanding += (
+            next_output.batch_size[0] if next_output.batch_dims else 1
+        )
+
+    def _maybe_async_prefetch(self, next_output: TensorDictBase) -> None:
+        """Launch another async step only while the remaining budget allows.
+
+        In-progress ``_yield_queues`` count toward the budget so ``num_envs>1``
+        cannot complete extra dialogs past ``total_dialog_turns``. If those
+        queues already fill the budget but no dialog is done, step a single
+        env so we can yield without launching the rest of the pool.
+        """
+        remaining = self._frames + self._in_flight_dialog_turns() < self.total_frames
+        if remaining:
+            prefetch = next_output
+        elif not self._trajectory_queue and self._async_outstanding == 0:
+            prefetch = next_output[0]
+        else:
+            return
+        self._async_send(prefetch)
 
     def _rollout_all(self) -> TensorDictBase:  # A simplified version of rollout
         if self.reset_at_each_iter or self._shuttle is None:
@@ -419,8 +454,7 @@ class LLMCollector(Collector):
             if self._shuttle is None:
                 self._shuttle = self.env.reset()
             next_output = self._shuttle
-            env_input = self.policy(next_output)
-            self.env.async_step_and_maybe_reset_send(env_input)
+            self._async_send(next_output)
         self.started = True
 
         collected_steps = 0
@@ -431,6 +465,7 @@ class LLMCollector(Collector):
                 break
 
             cur_output, next_output = self.env.async_step_and_maybe_reset_recv()
+            self._async_outstanding -= cur_output.batch_size[0]
 
             # Get the env ids - flatten to handle multi-dimensional batch sizes
             # (e.g., AsyncEnvPool with batch_size=[4, 1] gives [[0], [1], [2], [3]])
@@ -458,12 +493,7 @@ class LLMCollector(Collector):
                 for idx in dones.nonzero(as_tuple=True)[0].tolist():
                     self._enqueue_completed_traj(idx)
 
-            # Prefetch only while counted env turns plus queued yields
-            # are still below total_dialog_turns.
-            pending = sum(td.numel() for td in self._trajectory_queue)
-            if self._frames + pending < self.total_frames:
-                env_input = self.policy(next_output)
-                self.env.async_step_and_maybe_reset_send(env_input)
+            self._maybe_async_prefetch(next_output)
 
         result = self._trajectory_queue.popleft()
         # Flatten the result - AsyncEnvPool child envs with batch_size=(1,) produce

--- a/torchrl/collectors/llm/base.py
+++ b/torchrl/collectors/llm/base.py
@@ -39,7 +39,11 @@ class LLMCollector(Collector):
         dialog_turns_per_batch (int, optional): A keyword-only argument representing the total
             number of elements in a batch. It is always required except when `yield_completed_trajectories=True`.
         total_dialog_turns (int): A keyword-only argument representing the total
-            number of steps returned by the collector during its lifespan. -1 is never ending (until shutdown).
+            number of environment dialog turns (steps that actually ran) during
+            the collector's lifespan. When ``yield_only_last_steps=True``,
+            dropped intermediate turns still count toward this budget so a
+            3-turn dialog with ``total_dialog_turns=3`` completes one
+            trajectory, not three. -1 is never ending (until shutdown).
             Defaults to -1.
         yield_completed_trajectories (bool, optional): whether to yield batches of rollouts with a given number of steps
             (`yield_completed_trajectories=False`, default) or single, completed trajectories
@@ -52,6 +56,7 @@ class LLMCollector(Collector):
         yield_only_last_steps (bool, optional): whether to yield every step of a trajectory, or only the
             last (done) steps.
             If `True`, a single trajectory is yielded (or written in the buffer) at a time.
+            Dropped intermediate turns still count toward :attr:`total_dialog_turns`.
 
             .. warning:: If the `done` state of the environment is not properly set, this may lead to a collector
                 that never leads any data.
@@ -302,6 +307,28 @@ class LLMCollector(Collector):
         else:
             return self._rollout_all
 
+    def _enqueue_completed_traj(self, idx: int) -> TensorDictBase:
+        """Queue a finished dialog and count any turns that will not be yielded.
+
+        When ``yield_only_last_steps=True``, only the last (done) row is
+        returned, so :meth:`iterator` would otherwise increment
+        :attr:`_frames` by that row's ``numel`` alone. Intermediate env
+        turns are added to ``_frames`` here so ``total_dialog_turns``
+        counts steps that ran, not only yielded last-step rows.
+        """
+        queue = self._yield_queues[idx]
+        if not self.yield_only_last_steps:
+            result = lazy_stack(queue, -1)
+        else:
+            dropped = len(queue) - 1
+            if dropped:
+                self._frames += dropped
+            # lazy-stack (not unsqueeze) so string fields stay nested in lists
+            result = lazy_stack([queue[-1]])
+        self._trajectory_queue.append(result)
+        queue.clear()
+        return result
+
     def _rollout_all(self) -> TensorDictBase:  # A simplified version of rollout
         if self.reset_at_each_iter or self._shuttle is None:
             self._shuttle = self.env.reset()
@@ -367,17 +394,8 @@ class LLMCollector(Collector):
                 dones[i] = _data["next", "done"].any()
             if dones.any():
                 for idx in dones.nonzero(as_tuple=True)[0].tolist():
-                    if not self.yield_only_last_steps:
-                        _result = lazy_stack(self._yield_queues[idx], -1)
-                        self._trajectory_queue.append(_result)
-                    else:
-                        # FIXME: We need to increment the step count here because iterator() won't
-                        #  see the extra steps
-                        # We use lazy-stack because unsqueeze doesn't nest the strings in lists
-                        _result = lazy_stack([self._yield_queues[idx][-1]])
-                        self._trajectory_queue.append(_result)
+                    _result = self._enqueue_completed_traj(idx)
                     self._result_numel += _result.numel()
-                    self._yield_queues[idx].clear()
         result = [self._trajectory_queue.popleft()]
         elt = result[0].numel()
         self._result_numel -= result[0].numel()
@@ -438,22 +456,12 @@ class LLMCollector(Collector):
                 dones[i] = _data["next", "done"].any()
             if dones.any():
                 for idx in dones.nonzero(as_tuple=True)[0].tolist():
-                    if not self.yield_only_last_steps:
-                        self._trajectory_queue.append(
-                            lazy_stack(self._yield_queues[idx], -1)
-                        )
-                    else:
-                        # FIXME: We need to increment the step count here because iterator() won't
-                        #  see the extra steps
-                        # We use lazy-stack because unsqueeze doesn't nest the strings in lists
-                        self._trajectory_queue.append(
-                            lazy_stack([self._yield_queues[idx][-1]])
-                        )
-                    self._yield_queues[idx].clear()
+                    self._enqueue_completed_traj(idx)
 
-            # Launch the next batch:
-            # FIXME: Add a condition RE number of frames here
-            if True:
+            # Prefetch only while counted env turns plus queued yields
+            # are still below total_dialog_turns.
+            pending = sum(td.numel() for td in self._trajectory_queue)
+            if self._frames + pending < self.total_frames:
                 env_input = self.policy(next_output)
                 self.env.async_step_and_maybe_reset_send(env_input)
 

--- a/torchrl/collectors/llm/ray_collector.py
+++ b/torchrl/collectors/llm/ray_collector.py
@@ -42,7 +42,9 @@ class RayLLMCollector(LLMCollector):
         dialog_turns_per_batch (int): A keyword-only argument representing the total
             number of elements in a batch.
         total_dialog_turns (int): A keyword-only argument representing the total
-            number of dialog turns returned by the collector during its lifespan.
+            number of environment dialog turns (steps that actually ran) during
+            the collector's lifespan. When ``yield_only_last_steps=True``,
+            dropped intermediate turns still count.
         yield_only_last_steps (bool, optional): whether to yield every step of a trajectory, or only the
             last (done) steps.
         yield_completed_trajectories (bool, optional): whether to yield batches of rollouts with a given number of steps


### PR DESCRIPTION
## Description

With `yield_only_last_steps=True`, `iterator()` incremented `_frames` by the yielded last-step `numel()`. `total_dialog_turns=N` therefore stopped after N completed trajectories, not N dialog turns.

Dropped intermediate turns are now added to `_frames` before the last-step row is queued. Async prefetch no longer uses `if True:`; it only launches another step while the remaining budget allows.

A 3-turn dialog with `total_dialog_turns=3` completes one trajectory.

### Code example

A three-turn dialog consumes the full budget while yielding only its final transition. This uses a fixed response policy and needs no model download.

```python
from tensordict.nn import TensorDictModuleBase
from torchrl.collectors.llm import LLMCollector
from torchrl.data.llm import History
from torchrl.envs import StepCounter
from torchrl.envs.llm import ChatEnv
from torchrl.testing import DummyStrDataLoader

class AssistantPolicy(TensorDictModuleBase):
    in_keys = [("history", "prompt")]
    out_keys = [("history", "full")]

    def forward(self, td):
        prompt = td["history", "prompt"]
        response = History(role="assistant", content="ok").unsqueeze(0).unsqueeze(-1)
        td["history", "full"] = prompt.extend(response, dim=-1)
        return td

env = ChatEnv.from_dataloader(
    DummyStrDataLoader(1), input_mode="history", batch_size=1, group_repeats=True,
).append_transform(StepCounter(max_steps=3))
collector = LLMCollector(
    env=env, policy=AssistantPolicy(), dialog_turns_per_batch=1,
    total_dialog_turns=3, yield_only_last_steps=True,
)
batches = list(collector)
assert len(batches) == 1  # Previously collected three complete dialogs.
assert batches[0].numel() == 1
assert batches[0]["next", "step_count"].max() == 3
collector.shutdown()
```

## Motivation and Context

close #4347

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.