### PR TITLE
[Feature] MicroDuck tasks keep the head level, and a turning task

### DIFF
--- a/examples/microduck/README.md
+++ b/examples/microduck/README.md
@@ -25,7 +25,7 @@ observation, action, reward and termination definitions. A task is data:
 in body-frame m/s, the warm start and joint reset noise, the gait clock
 frequency, one weight per reward term, the term parameters, a sampling
 `weight` and a `name`. The presets `MicroDuckEnv.tracking_task(speed)`, `standing_task()`,
-`speed_range_task(low, high)`, `sidestep_task(speed)` and `jump_task()` fill
+`speed_range_task(low, high)`, `sidestep_task(speed)`, `turning_task(rate)` and `jump_task()` fill
 every field and take overrides by name (`reward_weights={"tracking": 4.0}`,
 `tracking_std=0.2`, `warm_start_fraction=0.5`). The env takes a library, one
 task, a list or a `torch.stack` of tasks, and every env of the batch holds one

--- a/examples/microduck/ppo_mujoco.py
+++ b/examples/microduck/ppo_mujoco.py
@@ -107,6 +107,7 @@ TASK_PRESETS = (
     "standing_task",
     "speed_range_task",
     "sidestep_task",
+    "turning_task",
     "jump_task",
 )
 # The asset location is machine specific and is never taken from a checkpoint.

--- a/test/libs/test_mujoco.py
+++ b/test/libs/test_mujoco.py
@@ -156,6 +156,8 @@ class TestMujoco:
             '  <worldbody><geom type="plane" size="1 1 0.1" contype="1" conaffinity="1"/>',
             '    <body name="torso" pos="0 0 0.12"><freejoint name="root"/>',
             '      <geom type="sphere" size="0.02" mass="0.1"/>',
+            '      <site name="head_imu" pos="0 0 0.02"/>',
+            '      <site name="mouth_tip" pos="0.03 0 0.02"/>',
         ]
         for side, y in (("left", 0.03), ("right", -0.03)):
             lines.extend(
@@ -889,6 +891,76 @@ class TestMujoco:
         assert torch.equal(first_sample, second_sample)
 
     @pytest.mark.skipif(not _has_mujoco, reason="MuJoCo is not installed")
+    def test_microduck_head_level_and_turn_terms(self, tmp_path):
+        scene = self._write_microduck_fixture(tmp_path)
+        env = MicroDuckEnv(
+            scene,
+            backend="mujoco",
+            tasks=[
+                MicroDuckEnv.standing_task(),
+                MicroDuckEnv.turning_task(1.0),
+                MicroDuckEnv.turning_task(-1.0),
+            ],
+            seed=0,
+            diagnostics=True,
+        )
+        action = torch.zeros_like(env.action_spec.rand())
+        env.reset(TensorDict({"task_id": torch.tensor([[0]])}, batch_size=(1,)))
+        level = env.get_state()
+        # Pitch the whole robot 45 degrees nose down: the fixture's gaze runs
+        # along +x, so it drops below the horizon and head_level pays less.
+        nose_down = level.clone()
+        nose_down["qpos"][..., 3:7] = torch.tensor(
+            [math.cos(math.pi / 8), 0.0, math.sin(math.pi / 8), 0.0]
+        )
+        head_level = "diagnostic_reward_head_level"
+        env.reset(
+            TensorDict(qpos=level["qpos"], qvel=level["qvel"], batch_size=[1]),
+            set_state=True,
+        )
+        torch.testing.assert_close(env.head_pitch(), torch.zeros(1), atol=1e-4, rtol=0)
+        paid_level = env._reward_components(level, action)[head_level]
+        env.reset(
+            TensorDict(qpos=nose_down["qpos"], qvel=nose_down["qvel"], batch_size=[1]),
+            set_state=True,
+        )
+        torch.testing.assert_close(
+            env.head_pitch(), torch.full((1,), -math.pi / 4), atol=1e-3, rtol=0
+        )
+        assert (
+            env._reward_components(nose_down, action)[head_level] < paid_level
+        ).all()
+        # Every preset keeps the head level by default.
+        assert (
+            MicroDuckEnv.standing_task().reward_weights[
+                list(MicroDuckEnv.REWARD_TERMS).index("head_level")
+            ]
+            == 1.0
+        )
+
+        # The turning task tracks its yaw rate in place of the yaw_rate cost.
+        turn = "diagnostic_reward_turn"
+        left = MicroDuckEnv.turning_task(1.0)
+        assert left.params["turn_rate"] == 1.0
+        assert (
+            left.reward_weights[list(MicroDuckEnv.REWARD_TERMS).index("yaw_rate")]
+            == 0.0
+        )
+        env.reset(TensorDict({"task_id": torch.tensor([[1]])}, batch_size=(1,)))
+        spinning_left, spinning_right = level.clone(), level.clone()
+        spinning_left["qvel"][..., 5] = 1.0
+        spinning_right["qvel"][..., 5] = -1.0
+        components = env._reward_components(spinning_left, action)
+        assert (
+            components[turn] > env._reward_components(spinning_right, action)[turn]
+        ).all()
+        env.reset(TensorDict({"task_id": torch.tensor([[2]])}, batch_size=(1,)))
+        assert (
+            env._reward_components(spinning_right, action)[turn]
+            > env._reward_components(spinning_left, action)[turn]
+        ).all()
+        env.close()
+
     def test_microduck_register_reward_adds_a_weighted_term(
         self, tmp_path, monkeypatch
     ):

--- a/torchrl/envs/custom/mujoco/microduck.py
+++ b/torchrl/envs/custom/mujoco/microduck.py
@@ -328,7 +328,8 @@ class MicroDuckTask:
     with the presets
     (:meth:`MicroDuckEnv.tracking_task`, :meth:`MicroDuckEnv.standing_task`,
     :meth:`MicroDuckEnv.speed_range_task`, :meth:`MicroDuckEnv.sidestep_task`,
-    :meth:`MicroDuckEnv.jump_task`), which fill every field and accept
+    :meth:`MicroDuckEnv.turning_task`, :meth:`MicroDuckEnv.jump_task`), which
+    fill every field and accept
     overrides, and stack them with :func:`torch.stack` or by handing a
     sequence to the env. Stacking is the structural validation: every task
     must carry the full reward weight vector and every parameter key.
@@ -622,6 +623,8 @@ class MicroDuckEnv(MujocoEnv, metaclass=_MicroDuckMeta):
         "right_foot_collision",
     )
     FOOT_SITES: ClassVar[tuple[str, str]] = ("left_foot", "right_foot")
+    HEAD_SITES: ClassVar[tuple[str, str]] = ("head_imu", "mouth_tip")
+    """Sites at the back of the head and at the beak tip; their difference is the gaze."""
     BODY_VELOCITY_START: ClassVar[int] = 6
     """Index of the body-frame linear velocity ``(vx, vy, vz)`` in the observation."""
     COMMAND_START: ClassVar[int] = 9
@@ -643,6 +646,7 @@ class MicroDuckEnv(MujocoEnv, metaclass=_MicroDuckMeta):
     HOP_RHYTHM_WEIGHT: ClassVar[float] = 1.0
     HOP_FREQUENCY_HZ: ClassVar[float] = 2.0
     DRIFT_WEIGHT: ClassVar[float] = -5.0
+    TURN_WEIGHT: ClassVar[float] = 2.0
     GAIT_TERMS: ClassVar[tuple[str, ...]] = (
         "air_time",
         "swing_height",
@@ -873,7 +877,8 @@ class MicroDuckEnv(MujocoEnv, metaclass=_MicroDuckMeta):
         ``angular_velocity`` (3), ``upright`` (cosine of the tilt), ``base_height``,
         ``standing_height``, ``joint_error`` (14), ``joint_velocity`` (14),
         ``action`` (14), ``previous_action`` (14), ``contacts`` (bool, 2),
-        ``foot_heights`` (2), ``touchdown_air_time`` (2), ``gait_phase``
+        ``foot_heights`` (2), ``head_pitch`` (gaze pitch above the horizontal,
+        radians), ``touchdown_air_time`` (2), ``gait_phase``
         (radians), ``command`` (2) and ``fallen`` (bool). ``params`` is the
         per-env TensorDict of task parameters, each of shape ``(num_envs,)``.
 
@@ -1104,6 +1109,32 @@ class MicroDuckEnv(MujocoEnv, metaclass=_MicroDuckMeta):
         )
 
     @classmethod
+    def turning_task(
+        cls, rate: float = 1.0, *, weight: float = 1.0, **overrides: Any
+    ) -> MicroDuckTask:
+        """Turn in place at ``rate`` rad/s, to the left (positive) or the right.
+
+        The command is zero, so the task is told apart from standing by its
+        row alone; the ``turn`` term tracks the yaw rate and replaces the
+        ``yaw_rate`` cost, and the gait terms stay on so the robot steps
+        around instead of twisting on planted feet.
+        """
+        reward_weights = {"turn": cls.TURN_WEIGHT, "yaw_rate": 0.0}
+        reward_weights.update(overrides.pop("reward_weights", None) or {})
+        return cls.make_task(
+            (0.0, 0.0),
+            (0.0, 0.0),
+            weight=weight,
+            reward_weights=reward_weights,
+            **{
+                "name": f"turn{float(rate):+.2f}",
+                "turn_rate": float(rate),
+                "pose_std": cls.POSE_STD_MOVING,
+                **overrides,
+            },
+        )
+
+    @classmethod
     def jump_task(cls, *, weight: float = 1.0, **overrides: Any) -> MicroDuckTask:
         """Hop in place under a zero command.
 
@@ -1281,6 +1312,16 @@ class MicroDuckEnv(MujocoEnv, metaclass=_MicroDuckMeta):
     def foot_heights(self) -> torch.Tensor:
         """Return a ``(num_envs, 2)`` tensor with the left/right foot site heights."""
         return self.site_positions(self.FOOT_SITES)[..., 2]
+
+    def head_pitch(self) -> torch.Tensor:
+        """Return the ``(num_envs,)`` pitch of the gaze above the horizontal, in radians.
+
+        The gaze runs from the :attr:`HEAD_SITES` at the back of the head to the
+        beak tip, so it follows the trunk and the neck and head joints together.
+        """
+        back, tip = self.site_positions(self.HEAD_SITES).unbind(-2)
+        gaze = tip - back
+        return torch.atan2(gaze[..., 2], gaze[..., :2].norm(dim=-1))
 
     # ------------------------------------------------------------------
     # Specs and observations
@@ -1574,6 +1615,7 @@ class MicroDuckEnv(MujocoEnv, metaclass=_MicroDuckMeta):
                 "previous_action": self._previous_action,
                 "contacts": self._contacts,
                 "foot_heights": self._foot_heights,
+                "head_pitch": self.head_pitch().to(self.dtype),
                 "touchdown_air_time": self._touchdown_air_time,
                 "gait_phase": phase,
                 "command": self._command,
@@ -1810,6 +1852,22 @@ def _yaw_rate(features: TensorDictBase, params: TensorDictBase) -> torch.Tensor:
     return torch.exp(
         -features["angular_velocity"][..., 2].square() / params["yaw_rate_std"].square()
     )
+
+
+@MicroDuckEnv.register_reward("turn", weight=0.0, turn_rate=0.0, turn_rate_std=0.5)
+def _turn(features: TensorDictBase, params: TensorDictBase) -> torch.Tensor:
+    error = features["angular_velocity"][..., 2] - params["turn_rate"]
+    return torch.exp(-error.square() / params["turn_rate_std"].square())
+
+
+@MicroDuckEnv.register_reward(
+    "head_level", weight=1.0, head_pitch_target=0.0, head_level_std=0.3
+)
+def _head_level(features: TensorDictBase, params: TensorDictBase) -> torch.Tensor:
+    # Keeps the gaze on the horizon: the head carries the camera, and a
+    # policy left free to move the four head joints stares at its feet.
+    error = features["head_pitch"] - params["head_pitch_target"]
+    return torch.exp(-error.square() / params["head_level_std"].square())
 
 
 @MicroDuckEnv.register_reward("upright", weight=2.0, upright_std=0.05**0.5)


### PR DESCRIPTION
MicroDuck can keep its head physically level while turning in place. The previous gaze calculation joined the IMU to the beak tip, a line tilted 41.16 degrees below the head's forward axis. Rewarding that line for being horizontal made the trained standing duck look about 40 degrees upward.

The gaze now follows the head IMU frame's local -z axis. `head_level` rewards pitch relative to the horizon and yaw relative to the trunk, so turning the whole robot does not incur a head-alignment penalty. Diagnostics expose both head angles, yaw rate and height gain. The left/right `turning_task(rate)` presets retain their signed yaw-rate targets.

All physics backends expose site rotations. The mujoco-torch reset also recomputes derived state after restoring qpos/qvel; otherwise the new orientation query returned the old pose until stepping. The refreshed state is cloned to materialize broadcast contact fields, keeping strides stable across reset/step and preventing compiler recompilation.

Validation: the geometry regression uses the real 41-degree landmark offset, checks a 45-degree pitch and a 90-degree body turn, and verifies both turn reward directions. Both native MuJoCo and mujoco-torch cases pass locally. The nine-skill retraining and versioned checkpoint/video delivery are included in #4330; #4362 carries this correction while preserving its existing walker revision.

The validated nine-skill checkpoint and video are published through #4330 at Hugging Face revision `01ebcefca08850231edc0eb428a0151474559a85`; all 288 held-out episodes survive, and standing head pitch/yaw absolute p95 are 1.08/0.37 degrees.

The compiler test now excludes reset setup from its graph count. MuJoCo-Torch 0.2.0 compiles an internal solver during eager `vmap(forward)`; counting that as a physics-step recompile caused a false CI failure. A staged local reproduction records one reset graph, one physics graph and no further graphs across steps or resets. The test still requires exactly one physics-step graph, and the revised Inductor test passes on PyTorch 2.12 with the exact MuJoCo-Torch 0.2.0 dependency (49 seconds). No additional simulator or TensorDict change is needed for this failure.
