### PR TITLE
[BugFix] Mask post-done rewards in CEM and MPPI planners

### DIFF
--- a/test/modules/test_planners.py
+++ b/test/modules/test_planners.py
@@ -8,14 +8,182 @@ import argparse
 
 import pytest
 import torch
-from tensordict import TensorDict
+from tensordict import TensorDict, TensorDictBase
 from torch import nn
+from torchrl.data import Composite, Unbounded
+from torchrl.envs import EnvBase
 from torchrl.modules import CEMPlanner, ValueOperator
+from torchrl.modules.planners.common import _mask_post_done_reward
 from torchrl.modules.planners.mppi import MPPIPlanner
 from torchrl.objectives.value import TDLambdaEstimator
 
 from torchrl.testing import get_default_devices
 from torchrl.testing.mocking_classes import MockBatchedUnLockedEnv
+
+FIRST_REWARD = 1.25
+LATER_REWARD = 50.0
+PLANNING_HORIZON = 4
+
+
+class _DoneAfterOneStepEnv(EnvBase):
+    """Batch-unlocked env that is done after one step.
+
+    The first transition yields ``FIRST_REWARD``. After that, a non-breaking
+    rollout auto-resets and later transitions yield ``LATER_REWARD``.
+    """
+
+    @classmethod
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls, *args, _batch_locked=False, **kwargs)
+
+    def __init__(self, device="cpu"):
+        super().__init__(device=device)
+        self.observation_spec = Composite(
+            observation=Unbounded((1,), device=device),
+            device=device,
+        )
+        self.action_spec = Unbounded((1,), device=device)
+        self.reward_spec = Unbounded((1,), device=device)
+        self._started = False
+
+    def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
+        if tensordict is None:
+            batch_size = self.batch_size
+            device = self.device
+        else:
+            batch_size = tensordict.batch_size
+            device = tensordict.device if tensordict.device is not None else self.device
+        if tensordict is None or "_reset" not in tensordict.keys():
+            self._started = False
+        done = torch.zeros(*batch_size, 1, dtype=torch.bool, device=device)
+        return TensorDict(
+            {
+                "observation": torch.zeros(
+                    *batch_size, 1, device=device, dtype=torch.get_default_dtype()
+                ),
+                "done": done,
+                "terminated": done.clone(),
+            },
+            batch_size=batch_size,
+            device=device,
+        )
+
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        batch_size = tensordict.batch_size
+        device = tensordict.device if tensordict.device is not None else self.device
+        reward_value = LATER_REWARD if self._started else FIRST_REWARD
+        self._started = True
+        done = torch.ones(*batch_size, 1, dtype=torch.bool, device=device)
+        return TensorDict(
+            {
+                "observation": tensordict.get("observation") + 1,
+                "reward": torch.full(
+                    (*batch_size, 1),
+                    reward_value,
+                    device=device,
+                    dtype=torch.get_default_dtype(),
+                ),
+                "done": done,
+                "terminated": done.clone(),
+            },
+            batch_size=batch_size,
+            device=device,
+        )
+
+    def _set_seed(self, seed: int | None) -> None:
+        pass
+
+
+class _SurviveIfPositiveEnv(EnvBase):
+    """Reward is 1 each step. The episode ends when ``action[..., :1] < 0``."""
+
+    @classmethod
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls, *args, _batch_locked=False, **kwargs)
+
+    def __init__(self, device="cpu"):
+        super().__init__(device=device)
+        self.observation_spec = Composite(
+            observation=Unbounded((1,), device=device),
+            device=device,
+        )
+        self.action_spec = Unbounded((1,), device=device)
+        self.reward_spec = Unbounded((1,), device=device)
+
+    def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
+        if tensordict is None:
+            batch_size = self.batch_size
+            device = self.device
+        else:
+            batch_size = tensordict.batch_size
+            device = tensordict.device if tensordict.device is not None else self.device
+        done = torch.zeros(*batch_size, 1, dtype=torch.bool, device=device)
+        return TensorDict(
+            {
+                "observation": torch.zeros(
+                    *batch_size, 1, device=device, dtype=torch.get_default_dtype()
+                ),
+                "done": done,
+                "terminated": done.clone(),
+            },
+            batch_size=batch_size,
+            device=device,
+        )
+
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        action = tensordict.get("action")
+        device = action.device
+        done = action[..., :1] < 0
+        return TensorDict(
+            {
+                "observation": tensordict.get("observation") + 1,
+                "reward": torch.ones(
+                    *tensordict.batch_size,
+                    1,
+                    device=device,
+                    dtype=torch.get_default_dtype(),
+                ),
+                "done": done,
+                "terminated": done.clone(),
+            },
+            batch_size=tensordict.batch_size,
+            device=device,
+        )
+
+    def _set_seed(self, seed: int | None) -> None:
+        pass
+
+
+class _SumRewardAdvantage(nn.Module):
+    """Advantage equal to the trajectory return, written at every time step."""
+
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        reward = tensordict.get(("next", "reward"))
+        ret = reward.sum(dim=-2, keepdim=True)
+        tensordict.set("advantage", ret.expand_as(reward))
+        return tensordict
+
+
+def _make_planner(name, env, *, planning_horizon=PLANNING_HORIZON):
+    if name == "cem":
+        return CEMPlanner(
+            env,
+            planning_horizon=planning_horizon,
+            optim_steps=1,
+            num_candidates=8,
+            top_k=2,
+            reward_key=("next", "reward"),
+        )
+    return MPPIPlanner(
+        env,
+        _SumRewardAdvantage(),
+        temperature=1.0,
+        planning_horizon=planning_horizon,
+        optim_steps=1,
+        num_candidates=8,
+        top_k=2,
+        reward_key=("next", "reward"),
+    )
 
 
 @pytest.mark.parametrize("device", get_default_devices())
@@ -76,6 +244,150 @@ class TestPlanner:
         for key in td.keys():
             if key != "action":
                 assert torch.allclose(td[key], td_copy[key])
+
+    @pytest.mark.parametrize("planner_name", ["cem", "mppi"])
+    def test_planner_ignores_post_done_rewards(self, device, batch_size, planner_name):
+        env = _DoneAfterOneStepEnv(device=device)
+        planner = _make_planner(planner_name, env)
+        td = env.reset(TensorDict(batch_size=batch_size).to(device))
+        num_candidates = 8
+        expanded = (
+            td.unsqueeze(-1).expand(*td.batch_size, num_candidates).to_tensordict()
+        )
+
+        def policy(tensordict):
+            tensordict.set(
+                "action",
+                torch.zeros(
+                    *tensordict.batch_size,
+                    *env.action_spec.shape,
+                    device=tensordict.device,
+                    dtype=env.action_spec.dtype,
+                ),
+            )
+            return tensordict
+
+        rollout = env.rollout(
+            max_steps=PLANNING_HORIZON,
+            policy=policy,
+            auto_reset=False,
+            tensordict=expanded.clone(),
+            break_when_any_done=False,
+        )
+        raw = rollout.get(("next", "reward"))
+        assert raw.shape[-2] == PLANNING_HORIZON
+        torch.testing.assert_close(
+            raw[..., 0, :],
+            torch.full_like(raw[..., 0, :], FIRST_REWARD),
+        )
+        torch.testing.assert_close(
+            raw[..., 1:, :],
+            torch.full_like(raw[..., 1:, :], LATER_REWARD),
+        )
+
+        masked = _mask_post_done_reward(
+            rollout, reward_key=("next", "reward"), time_dim=-2
+        )
+        expected = torch.zeros_like(raw)
+        expected[..., 0, :] = FIRST_REWARD
+        torch.testing.assert_close(masked, expected)
+        torch.testing.assert_close(
+            masked.sum(dim=-2),
+            torch.full_like(masked.sum(dim=-2), FIRST_REWARD),
+        )
+
+        td = env.reset(TensorDict(batch_size=batch_size).to(device))
+        out = planner(td.clone())
+        assert env.action_spec.is_in(out.get("action"))
+
+
+@pytest.mark.parametrize("device", get_default_devices())
+class TestPlannerDoneMask:
+    def test_mask_post_done_reward_values(self, device):
+        reward = torch.tensor(
+            [[[1.0], [2.0], [3.0]]],
+            device=device,
+            dtype=torch.get_default_dtype(),
+        )
+        done = torch.tensor([[[True], [False], [True]]], device=device)
+        td = TensorDict(
+            {"next": {"reward": reward, "done": done}},
+            batch_size=[1, 3],
+            device=device,
+        )
+        masked = _mask_post_done_reward(td, reward_key=("next", "reward"))
+        expected = torch.tensor(
+            [[[1.0], [0.0], [0.0]]],
+            device=device,
+            dtype=torch.get_default_dtype(),
+        )
+        torch.testing.assert_close(masked, expected)
+
+        done_later = torch.tensor([[[False], [True], [False]]], device=device)
+        td_later = TensorDict(
+            {"next": {"reward": reward, "done": done_later}},
+            batch_size=[1, 3],
+            device=device,
+        )
+        masked_later = _mask_post_done_reward(
+            td_later, reward_key=("next", "reward")
+        )
+        expected_later = torch.tensor(
+            [[[1.0], [2.0], [0.0]]],
+            device=device,
+            dtype=torch.get_default_dtype(),
+        )
+        torch.testing.assert_close(masked_later, expected_later)
+
+    def test_mask_post_done_reward_nested_keys(self, device):
+        reward = torch.zeros(2, 3, 1, device=device, dtype=torch.get_default_dtype())
+        reward[:, 0] = 1.0
+        reward[:, 1] = 2.0
+        reward[:, 2] = 3.0
+        done = torch.zeros(2, 3, 1, dtype=torch.bool, device=device)
+        done[:, 0] = True
+        td = TensorDict(
+            {"next": {"agents": {"reward": reward, "done": done}}},
+            batch_size=[2, 3],
+            device=device,
+        )
+        masked = _mask_post_done_reward(
+            td,
+            reward_key=("next", "agents", "reward"),
+            done_key=("next", "agents", "done"),
+        )
+        expected = torch.zeros_like(reward)
+        expected[:, 0] = 1.0
+        torch.testing.assert_close(masked, expected)
+
+    @pytest.mark.parametrize("planner_name", ["cem", "mppi"])
+    def test_planner_prefers_surviving_actions(self, device, planner_name, seed=0):
+        torch.manual_seed(seed)
+        env = _SurviveIfPositiveEnv(device=device)
+        if planner_name == "cem":
+            planner = CEMPlanner(
+                env,
+                planning_horizon=4,
+                optim_steps=3,
+                num_candidates=64,
+                top_k=8,
+                reward_key=("next", "reward"),
+            )
+        else:
+            planner = MPPIPlanner(
+                env,
+                _SumRewardAdvantage(),
+                temperature=1.0,
+                planning_horizon=4,
+                optim_steps=3,
+                num_candidates=64,
+                top_k=8,
+                reward_key=("next", "reward"),
+            )
+        td = env.reset(TensorDict(batch_size=()).to(device))
+        out = planner(td)
+        # Surviving (non-negative) first actions score 4; dying at step 0 scores 1.
+        assert out.get("action").item() > 0
 
 
 if __name__ == "__main__":

--- a/test/modules/test_planners.py
+++ b/test/modules/test_planners.py
@@ -12,7 +12,7 @@ import pytest
 import torch
 from tensordict import TensorDict, TensorDictBase
 from torch import nn
-from torchrl.data import Composite, Unbounded
+from torchrl.data import Categorical, Composite, Unbounded
 from torchrl.envs import EnvBase
 from torchrl.modules import CEMPlanner, ValueOperator
 from torchrl.modules.planners.common import _mask_post_done_reward
@@ -22,142 +22,10 @@ from torchrl.objectives.value import TDLambdaEstimator
 from torchrl.testing import get_default_devices
 from torchrl.testing.mocking_classes import MockBatchedUnLockedEnv
 
-FIRST_REWARD = 1.25
-LATER_REWARD = 50.0
-PLANNING_HORIZON = 4
 DIE_REWARD = 1.0
 LIVE_REWARD = 5.0
 JACKPOT_REWARD = 50.0
 TWO_SEQ_HORIZON = 3
-
-
-class _DoneAfterOneStepEnv(EnvBase):
-    """Batch-unlocked env that is done after one step.
-
-    The first transition yields ``FIRST_REWARD``. After that, a non-breaking
-    rollout auto-resets and later transitions yield ``LATER_REWARD``.
-    """
-
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(cls, *args, _batch_locked=False, **kwargs)
-
-    def __init__(self, device="cpu"):
-        super().__init__(device=device)
-        self.observation_spec = Composite(
-            observation=Unbounded((1,), device=device),
-            device=device,
-        )
-        self.action_spec = Unbounded((1,), device=device)
-        self.reward_spec = Unbounded((1,), device=device)
-        self._started = False
-
-    def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
-        if tensordict is None:
-            batch_size = self.batch_size
-            device = self.device
-        else:
-            batch_size = tensordict.batch_size
-            device = tensordict.device if tensordict.device is not None else self.device
-        if tensordict is None or "_reset" not in tensordict.keys():
-            self._started = False
-        done = torch.zeros(*batch_size, 1, dtype=torch.bool, device=device)
-        return TensorDict(
-            {
-                "observation": torch.zeros(
-                    *batch_size, 1, device=device, dtype=torch.get_default_dtype()
-                ),
-                "done": done,
-                "terminated": done.clone(),
-            },
-            batch_size=batch_size,
-            device=device,
-        )
-
-    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
-        batch_size = tensordict.batch_size
-        device = tensordict.device if tensordict.device is not None else self.device
-        reward_value = LATER_REWARD if self._started else FIRST_REWARD
-        self._started = True
-        done = torch.ones(*batch_size, 1, dtype=torch.bool, device=device)
-        return TensorDict(
-            {
-                "observation": tensordict.get("observation") + 1,
-                "reward": torch.full(
-                    (*batch_size, 1),
-                    reward_value,
-                    device=device,
-                    dtype=torch.get_default_dtype(),
-                ),
-                "done": done,
-                "terminated": done.clone(),
-            },
-            batch_size=batch_size,
-            device=device,
-        )
-
-    def _set_seed(self, seed: int | None) -> None:
-        pass
-
-
-class _SurviveIfPositiveEnv(EnvBase):
-    """Reward is 1 each step. The episode ends when ``action[..., :1] < 0``."""
-
-    @classmethod
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(cls, *args, _batch_locked=False, **kwargs)
-
-    def __init__(self, device="cpu"):
-        super().__init__(device=device)
-        self.observation_spec = Composite(
-            observation=Unbounded((1,), device=device),
-            device=device,
-        )
-        self.action_spec = Unbounded((1,), device=device)
-        self.reward_spec = Unbounded((1,), device=device)
-
-    def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
-        if tensordict is None:
-            batch_size = self.batch_size
-            device = self.device
-        else:
-            batch_size = tensordict.batch_size
-            device = tensordict.device if tensordict.device is not None else self.device
-        done = torch.zeros(*batch_size, 1, dtype=torch.bool, device=device)
-        return TensorDict(
-            {
-                "observation": torch.zeros(
-                    *batch_size, 1, device=device, dtype=torch.get_default_dtype()
-                ),
-                "done": done,
-                "terminated": done.clone(),
-            },
-            batch_size=batch_size,
-            device=device,
-        )
-
-    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
-        action = tensordict.get("action")
-        device = action.device
-        done = action[..., :1] < 0
-        return TensorDict(
-            {
-                "observation": tensordict.get("observation") + 1,
-                "reward": torch.ones(
-                    *tensordict.batch_size,
-                    1,
-                    device=device,
-                    dtype=torch.get_default_dtype(),
-                ),
-                "done": done,
-                "terminated": done.clone(),
-            },
-            batch_size=tensordict.batch_size,
-            device=device,
-        )
-
-    def _set_seed(self, seed: int | None) -> None:
-        pass
 
 
 class _TwoSequenceEnv(EnvBase):
@@ -166,15 +34,22 @@ class _TwoSequenceEnv(EnvBase):
     Dying pays ``DIE_REWARD`` and sets ``done``. After a non-breaking rollout
     auto-reset, later non-negative actions still pay their face value, so a
     die-then-jackpot sequence can beat a steady live sequence on the unmasked
-    sum while losing once rewards after the first ``("next", "done")`` are
-    dropped. ``terminated`` follows ``done`` only when ``terminate_on_done``.
+    sum while losing once rewards after the first ``done`` are dropped.
+    ``terminated`` follows ``done`` only when ``terminate_on_done``.
+    When ``done_group`` is set, done flags live only under that nested group.
     """
 
     @classmethod
     def __new__(cls, *args, **kwargs):
         return super().__new__(cls, *args, _batch_locked=False, **kwargs)
 
-    def __init__(self, device="cpu", *, terminate_on_done: bool = True):
+    def __init__(
+        self,
+        device="cpu",
+        *,
+        terminate_on_done: bool = True,
+        done_group: str | None = None,
+    ):
         super().__init__(device=device)
         self.observation_spec = Composite(
             observation=Unbounded((1,), device=device),
@@ -183,6 +58,35 @@ class _TwoSequenceEnv(EnvBase):
         self.action_spec = Unbounded((1,), device=device)
         self.reward_spec = Unbounded((1,), device=device)
         self.terminate_on_done = terminate_on_done
+        self.done_group = done_group
+        if done_group is not None:
+            flag = Categorical(2, dtype=torch.bool, shape=(1,), device=device)
+            self.done_spec = Composite(
+                {
+                    done_group: Composite(
+                        {"done": flag, "terminated": flag.clone()},
+                        shape=(),
+                        device=device,
+                    )
+                },
+                shape=(),
+                device=device,
+            )
+
+    def _done_payload(self, done, terminated):
+        if self.done_group is None:
+            return {"done": done, "terminated": terminated}
+        return {self.done_group: {"done": done, "terminated": terminated}}
+
+    def next_done_key(self):
+        if self.done_group is None:
+            return ("next", "done")
+        return ("next", self.done_group, "done")
+
+    def next_terminated_key(self):
+        if self.done_group is None:
+            return ("next", "terminated")
+        return ("next", self.done_group, "terminated")
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         if tensordict is None:
@@ -197,8 +101,7 @@ class _TwoSequenceEnv(EnvBase):
                 "observation": torch.zeros(
                     *batch_size, 1, device=device, dtype=torch.get_default_dtype()
                 ),
-                "done": done,
-                "terminated": done.clone(),
+                **self._done_payload(done, done.clone()),
             },
             batch_size=batch_size,
             device=device,
@@ -218,8 +121,7 @@ class _TwoSequenceEnv(EnvBase):
             {
                 "observation": tensordict.get("observation") + 1,
                 "reward": reward,
-                "done": die,
-                "terminated": terminated,
+                **self._done_payload(die, terminated),
             },
             batch_size=tensordict.batch_size,
             device=device,
@@ -258,20 +160,19 @@ def _rollout_action_sequence(env, actions):
         t += 1
         return tensordict
 
-    td = env.reset(TensorDict(batch_size=(), device=actions.device))
     return env.rollout(
         max_steps=actions.shape[0],
         policy=policy,
         auto_reset=False,
-        tensordict=td,
+        tensordict=env.reset(),
         break_when_any_done=False,
     )
 
 
-def _sum_until_first_done(rollout):
-    """Sum rewards through the first ``("next", "done")``; unmasked total."""
+def _sum_until_first_done(rollout, done_key=("next", "done")):
+    """Sum rewards through the first ``done``; also return the unmasked total."""
     reward = rollout.get(("next", "reward")).reshape(rollout.shape[-1])
-    done = rollout.get(("next", "done")).reshape(rollout.shape[-1])
+    done = rollout.get(done_key).reshape(rollout.shape[-1])
     unmasked = reward.sum()
     hits = done.nonzero(as_tuple=False)
     if hits.numel():
@@ -318,8 +219,8 @@ def _make_planner(
     name,
     env,
     *,
-    planning_horizon=PLANNING_HORIZON,
-    num_candidates=8,
+    planning_horizon=TWO_SEQ_HORIZON,
+    num_candidates=4,
     top_k=2,
 ):
     if name == "cem":
@@ -341,6 +242,44 @@ def _make_planner(
         top_k=top_k,
         reward_key=("next", "reward"),
     )
+
+
+def _assert_planner_picks_live_sequence(env, planner_name, device):
+    die_seq = _die_then_jackpot_sequence(device)
+    live_seq = _steady_live_sequence(device)
+    done_key = env.next_done_key()
+    terminated_key = env.next_terminated_key()
+
+    die_rollout = _rollout_action_sequence(env, die_seq)
+    live_rollout = _rollout_action_sequence(env, live_seq)
+    die_done = die_rollout.get(done_key)
+    die_terminated = die_rollout.get(terminated_key)
+    assert die_done[0].all()
+    assert not live_rollout.get(done_key).any()
+    if env.terminate_on_done:
+        torch.testing.assert_close(die_terminated, die_done)
+    else:
+        assert not die_terminated.any()
+
+    die_masked, die_unmasked = _sum_until_first_done(die_rollout, done_key=done_key)
+    live_masked, live_unmasked = _sum_until_first_done(live_rollout, done_key=done_key)
+    torch.testing.assert_close(die_masked, die_masked.new_tensor(DIE_REWARD))
+    torch.testing.assert_close(
+        die_unmasked,
+        die_unmasked.new_tensor(DIE_REWARD + 2 * JACKPOT_REWARD),
+    )
+    torch.testing.assert_close(
+        live_masked, live_masked.new_tensor(TWO_SEQ_HORIZON * LIVE_REWARD)
+    )
+    torch.testing.assert_close(live_unmasked, live_masked)
+    assert live_masked > die_masked
+    assert die_unmasked > live_unmasked
+
+    planner = _make_planner(planner_name, env)
+    td = env.reset()
+    with _fixed_planner_candidates(planner_name, die_seq, live_seq, die_seq, live_seq):
+        out = planner(td)
+    torch.testing.assert_close(out.get("action"), live_seq[0])
 
 
 @pytest.mark.parametrize("device", get_default_devices())
@@ -402,100 +341,9 @@ class TestPlanner:
             if key != "action":
                 assert torch.allclose(td[key], td_copy[key])
 
-    @pytest.mark.parametrize("planner_name", ["cem", "mppi"])
-    def test_planner_ignores_post_done_rewards(self, device, batch_size, planner_name):
-        env = _DoneAfterOneStepEnv(device=device)
-        planner = _make_planner(planner_name, env)
-        td = env.reset(TensorDict(batch_size=batch_size).to(device))
-        num_candidates = 8
-        expanded = (
-            td.unsqueeze(-1).expand(*td.batch_size, num_candidates).to_tensordict()
-        )
-
-        def policy(tensordict):
-            tensordict.set(
-                "action",
-                torch.zeros(
-                    *tensordict.batch_size,
-                    *env.action_spec.shape,
-                    device=tensordict.device,
-                    dtype=env.action_spec.dtype,
-                ),
-            )
-            return tensordict
-
-        rollout = env.rollout(
-            max_steps=PLANNING_HORIZON,
-            policy=policy,
-            auto_reset=False,
-            tensordict=expanded.clone(),
-            break_when_any_done=False,
-        )
-        raw = rollout.get(("next", "reward"))
-        assert raw.shape[-2] == PLANNING_HORIZON
-        torch.testing.assert_close(
-            raw[..., 0, :],
-            torch.full_like(raw[..., 0, :], FIRST_REWARD),
-        )
-        torch.testing.assert_close(
-            raw[..., 1:, :],
-            torch.full_like(raw[..., 1:, :], LATER_REWARD),
-        )
-
-        masked = _mask_post_done_reward(
-            rollout, reward_key=("next", "reward"), time_dim=-2
-        )
-        expected = torch.zeros_like(raw)
-        expected[..., 0, :] = FIRST_REWARD
-        torch.testing.assert_close(masked, expected)
-        torch.testing.assert_close(
-            masked.sum(dim=-2),
-            torch.full_like(masked.sum(dim=-2), FIRST_REWARD),
-        )
-
-        td = env.reset(TensorDict(batch_size=batch_size).to(device))
-        out = planner(td.clone())
-        assert env.action_spec.is_in(out.get("action"))
-
 
 @pytest.mark.parametrize("device", get_default_devices())
 class TestPlannerDoneMask:
-    def test_mask_post_done_reward_values(self, device):
-        reward = torch.tensor(
-            [[[1.0], [2.0], [3.0]]],
-            device=device,
-            dtype=torch.get_default_dtype(),
-        )
-        done = torch.tensor([[[True], [False], [True]]], device=device)
-        td = TensorDict(
-            {"next": {"reward": reward, "done": done}},
-            batch_size=[1, 3],
-            device=device,
-        )
-        masked = _mask_post_done_reward(td, reward_key=("next", "reward"))
-        expected = torch.tensor(
-            [[[1.0], [0.0], [0.0]]],
-            device=device,
-            dtype=torch.get_default_dtype(),
-        )
-        torch.testing.assert_close(masked, expected)
-
-        done_later = torch.tensor([[[False], [True], [False]]], device=device)
-        td_later = TensorDict(
-            {"next": {"reward": reward, "done": done_later}},
-            batch_size=[1, 3],
-            device=device,
-        )
-        masked_later = _mask_post_done_reward(
-            td_later, reward_key=("next", "reward")
-        )
-        expected_later = torch.tensor(
-            [[[1.0], [2.0], [0.0]]],
-            device=device,
-            dtype=torch.get_default_dtype(),
-        )
-        torch.testing.assert_close(masked_later, expected_later)
-
     def test_mask_post_done_reward_nested_keys(self, device):
         reward = torch.zeros(2, 3, 1, device=device, dtype=torch.get_default_dtype())
         reward[:, 0] = 1.0
@@ -504,47 +352,18 @@ class TestPlannerDoneMask:
         done = torch.zeros(2, 3, 1, dtype=torch.bool, device=device)
         done[:, 0] = True
         td = TensorDict(
-            {"next": {"agents": {"reward": reward, "done": done}}},
+            {"next": {"agent": {"reward": reward, "done": done}}},
             batch_size=[2, 3],
             device=device,
         )
         masked = _mask_post_done_reward(
             td,
-            reward_key=("next", "agents", "reward"),
-            done_key=("next", "agents", "done"),
+            reward_key=("next", "agent", "reward"),
+            done_key=("next", "agent", "done"),
         )
         expected = torch.zeros_like(reward)
         expected[:, 0] = 1.0
         torch.testing.assert_close(masked, expected)
-
-    @pytest.mark.parametrize("planner_name", ["cem", "mppi"])
-    def test_planner_prefers_surviving_actions(self, device, planner_name, seed=0):
-        torch.manual_seed(seed)
-        env = _SurviveIfPositiveEnv(device=device)
-        if planner_name == "cem":
-            planner = CEMPlanner(
-                env,
-                planning_horizon=4,
-                optim_steps=3,
-                num_candidates=64,
-                top_k=8,
-                reward_key=("next", "reward"),
-            )
-        else:
-            planner = MPPIPlanner(
-                env,
-                _SumRewardAdvantage(),
-                temperature=1.0,
-                planning_horizon=4,
-                optim_steps=3,
-                num_candidates=64,
-                top_k=8,
-                reward_key=("next", "reward"),
-            )
-        td = env.reset(TensorDict(batch_size=()).to(device))
-        out = planner(td)
-        # Surviving (non-negative) first actions score 4; dying at step 0 scores 1.
-        assert out.get("action").item() > 0
 
     @pytest.mark.parametrize("planner_name", ["cem", "mppi"])
     @pytest.mark.parametrize("terminate_on_done", [True, False])
@@ -552,49 +371,15 @@ class TestPlannerDoneMask:
         self, device, planner_name, terminate_on_done
     ):
         env = _TwoSequenceEnv(device=device, terminate_on_done=terminate_on_done)
-        die_seq = _die_then_jackpot_sequence(device)
-        live_seq = _steady_live_sequence(device)
+        _assert_planner_picks_live_sequence(env, planner_name, device)
 
-        die_rollout = _rollout_action_sequence(env, die_seq)
-        live_rollout = _rollout_action_sequence(env, live_seq)
-        die_done = die_rollout.get(("next", "done"))
-        die_terminated = die_rollout.get(("next", "terminated"))
-        assert die_done[0].all()
-        assert not live_rollout.get(("next", "done")).any()
-        if terminate_on_done:
-            torch.testing.assert_close(die_terminated, die_done)
-        else:
-            assert not die_terminated.any()
-
-        die_masked, die_unmasked = _sum_until_first_done(die_rollout)
-        live_masked, live_unmasked = _sum_until_first_done(live_rollout)
-        torch.testing.assert_close(
-            die_masked, die_masked.new_tensor(DIE_REWARD)
-        )
-        torch.testing.assert_close(
-            die_unmasked,
-            die_unmasked.new_tensor(DIE_REWARD + 2 * JACKPOT_REWARD),
-        )
-        torch.testing.assert_close(
-            live_masked, live_masked.new_tensor(TWO_SEQ_HORIZON * LIVE_REWARD)
-        )
-        torch.testing.assert_close(live_unmasked, live_masked)
-        assert live_masked > die_masked
-        assert die_unmasked > live_unmasked
-
-        planner = _make_planner(
-            planner_name,
-            env,
-            planning_horizon=TWO_SEQ_HORIZON,
-            num_candidates=4,
-            top_k=2,
-        )
-        td = env.reset(TensorDict(batch_size=(), device=device))
-        with _fixed_planner_candidates(
-            planner_name, die_seq, live_seq, die_seq, live_seq
-        ):
-            out = planner(td)
-        torch.testing.assert_close(out.get("action"), live_seq[0])
+    @pytest.mark.parametrize("planner_name", ["cem", "mppi"])
+    def test_planner_nested_done_keys(self, device, planner_name):
+        env = _TwoSequenceEnv(device=device, done_group="agent")
+        assert "done" not in env.done_keys
+        assert ("agent", "done") in env.done_keys
+        assert ("agent", "terminated") in env.done_keys
+        _assert_planner_picks_live_sequence(env, planner_name, device)
 
 
 if __name__ == "__main__":

--- a/test/modules/test_planners.py
+++ b/test/modules/test_planners.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -23,6 +25,10 @@ from torchrl.testing.mocking_classes import MockBatchedUnLockedEnv
 FIRST_REWARD = 1.25
 LATER_REWARD = 50.0
 PLANNING_HORIZON = 4
+DIE_REWARD = 1.0
+LIVE_REWARD = 5.0
+JACKPOT_REWARD = 50.0
+TWO_SEQ_HORIZON = 3
 
 
 class _DoneAfterOneStepEnv(EnvBase):
@@ -154,6 +160,150 @@ class _SurviveIfPositiveEnv(EnvBase):
         pass
 
 
+class _TwoSequenceEnv(EnvBase):
+    """Reward equals the action when it is non-negative; a negative action dies.
+
+    Dying pays ``DIE_REWARD`` and sets ``done``. After a non-breaking rollout
+    auto-reset, later non-negative actions still pay their face value, so a
+    die-then-jackpot sequence can beat a steady live sequence on the unmasked
+    sum while losing once rewards after the first ``("next", "done")`` are
+    dropped. ``terminated`` follows ``done`` only when ``terminate_on_done``.
+    """
+
+    @classmethod
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls, *args, _batch_locked=False, **kwargs)
+
+    def __init__(self, device="cpu", *, terminate_on_done: bool = True):
+        super().__init__(device=device)
+        self.observation_spec = Composite(
+            observation=Unbounded((1,), device=device),
+            device=device,
+        )
+        self.action_spec = Unbounded((1,), device=device)
+        self.reward_spec = Unbounded((1,), device=device)
+        self.terminate_on_done = terminate_on_done
+
+    def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
+        if tensordict is None:
+            batch_size = self.batch_size
+            device = self.device
+        else:
+            batch_size = tensordict.batch_size
+            device = tensordict.device if tensordict.device is not None else self.device
+        done = torch.zeros(*batch_size, 1, dtype=torch.bool, device=device)
+        return TensorDict(
+            {
+                "observation": torch.zeros(
+                    *batch_size, 1, device=device, dtype=torch.get_default_dtype()
+                ),
+                "done": done,
+                "terminated": done.clone(),
+            },
+            batch_size=batch_size,
+            device=device,
+        )
+
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        action = tensordict.get("action")
+        device = action.device
+        die = action[..., :1] < 0
+        reward = torch.where(
+            die,
+            torch.full_like(action[..., :1], DIE_REWARD),
+            action[..., :1],
+        )
+        terminated = die if self.terminate_on_done else torch.zeros_like(die)
+        return TensorDict(
+            {
+                "observation": tensordict.get("observation") + 1,
+                "reward": reward,
+                "done": die,
+                "terminated": terminated,
+            },
+            batch_size=tensordict.batch_size,
+            device=device,
+        )
+
+    def _set_seed(self, seed: int | None) -> None:
+        pass
+
+
+def _die_then_jackpot_sequence(device) -> torch.Tensor:
+    return torch.tensor(
+        [[-1.0], [JACKPOT_REWARD], [JACKPOT_REWARD]],
+        device=device,
+        dtype=torch.get_default_dtype(),
+    )
+
+
+def _steady_live_sequence(device) -> torch.Tensor:
+    return torch.full(
+        (TWO_SEQ_HORIZON, 1),
+        LIVE_REWARD,
+        device=device,
+        dtype=torch.get_default_dtype(),
+    )
+
+
+def _rollout_action_sequence(env, actions):
+    t = 0
+
+    def policy(tensordict):
+        nonlocal t
+        tensordict.set(
+            "action",
+            actions[t].expand(*tensordict.batch_size, *actions.shape[1:]),
+        )
+        t += 1
+        return tensordict
+
+    td = env.reset(TensorDict(batch_size=(), device=actions.device))
+    return env.rollout(
+        max_steps=actions.shape[0],
+        policy=policy,
+        auto_reset=False,
+        tensordict=td,
+        break_when_any_done=False,
+    )
+
+
+def _sum_until_first_done(rollout):
+    """Sum rewards through the first ``("next", "done")``; unmasked total."""
+    reward = rollout.get(("next", "reward")).reshape(rollout.shape[-1])
+    done = rollout.get(("next", "done")).reshape(rollout.shape[-1])
+    unmasked = reward.sum()
+    hits = done.nonzero(as_tuple=False)
+    if hits.numel():
+        return reward[: int(hits[0, 0]) + 1].sum(), unmasked
+    return unmasked, unmasked
+
+
+@contextmanager
+def _fixed_planner_candidates(planner_name, *sequences):
+    """Make CEM/MPPI's first (and only) sample the given action sequences."""
+    stacked = torch.stack(sequences, dim=0)
+
+    def fake_randn(*size, device=None, dtype=None, **kwargs):
+        if len(size) == 1 and not isinstance(size[0], int):
+            shape = tuple(size[0])
+        else:
+            shape = tuple(size)
+        actions = stacked.to(device=device, dtype=dtype)
+        if shape[-stacked.ndim :] != tuple(actions.shape):
+            raise ValueError(
+                f"planner randn shape {shape} does not end with {tuple(actions.shape)}"
+            )
+        return actions.expand(shape).clone()
+
+    module = {
+        "cem": "torchrl.modules.planners.cem",
+        "mppi": "torchrl.modules.planners.mppi",
+    }[planner_name]
+    with patch(f"{module}.torch.randn", fake_randn):
+        yield
+
+
 class _SumRewardAdvantage(nn.Module):
     """Advantage equal to the trajectory return, written at every time step."""
 
@@ -164,14 +314,21 @@ class _SumRewardAdvantage(nn.Module):
         return tensordict
 
 
-def _make_planner(name, env, *, planning_horizon=PLANNING_HORIZON):
+def _make_planner(
+    name,
+    env,
+    *,
+    planning_horizon=PLANNING_HORIZON,
+    num_candidates=8,
+    top_k=2,
+):
     if name == "cem":
         return CEMPlanner(
             env,
             planning_horizon=planning_horizon,
             optim_steps=1,
-            num_candidates=8,
-            top_k=2,
+            num_candidates=num_candidates,
+            top_k=top_k,
             reward_key=("next", "reward"),
         )
     return MPPIPlanner(
@@ -180,8 +337,8 @@ def _make_planner(name, env, *, planning_horizon=PLANNING_HORIZON):
         temperature=1.0,
         planning_horizon=planning_horizon,
         optim_steps=1,
-        num_candidates=8,
-        top_k=2,
+        num_candidates=num_candidates,
+        top_k=top_k,
         reward_key=("next", "reward"),
     )
 
@@ -388,6 +545,56 @@ class TestPlannerDoneMask:
         out = planner(td)
         # Surviving (non-negative) first actions score 4; dying at step 0 scores 1.
         assert out.get("action").item() > 0
+
+    @pytest.mark.parametrize("planner_name", ["cem", "mppi"])
+    @pytest.mark.parametrize("terminate_on_done", [True, False])
+    def test_planner_picks_higher_masked_sequence(
+        self, device, planner_name, terminate_on_done
+    ):
+        env = _TwoSequenceEnv(device=device, terminate_on_done=terminate_on_done)
+        die_seq = _die_then_jackpot_sequence(device)
+        live_seq = _steady_live_sequence(device)
+
+        die_rollout = _rollout_action_sequence(env, die_seq)
+        live_rollout = _rollout_action_sequence(env, live_seq)
+        die_done = die_rollout.get(("next", "done"))
+        die_terminated = die_rollout.get(("next", "terminated"))
+        assert die_done[0].all()
+        assert not live_rollout.get(("next", "done")).any()
+        if terminate_on_done:
+            torch.testing.assert_close(die_terminated, die_done)
+        else:
+            assert not die_terminated.any()
+
+        die_masked, die_unmasked = _sum_until_first_done(die_rollout)
+        live_masked, live_unmasked = _sum_until_first_done(live_rollout)
+        torch.testing.assert_close(
+            die_masked, die_masked.new_tensor(DIE_REWARD)
+        )
+        torch.testing.assert_close(
+            die_unmasked,
+            die_unmasked.new_tensor(DIE_REWARD + 2 * JACKPOT_REWARD),
+        )
+        torch.testing.assert_close(
+            live_masked, live_masked.new_tensor(TWO_SEQ_HORIZON * LIVE_REWARD)
+        )
+        torch.testing.assert_close(live_unmasked, live_masked)
+        assert live_masked > die_masked
+        assert die_unmasked > live_unmasked
+
+        planner = _make_planner(
+            planner_name,
+            env,
+            planning_horizon=TWO_SEQ_HORIZON,
+            num_candidates=4,
+            top_k=2,
+        )
+        td = env.reset(TensorDict(batch_size=(), device=device))
+        with _fixed_planner_candidates(
+            planner_name, die_seq, live_seq, die_seq, live_seq
+        ):
+            out = planner(td)
+        torch.testing.assert_close(out.get("action"), live_seq[0])
 
 
 if __name__ == "__main__":

--- a/torchrl/modules/planners/cem.py
+++ b/torchrl/modules/planners/cem.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING
 
 import torch
 from tensordict import NestedKey, TensorDict, TensorDictBase
-from torchrl.modules.planners.common import _mask_post_done_reward, MPCPlannerBase
+from torchrl.modules.planners.common import (
+    _mask_post_done_reward,
+    _planning_done_keys,
+    MPCPlannerBase,
+)
 
 if TYPE_CHECKING:
     from torchrl.envs.common import EnvBase
@@ -25,8 +29,8 @@ class CEMPlanner(MPCPlannerBase):
     distribution with zero mean and unit variance.
     The sampled actions are then used to perform a rollout in the environment.
     Rollouts always run for the full planning horizon. Rewards after the
-    first :obj:`("next", "done")` are ignored, and the remaining return is
-    ranked. We select the top-k episodes and use their actions to update the
+    first environment ``done`` (termination or truncation) are ignored, and
+    the remaining return is ranked. We select the top-k episodes and use their actions to update the
     mean and standard deviation of the actions distribution.
     The CEM planning step is repeated for a specified number of steps.
 
@@ -204,6 +208,7 @@ class CEMPlanner(MPCPlannerBase):
             sum_rewards = _mask_post_done_reward(
                 optim_tensordict,
                 reward_key=self.reward_key,
+                done_key=_planning_done_keys(self.env),
                 time_dim=TIME_DIM,
             ).sum(dim=TIME_DIM, keepdim=True)
             _, top_k = sum_rewards.topk(self.top_k, dim=K_DIM)

--- a/torchrl/modules/planners/cem.py
+++ b/torchrl/modules/planners/cem.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from tensordict import TensorDict, TensorDictBase
-from torchrl.modules.planners.common import MPCPlannerBase
+from tensordict import NestedKey, TensorDict, TensorDictBase
+from torchrl.modules.planners.common import _mask_post_done_reward, MPCPlannerBase
 
 if TYPE_CHECKING:
     from torchrl.envs.common import EnvBase
@@ -24,7 +24,8 @@ class CEMPlanner(MPCPlannerBase):
     The CEM planning step is performed by sampling actions from a Gaussian
     distribution with zero mean and unit variance.
     The sampled actions are then used to perform a rollout in the environment.
-    The cumulative rewards obtained with the rollout is then
+    Rollouts always run for the full planning horizon. Rewards after the
+    first :obj:`("next", "done")` are ignored, and the remaining return is
     ranked. We select the top-k episodes and use their actions to update the
     mean and standard deviation of the actions distribution.
     The CEM planning step is repeated for a specified number of steps.
@@ -42,10 +43,10 @@ class CEMPlanner(MPCPlannerBase):
             Gaussian distributions.
         top_k (int): The number of top candidates to use to
             update the mean and standard deviation of the Gaussian distribution.
-        reward_key (str, optional): The key in the TensorDict to use to
-            retrieve the reward. Defaults to "reward".
-        action_key (str, optional): The key in the TensorDict to use to store
-            the action. Defaults to "action"
+        reward_key (NestedKey, optional): The key in the TensorDict to use to
+            retrieve the reward. Defaults to ``("next", "reward")``.
+        action_key (NestedKey, optional): The key in the TensorDict to use to store
+            the action. Defaults to ``"action"``.
 
     Examples:
         >>> from tensordict import TensorDict
@@ -123,8 +124,8 @@ class CEMPlanner(MPCPlannerBase):
         optim_steps: int,
         num_candidates: int,
         top_k: int,
-        reward_key: str = ("next", "reward"),
-        action_key: str = "action",
+        reward_key: NestedKey = ("next", "reward"),
+        action_key: NestedKey = "action",
     ):
         super().__init__(env=env, action_key=action_key)
         self.planning_horizon = planning_horizon
@@ -191,16 +192,20 @@ class CEMPlanner(MPCPlannerBase):
             actions = self.env.action_spec.project(actions)
             optim_tensordict = container.get("tensordict").clone()
             policy = _PrecomputedActionsSequentialSetter(actions)
+            # Full horizon for every candidate; post-done rewards are masked below.
             optim_tensordict = self.env.rollout(
                 max_steps=self.planning_horizon,
                 policy=policy,
                 auto_reset=False,
                 tensordict=optim_tensordict,
+                break_when_any_done=False,
             )
 
-            sum_rewards = optim_tensordict.get(self.reward_key).sum(
-                dim=TIME_DIM, keepdim=True
-            )
+            sum_rewards = _mask_post_done_reward(
+                optim_tensordict,
+                reward_key=self.reward_key,
+                time_dim=TIME_DIM,
+            ).sum(dim=TIME_DIM, keepdim=True)
             _, top_k = sum_rewards.topk(self.top_k, dim=K_DIM)
             top_k = top_k.expand(action_topk_shape)
             best_actions = actions.gather(K_DIM, top_k)

--- a/torchrl/modules/planners/common.py
+++ b/torchrl/modules/planners/common.py
@@ -5,21 +5,48 @@
 from __future__ import annotations
 
 import abc
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import torch
-from tensordict import NestedKey, TensorDictBase
+from tensordict import NestedKey, TensorDictBase, unravel_key
 
+from torchrl._utils import _ends_with
 from torchrl.modules import SafeModule
 
 if TYPE_CHECKING:
     from torchrl.envs.common import EnvBase
 
 
+def _planning_done_keys(env: EnvBase) -> list[NestedKey]:
+    """Return rollout ``done`` keys used to mask post-done planning rewards.
+
+    Only keys that end with ``"done"`` are used, so a truncated episode
+    (``done`` and not ``terminated``) still stops contributing. Keys are
+    taken from the environment and prefixed with ``"next"``; a root
+    ``"done"`` is not invented when the env only exposes a nested group.
+    """
+    return [
+        unravel_key(("next", key))
+        for key in env.done_keys
+        if _ends_with(key, "done")
+    ]
+
+
+def _normalize_done_keys(
+    done_key: NestedKey | Sequence[NestedKey],
+) -> tuple[NestedKey, ...]:
+    if isinstance(done_key, str):
+        return (done_key,)
+    if isinstance(done_key, tuple) and (not done_key or isinstance(done_key[0], str)):
+        return (unravel_key(done_key),)
+    return tuple(unravel_key(key) for key in done_key)
+
+
 def _mask_post_done_reward(
     tensordict: TensorDictBase,
     reward_key: NestedKey = ("next", "reward"),
-    done_key: NestedKey = ("next", "done"),
+    done_key: NestedKey | Sequence[NestedKey] = ("next", "done"),
     *,
     time_dim: int | None = None,
 ) -> torch.Tensor:
@@ -27,18 +54,25 @@ def _mask_post_done_reward(
 
     The reward at the first ``done`` step is kept. ``done`` is used (not
     ``terminated``) so a truncated episode also stops contributing to the
-    planning score.
+    planning score. Several ``done`` keys are combined with a logical or.
     """
     reward = tensordict.get(reward_key)
-    done = tensordict.get(done_key)
+    done = None
+    for key in _normalize_done_keys(done_key):
+        flag = tensordict.get(key)
+        if flag is None:
+            raise KeyError(f"Done key {key!r} not found in tensordict.")
+        if flag.shape != reward.shape:
+            flag = flag.expand_as(reward)
+        done = flag if done is None else torch.logical_or(done, flag)
+    if done is None:
+        return reward
     if time_dim is None:
         names = tensordict.names
         if names is not None and "time" in names:
             time_dim = names.index("time")
         else:
             time_dim = -2
-    if done.shape != reward.shape:
-        done = done.expand_as(reward)
     done_int = done.to(dtype=torch.int64)
     already_done = done_int.cumsum(dim=time_dim) > done_int
     return torch.where(already_done, torch.zeros_like(reward), reward)
@@ -51,7 +85,8 @@ class MPCPlannerBase(SafeModule, metaclass=abc.ABCMeta):
     At the end of the planning step, the :obj:`MPCPlanner` will return a proposed action.
 
     Imagined rollouts keep a full planning horizon even after a candidate
-    hits ``done``. Rewards after the first :obj:`("next", "done")` are ignored
+    hits ``done``. Rewards after the first environment ``done`` flag
+    (termination or truncation, including nested done keys) are ignored
     when scoring those trajectories.
 
     Args:

--- a/torchrl/modules/planners/common.py
+++ b/torchrl/modules/planners/common.py
@@ -8,12 +8,40 @@ import abc
 from typing import TYPE_CHECKING
 
 import torch
-from tensordict import TensorDictBase
+from tensordict import NestedKey, TensorDictBase
 
 from torchrl.modules import SafeModule
 
 if TYPE_CHECKING:
     from torchrl.envs.common import EnvBase
+
+
+def _mask_post_done_reward(
+    tensordict: TensorDictBase,
+    reward_key: NestedKey = ("next", "reward"),
+    done_key: NestedKey = ("next", "done"),
+    *,
+    time_dim: int | None = None,
+) -> torch.Tensor:
+    """Zero rewards that follow the first ``done`` along the time dimension.
+
+    The reward at the first ``done`` step is kept. ``done`` is used (not
+    ``terminated``) so a truncated episode also stops contributing to the
+    planning score.
+    """
+    reward = tensordict.get(reward_key)
+    done = tensordict.get(done_key)
+    if time_dim is None:
+        names = tensordict.names
+        if names is not None and "time" in names:
+            time_dim = names.index("time")
+        else:
+            time_dim = -2
+    if done.shape != reward.shape:
+        done = done.expand_as(reward)
+    done_int = done.to(dtype=torch.int64)
+    already_done = done_int.cumsum(dim=time_dim) > done_int
+    return torch.where(already_done, torch.zeros_like(reward), reward)
 
 
 class MPCPlannerBase(SafeModule, metaclass=abc.ABCMeta):
@@ -22,15 +50,19 @@ class MPCPlannerBase(SafeModule, metaclass=abc.ABCMeta):
     This class inherits from :obj:`SafeModule`. Provided a :obj:`TensorDict`, this module will perform a Model Predictive Control (MPC) planning step.
     At the end of the planning step, the :obj:`MPCPlanner` will return a proposed action.
 
+    Imagined rollouts keep a full planning horizon even after a candidate
+    hits ``done``. Rewards after the first :obj:`("next", "done")` are ignored
+    when scoring those trajectories.
+
     Args:
         env (EnvBase): The environment to perform the planning step on (Can be :obj:`ModelBasedEnvBase` or :obj:`EnvBase`).
-        action_key (str, optional): The key that will point to the computed action.
+        action_key (NestedKey, optional): The key that will point to the computed action.
     """
 
     def __init__(
         self,
         env: EnvBase,
-        action_key: str = "action",
+        action_key: NestedKey = "action",
     ):
         # Check if env is stateless
         if env.batch_locked:

--- a/torchrl/modules/planners/mppi.py
+++ b/torchrl/modules/planners/mppi.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from tensordict import TensorDict, TensorDictBase
+from tensordict import NestedKey, TensorDict, TensorDictBase
 from torch import nn
 
-from torchrl.modules.planners.common import MPCPlannerBase
+from torchrl.modules.planners.common import _mask_post_done_reward, MPCPlannerBase
 
 if TYPE_CHECKING:
     from torchrl.envs.common import EnvBase
@@ -28,6 +28,9 @@ class MPPIPlanner(MPCPlannerBase):
 
     This module will perform a MPPI planning step when given a TensorDict
     containing initial states.
+    Imagined rollouts always run for the full planning horizon. Rewards after
+    the first :obj:`("next", "done")` are zeroed before the advantage is
+    computed.
 
     A call to the module returns the actions that empirically maximised the
     returns given a planning horizon
@@ -42,10 +45,10 @@ class MPPIPlanner(MPCPlannerBase):
             Gaussian distributions.
         top_k (int): The number of top candidates to use to
             update the mean and standard deviation of the Gaussian distribution.
-        reward_key (str, optional): The key in the TensorDict to use to
-            retrieve the reward. Defaults to "reward".
-        action_key (str, optional): The key in the TensorDict to use to store
-            the action. Defaults to "action"
+        reward_key (NestedKey, optional): The key in the TensorDict to use to
+            retrieve the reward. Defaults to ``("next", "reward")``.
+        action_key (NestedKey, optional): The key in the TensorDict to use to store
+            the action. Defaults to ``"action"``.
 
     Examples:
         >>> from tensordict import TensorDict
@@ -141,8 +144,8 @@ class MPPIPlanner(MPCPlannerBase):
         optim_steps: int,
         num_candidates: int,
         top_k: int,
-        reward_key: str = ("next", "reward"),
-        action_key: str = "action",
+        reward_key: NestedKey = ("next", "reward"),
+        action_key: NestedKey = "action",
     ):
         super().__init__(env=env, action_key=action_key)
         self.advantage_module = advantage_module
@@ -216,11 +219,20 @@ class MPPIPlanner(MPCPlannerBase):
             actions = self.env.action_spec.project(actions)
             optim_tensordict = container.get("tensordict").clone()
             policy = _PrecomputedActionsSequentialSetter(actions)
+            # Full horizon for every candidate; post-done rewards are masked below.
             optim_tensordict = self.env.rollout(
                 max_steps=self.planning_horizon,
                 policy=policy,
                 auto_reset=False,
                 tensordict=optim_tensordict,
+                break_when_any_done=False,
+            )
+            optim_tensordict.set(
+                self.reward_key,
+                _mask_post_done_reward(
+                    optim_tensordict,
+                    reward_key=self.reward_key,
+                ),
             )
             # compute advantage
             self.advantage_module(optim_tensordict)

--- a/torchrl/modules/planners/mppi.py
+++ b/torchrl/modules/planners/mppi.py
@@ -10,7 +10,11 @@ import torch
 from tensordict import NestedKey, TensorDict, TensorDictBase
 from torch import nn
 
-from torchrl.modules.planners.common import _mask_post_done_reward, MPCPlannerBase
+from torchrl.modules.planners.common import (
+    _mask_post_done_reward,
+    _planning_done_keys,
+    MPCPlannerBase,
+)
 
 if TYPE_CHECKING:
     from torchrl.envs.common import EnvBase
@@ -29,8 +33,8 @@ class MPPIPlanner(MPCPlannerBase):
     This module will perform a MPPI planning step when given a TensorDict
     containing initial states.
     Imagined rollouts always run for the full planning horizon. Rewards after
-    the first :obj:`("next", "done")` are zeroed before the advantage is
-    computed.
+    the first environment ``done`` (termination or truncation) are zeroed
+    before the advantage is computed.
 
     A call to the module returns the actions that empirically maximised the
     returns given a planning horizon
@@ -232,6 +236,7 @@ class MPPIPlanner(MPCPlannerBase):
                 _mask_post_done_reward(
                     optim_tensordict,
                     reward_key=self.reward_key,
+                    done_key=_planning_done_keys(self.env),
                 ),
             )
             # compute advantage


### PR DESCRIPTION
## Description

CEM summed the whole imagined horizon. MPPI rolled out the same way. After `done`, later rewards (including auto-reset) leaked into the plan score.

Both planners now roll out with `break_when_any_done=False` and zero rewards after the first effective environment `done`, keeping the reward at that step. Done keys come from the environment: an ancestor done group takes precedence over its descendants at every nesting level, while independent sibling groups are combined with a logical OR. Scoring uses `done`, not `terminated`, so truncation also stops subsequent rewards from contributing.

### Code example

Minimal scoring regression using the internal helper shared by CEM and MPPI: keep the terminal reward, then ignore the remaining imagined rewards.

```python
import torch
from tensordict import TensorDict
from torchrl.modules.planners.common import _mask_post_done_reward

rollout = TensorDict(
    {"next": {
        "reward": torch.tensor([[1.0], [2.0], [1000.0]]),
        "done": torch.tensor([[False], [True], [False]]),
    }},
    batch_size=[3], names=["time"],
)
# Previously, summing the full imagined horizon gave 1003.
assert rollout["next", "reward"].sum() == 1003
scored_rewards = _mask_post_done_reward(rollout)
torch.testing.assert_close(scored_rewards, torch.tensor([[1.0], [2.0], [0.0]]))
assert scored_rewards.sum() == 3
```

## Motivation and Context

close #1660

- [x] I have raised an issue to propose this change ([required](https://github.com/pytorch/rl/issues) for new features and bug fixes)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/pytorch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.