### PR TITLE
[BugFix] Accept History on ChatEnv.reset

### DIFF
--- a/test/llm/test_llm_envs.py
+++ b/test/llm/test_llm_envs.py
@@ -295,6 +295,26 @@ class TestChatEnv:
         assert list(prompt[1].role) == ["user", "assistant"]
         assert list(prompt[1].content) == ["Bye", "See ya"]
 
+    @pytest.mark.parametrize("n_envs", [2, 3])
+    def test_chat_env_reset_broadcasts_time_only_history(self, n_envs):
+        env = ChatEnv(batch_size=(n_envs,), input_mode="history", device="cpu")
+        query = NonTensorData(
+            History.from_chats(
+                [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi"},
+                ]
+            )
+        )
+        td_reset = env.reset(
+            TensorDict(query=query, batch_size=(n_envs,), device=env.device)
+        )
+        prompt = td_reset["history"].prompt
+        assert prompt.batch_size == (n_envs, 2)
+        for i in range(n_envs):
+            assert list(prompt[i].role) == ["user", "assistant"]
+            assert list(prompt[i].content) == ["Hello", "Hi"]
+
 
 @_requires_llm_stack
 @pytest.mark.skipif(not _has_datasets, reason="requires datasets")

--- a/test/llm/test_llm_envs.py
+++ b/test/llm/test_llm_envs.py
@@ -17,7 +17,13 @@ import pytest
 import tensordict
 import torch
 
-from tensordict import lazy_stack, set_list_to_stack, TensorDict
+from tensordict import (
+    lazy_stack,
+    NonTensorData,
+    NonTensorStack,
+    set_list_to_stack,
+    TensorDict,
+)
 
 from torchrl._utils import logger as torchrl_logger
 from torchrl.collectors.llm.base import LLMCollector
@@ -184,7 +190,13 @@ class TestChatEnv:
 
     @pytest.mark.parametrize(
         "query_kind",
-        ["history_system_user", "history_user_assistant", "messages", "string"],
+        [
+            "history_system_user",
+            "history_user_assistant",
+            "nontensor_history",
+            "messages",
+            "string",
+        ],
     )
     @pytest.mark.parametrize("system_prompt", [None, "Be brief."])
     def test_chat_env_reset_query_formats(self, query_kind, system_prompt):
@@ -216,6 +228,19 @@ class TestChatEnv:
             )
             expected_roles = ["user", "assistant"]
             expected_contents = ["Hello", "Hi"]
+        elif query_kind == "nontensor_history":
+            query = NonTensorData(
+                History.from_chats(
+                    [
+                        [
+                            {"role": "user", "content": "Hello"},
+                            {"role": "assistant", "content": "Hi"},
+                        ]
+                    ]
+                )
+            )
+            expected_roles = ["user", "assistant"]
+            expected_contents = ["Hello", "Hi"]
         elif query_kind == "messages":
             query = [
                 [
@@ -240,6 +265,35 @@ class TestChatEnv:
         prompt = td_reset["history"][0].prompt
         assert prompt.role == expected_roles
         assert list(prompt.content) == expected_contents
+
+    def test_chat_env_reset_nontensor_stack_history(self):
+        env = ChatEnv(batch_size=(2,), input_mode="history", device="cpu")
+        query = NonTensorStack(
+            NonTensorData(
+                History.from_chats(
+                    [
+                        {"role": "user", "content": "Hello"},
+                        {"role": "assistant", "content": "Hi"},
+                    ]
+                )
+            ),
+            NonTensorData(
+                History.from_chats(
+                    [
+                        {"role": "user", "content": "Bye"},
+                        {"role": "assistant", "content": "See ya"},
+                    ]
+                )
+            ),
+        )
+        td_reset = env.reset(
+            TensorDict(query=query, batch_size=(2,), device=env.device)
+        )
+        prompt = td_reset["history"].prompt
+        assert list(prompt[0].role) == ["user", "assistant"]
+        assert list(prompt[0].content) == ["Hello", "Hi"]
+        assert list(prompt[1].role) == ["user", "assistant"]
+        assert list(prompt[1].content) == ["Bye", "See ya"]
 
 
 @_requires_llm_stack

--- a/test/llm/test_llm_envs.py
+++ b/test/llm/test_llm_envs.py
@@ -56,7 +56,7 @@ _has_ifeval = (
     and (importlib.util.find_spec("immutabledict") is not None)
 )
 
-pytestmark = pytest.mark.skipif(
+_requires_llm_stack = pytest.mark.skipif(
     not (_has_datasets & _has_transformers & _has_vllm & _has_ray),
     reason="requires datasets, transformers, vllm, and ray",
 )
@@ -95,6 +95,7 @@ class TestChatEnv:
 
         return AutoTokenizer.from_pretrained("Qwen/Qwen2.5-3B")
 
+    @pytest.mark.skipif(not _has_transformers, reason="requires transformers")
     @pytest.mark.parametrize("input_mode", ["text", "tokens", "history"])
     def test_chat_env(self, tokenizer, input_mode):
         # Set list to stack for tensordict
@@ -181,7 +182,67 @@ class TestChatEnv:
             expected_text = "<|im_start|>system\nI'm system, do what I want.<|im_end|>\n<|im_start|>user\nI'm the user. I'm going to tell you a little about something.<|im_end|>\n<|im_start|>assistant\nThis is the action from the assistant!<|im_end|>"
             assert td_next["next", "text"][0].prompt == expected_text
 
+    @pytest.mark.parametrize(
+        "query_kind",
+        ["history_system_user", "history_user_assistant", "messages", "string"],
+    )
+    @pytest.mark.parametrize("system_prompt", [None, "Be brief."])
+    def test_chat_env_reset_query_formats(self, query_kind, system_prompt):
+        env = ChatEnv(
+            batch_size=(1,),
+            input_mode="history",
+            system_prompt=system_prompt,
+            device="cpu",
+        )
+        if query_kind == "history_system_user":
+            query = History.from_chats(
+                [
+                    [
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "Hello"},
+                    ]
+                ]
+            )
+            expected_roles = ["system", "user"]
+            expected_contents = ["You are helpful.", "Hello"]
+        elif query_kind == "history_user_assistant":
+            query = History.from_chats(
+                [
+                    [
+                        {"role": "user", "content": "Hello"},
+                        {"role": "assistant", "content": "Hi"},
+                    ]
+                ]
+            )
+            expected_roles = ["user", "assistant"]
+            expected_contents = ["Hello", "Hi"]
+        elif query_kind == "messages":
+            query = [
+                [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi"},
+                ]
+            ]
+            expected_roles = ["user", "assistant"]
+            expected_contents = ["Hello", "Hi"]
+        else:
+            query = ["Just a string query"]
+            expected_roles = ["user"]
+            expected_contents = ["Just a string query"]
 
+        if system_prompt is not None:
+            expected_roles = ["system", *expected_roles]
+            expected_contents = [system_prompt, *expected_contents]
+
+        td_reset = env.reset(
+            TensorDict(query=query, batch_size=(1,), device=env.device)
+        )
+        prompt = td_reset["history"][0].prompt
+        assert prompt.role == expected_roles
+        assert list(prompt.content) == expected_contents
+
+
+@_requires_llm_stack
 @pytest.mark.skipif(not _has_datasets, reason="requires datasets")
 class TestGSM8K:
     @pytest.fixture(scope="class")
@@ -346,6 +407,7 @@ class TestGSM8KRewardParser:
         assert td_format["reward"] == 0.5
 
 
+@_requires_llm_stack
 @pytest.mark.skipif(not _has_ifeval, reason="requires IFEval libs")
 class TestIFEvalEnv:
     def test_ifeval(self):
@@ -548,6 +610,7 @@ class TestIFEvalRewardAggregator:
         assert 0.0 <= reward.item() <= 1.2
 
 
+@_requires_llm_stack
 class TestTools:
     @pytest.mark.skipif(not _has_transformers, reason="requires transformers")
     def test_python_interpreter_single_batch(self):
@@ -1139,6 +1202,7 @@ result
         assert "15.141592653589793" in tool_content or "Result: 15.14" in tool_content
 
 
+@_requires_llm_stack
 class TestThinkingPrompt:
     @pytest.fixture(autouse=True, scope="class")
     def base_env(self):
@@ -1265,6 +1329,7 @@ class TestThinkingPrompt:
         assert len(s[0]["next", "history"].prompt) == 3
 
 
+@_requires_llm_stack
 class TestChatEnvIntegration:
     @pytest.fixture(scope="module")
     def transformers_instance(self):

--- a/torchrl/envs/llm/chat.py
+++ b/torchrl/envs/llm/chat.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from typing import Any, Literal, TYPE_CHECKING
 
 import torch
-from tensordict import lazy_stack, TensorDictBase
+from tensordict import lazy_stack, NonTensorData, NonTensorStack, TensorDictBase
 from tensordict.utils import _zip_strict
 from torch.utils.data import DataLoader
 from torchrl.data import Composite, NonTensor
@@ -75,15 +75,23 @@ def _is_chat_payload(obj: Any) -> bool:
 def _reset_query_payload(content: Any) -> Any:
     if isinstance(content, History):
         return content
-    # NonTensorStack.data is the first element; prefer tolist() for stacks.
-    data = getattr(content, "data", None)
-    if isinstance(data, History):
-        return data
+    # NonTensorData.data is the payload. NonTensorStack.data is only the first
+    # env -- unwrap stacks with tolist() / unbind so every History is kept.
+    if isinstance(content, NonTensorData):
+        data = content.data
+        return data if isinstance(data, History) else _reset_query_payload(data)
+    if isinstance(content, NonTensorStack):
+        try:
+            items = content.tolist()
+        except Exception:
+            items = content.unbind(0)
+        return [_reset_query_payload(item) for item in items]
     if hasattr(content, "tolist") and not isinstance(content, (str, bytes)):
         try:
             return content.tolist()
         except Exception:
             pass
+    data = getattr(content, "data", None)
     if data is not None:
         return data
     return content
@@ -518,6 +526,12 @@ class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
         payload = _reset_query_payload(content)
         if isinstance(payload, History):
             return self._align_history_batch(payload)
+        if (
+            isinstance(payload, (list, tuple))
+            and payload
+            and all(isinstance(item, History) for item in payload)
+        ):
+            return self._align_history_batch(lazy_stack(list(payload)))
         if _is_chat_payload(payload):
             chats = [payload] if _is_chat_message(payload) else payload
             return self._align_history_batch(History.from_chats(chats))

--- a/torchrl/envs/llm/chat.py
+++ b/torchrl/envs/llm/chat.py
@@ -57,17 +57,20 @@ def _default_collate_fn(batch):
     return batch
 
 
-def _is_chat_message(obj: Any) -> bool:
-    return isinstance(obj, dict) and "role" in obj and "content" in obj
-
-
 def _is_chat_payload(obj: Any) -> bool:
-    if _is_chat_message(obj):
+    if isinstance(obj, dict) and "role" in obj and "content" in obj:
         return True
     if isinstance(obj, (list, tuple)) and obj:
-        if _is_chat_message(obj[0]):
+        first = obj[0]
+        if isinstance(first, dict) and "role" in first and "content" in first:
             return True
-        if isinstance(obj[0], (list, tuple)) and obj[0] and _is_chat_message(obj[0][0]):
+        if (
+            isinstance(first, (list, tuple))
+            and first
+            and isinstance(first[0], dict)
+            and "role" in first[0]
+            and "content" in first[0]
+        ):
             return True
     return False
 
@@ -508,7 +511,10 @@ class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
 
     def _align_history_batch(self, history: History) -> History:
         env_bs = torch.Size(self.batch_size)
-        if history.batch_size[: len(env_bs)] == env_bs:
+        # Already batched only when env dims are a prefix *and* a conversation
+        # axis remains. A time-only History is never an env batch, even if its
+        # length equals the env size.
+        if history.ndim > len(env_bs) and history.batch_size[: len(env_bs)] == env_bs:
             return history
         # Scalar message or time-only conversation: expand over the env batch.
         if history.ndim <= 1:
@@ -533,7 +539,10 @@ class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
         ):
             return self._align_history_batch(lazy_stack(list(payload)))
         if _is_chat_payload(payload):
-            chats = [payload] if _is_chat_message(payload) else payload
+            if isinstance(payload, dict) and "role" in payload and "content" in payload:
+                chats = [payload]
+            else:
+                chats = payload
             return self._align_history_batch(History.from_chats(chats))
 
         if getattr(content, "batch_size", ()) != self.batch_size:

--- a/torchrl/envs/llm/chat.py
+++ b/torchrl/envs/llm/chat.py
@@ -57,6 +57,38 @@ def _default_collate_fn(batch):
     return batch
 
 
+def _is_chat_message(obj: Any) -> bool:
+    return isinstance(obj, dict) and "role" in obj and "content" in obj
+
+
+def _is_chat_payload(obj: Any) -> bool:
+    if _is_chat_message(obj):
+        return True
+    if isinstance(obj, (list, tuple)) and obj:
+        if _is_chat_message(obj[0]):
+            return True
+        if isinstance(obj[0], (list, tuple)) and obj[0] and _is_chat_message(obj[0][0]):
+            return True
+    return False
+
+
+def _reset_query_payload(content: Any) -> Any:
+    if isinstance(content, History):
+        return content
+    # NonTensorStack.data is the first element; prefer tolist() for stacks.
+    data = getattr(content, "data", None)
+    if isinstance(data, History):
+        return data
+    if hasattr(content, "tolist") and not isinstance(content, (str, bytes)):
+        try:
+            return content.tolist()
+        except Exception:
+            pass
+    if data is not None:
+        return data
+    return content
+
+
 class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
     r"""A chat-based environment for LLMs, designed as a blank canvas for conversation and RL.
 
@@ -75,11 +107,13 @@ class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
     Reset Operation
         During reset, the environment:
 
-            1. Takes input text from the `data_key` (default: `"query"`) in the tensordict
-            2. Creates a :class:`~torchrl.data.llm.History` object with the user's message
-            3. Optionally prepends a system prompt if provided
-            4. Formats the conversation according to the selected input mode (history, text, or tokens)
-            5. Returns the formatted prompt ready for the LLM
+            1. Takes input from the `data_key` (default: `"query"`) in the tensordict.
+               The value may be a raw string (wrapped as a user message), a
+               :class:`~torchrl.data.llm.History` (used as-is), or a list of chat
+               messages (dicts with ``role`` / ``content``).
+            2. Optionally prepends a system prompt if provided
+            3. Formats the conversation according to the selected input mode (history, text, or tokens)
+            4. Returns the formatted prompt ready for the LLM
 
     Step Operation
         During step, the environment:
@@ -116,6 +150,9 @@ class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
         user_role (str, optional): The role of the user (at reset time). Defaults to `"user"`.
         policy_role (str, optional): The role of the policy/assistant. Defaults to `"assistant"`.
         data_key (str, optional): The key of the data input to the env at reset time (from dataloader). Defaults to `"query"`.
+            The value may be a raw string (wrapped as a user utterance), a
+            :class:`~torchrl.data.llm.History`, or a list of chat messages. A
+            :attr:`system_prompt`, if set, is prepended in all cases.
         device (torch.device, optional): The device to use for computations. Defaults to `None`.
         with_tokenizer (bool, optional): If ``True``, the environment is automatically wrapped with
             :class:`~torchrl.envs.llm.transforms.IncrementalTokenizer` to maintain ``tokens.prompt`` synchronized
@@ -126,6 +163,7 @@ class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
     Methods:
         reset (TensorDict): Resets the state of the environment. A tensordict or equivalent with a `"query"` entry
             (originating from the dataloader) must be passed. This key name is defined as a class attribute `data_key`.
+            ``query`` may be a raw string, a :class:`~torchrl.data.llm.History`, or a list of messages.
         step (TensorDict): Makes a step in the environment. A tensordict or equivalent with the LLM's response must be passed.
             The response key is defined as a class attribute `response_key`.
 
@@ -147,6 +185,16 @@ class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
         >>> reset_data = TensorDict({"query": "Hello, how are you?"}, batch_size=(1,))
         >>> obs = env.reset(reset_data)
         >>> print(obs["history"].prompt)  # History with system prompt + user message
+        >>>
+        >>> # Reset with an already-formatted conversation (roles are preserved)
+        >>> reset_data = TensorDict({
+        ...     "query": History.from_chats([[
+        ...         {"role": "user", "content": "Hello, how are you?"},
+        ...         {"role": "assistant", "content": "I'm well, thanks."},
+        ...     ]])
+        ... }, batch_size=(1,))
+        >>> obs = env.reset(reset_data)
+        >>> print(obs["history"].prompt.role)  # [['system', 'user', 'assistant']]
         >>>
         >>> # Simulate LLM response and step
         >>> response_data = TensorDict({
@@ -450,36 +498,63 @@ class ChatEnv(EnvBase, metaclass=_ChatEnvMeta):
         empty_td.set("tokens", new_history)
         return empty_td
 
+    def _align_history_batch(self, history: History) -> History:
+        env_bs = torch.Size(self.batch_size)
+        if history.batch_size[: len(env_bs)] == env_bs:
+            return history
+        # Scalar message or time-only conversation: expand over the env batch.
+        if history.ndim <= 1:
+            for s in reversed(env_bs):
+                history = lazy_stack([history for _ in range(s)])
+            return history
+        raise RuntimeError(
+            f"{type(self).__name__} reset query History has batch_size "
+            f"{history.batch_size} which is incompatible with env batch_size {env_bs}."
+        )
+
+    def _query_to_history(self, content: Any) -> History:
+        if isinstance(content, History):
+            return self._align_history_batch(content)
+        payload = _reset_query_payload(content)
+        if isinstance(payload, History):
+            return self._align_history_batch(payload)
+        if _is_chat_payload(payload):
+            chats = [payload] if _is_chat_message(payload) else payload
+            return self._align_history_batch(History.from_chats(chats))
+
+        if getattr(content, "batch_size", ()) != self.batch_size:
+            for s in reversed(self.batch_size):
+                content = [content for _ in range(s)]
+        role = self.user_role
+        for s in reversed(self.batch_size):
+            role = [role for _ in range(s)]
+        return History(role=role, content=content, batch_size=self.batch_size)
+
     def _reset(self, tensordict: TensorDictBase | None, **kwargs):
         if tensordict is None:
             raise RuntimeError(
                 f"{type(self).__name__} expects a tensordict as input. Got `None`."
             )
-        # Find the total text
         content = tensordict.get(self.data_key)
         if content is None:
             raise RuntimeError(
                 f"{type(self).__name__} expects a tensordict with a {self.data_key} key, got {tensordict.keys()}"
             )
-        if content.batch_size != self.batch_size:
-            for s in reversed(self.batch_size):
-                content = [content for _ in range(s)]
-
-        # FIXME: Assume the text is not formatted and this is just content
-        role = self.user_role
-        for s in reversed(self.batch_size):
-            role = [role for _ in range(s)]
-        history = History(role=role, content=content, batch_size=self.batch_size)
+        history = self._query_to_history(content)
         if self.system_prompt is not None:
-            system_role = self.system_role
             history_system = History(
-                role=system_role,
+                role=self.system_role,
                 content=self.system_prompt,
             )
             for s in reversed(self.batch_size):
                 history_system = lazy_stack([history_system for _ in range(s)])
-            history = lazy_stack([history_system, history], -1)
-        else:
+            if history.ndim == len(self.batch_size):
+                history = lazy_stack([history_system, history], -1)
+            else:
+                history = history_system.unsqueeze(-1).extend(
+                    history, inplace=False, dim=-1
+                )
+        elif history.ndim == len(self.batch_size):
             history = history.unsqueeze(-1)
 
         # Now that we have the history, call the specific reset method


### PR DESCRIPTION
## Description

`ChatEnv._reset` always wrapped `data_key` as a raw user utterance (`History(role=user, content=content)`). An already-built `History` or message list was wrapped again and roles were corrupted.

A `History` or list of `{role, content}` messages is now used as-is. A string is still wrapped as a user turn. `system_prompt` is still prepended when set.

### Code example

Pass a conversation with an explicit environment batch dimension. Reset preserves the existing user and assistant turns.

```python
from tensordict import TensorDict
from torchrl.data.llm import History
from torchrl.envs.llm import ChatEnv

query = History.from_chats([[
    {"role": "user", "content": "Hello"},
    {"role": "assistant", "content": "Hi"},
]])
env = ChatEnv(batch_size=(1,), input_mode="history", device="cpu")
td = env.reset(TensorDict(query=query, batch_size=[1], device="cpu"))
prompt = td["history"][0].prompt
assert list(prompt.role) == ["user", "assistant"]
assert list(prompt.content) == ["Hello", "Hi"]
# Previously, the whole History was wrapped as a new user utterance.
env.close()
```

## Motivation and Context

close #4348

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.